### PR TITLE
Fixed incorrect order of operations for win32 surfaces

### DIFF
--- a/core/src/os/surface.cpp
+++ b/core/src/os/surface.cpp
@@ -14,8 +14,9 @@ surface::surface(core::resource::cache_t& cache,
 				 core::resource::handle<data::window> data) :
 	m_Data(data),
 	m_InputSystem(new core::systems::input()),
-	m_Open(init_surface())
+	m_Open(false)
 {
+	m_Open = init_surface();
 }
 
 surface::~surface()

--- a/core/src/vk/swapchain.cpp
+++ b/core/src/vk/swapchain.cpp
@@ -29,6 +29,8 @@ swapchain::swapchain(core::resource::cache_t& cache,
 	vk::Win32SurfaceCreateInfoKHR createInfo;
 	createInfo.hinstance = m_OSSurface->surface_instance();
 	createInfo.hwnd		 = m_OSSurface->surface_handle();
+	psl_assert(createInfo.hinstance != nullptr, "missing win32 surface instance");
+	psl_assert(createInfo.hwnd != nullptr, "missing win32 surface handle");
 
 	utility::vulkan::check(m_Context->instance().createWin32SurfaceKHR(&createInfo, VK_NULL_HANDLE, &m_Surface));
 #elif defined(SURFACE_XCB)


### PR DESCRIPTION
Order of operation issue caused by `init_surface()` initializing the win32 handles, which are later overriden by the constructor.