### PR TITLE
Ability to rename components

### DIFF
--- a/psl/inc/psl/details/fixed_astring.hpp
+++ b/psl/inc/psl/details/fixed_astring.hpp
@@ -44,6 +44,11 @@ namespace psl
 				static_assert(end <= N + 1);
 				return fixed_astring<end - start> {&buf[start]};
 			}
+
+			constexpr auto begin() const noexcept { return &buf[0]; }
+			constexpr auto cbegin() const noexcept { return &buf[0]; }
+			constexpr auto end() const noexcept { return &buf[N]; }
+			constexpr auto cend() const noexcept { return &buf[N]; }
 		};
 		template <unsigned N>
 		fixed_astring(char const (&)[N]) -> fixed_astring<N - 1>;

--- a/psl/inc/psl/ecs/component_name.hpp
+++ b/psl/inc/psl/ecs/component_name.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include "psl/details/fixed_astring.hpp"
+#include <string_view>
+
+namespace psl::ecs
+{
+	namespace details
+	{
+		/// \brief Verify the given name is valid for component name substitution.
+		/// \details In general this means all characters are valid if they are also valid for that context for typenames.
+		/// This means the name has to start with an alphabetical letter or underscore. Subsequent values can be
+		/// alphanumeric.
+		template <psl::details::fixed_astring Name>
+		consteval auto is_valid_name() -> bool
+		{
+			using namespace std::literals::string_view_literals;
+			return static_cast<std::string_view>(Name).find_first_not_of(
+					 "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789:<>_"sv) ==
+					 std::string_view::npos &&
+				   "0123456789:<>"sv.find(Name[0]) == std::string_view::npos;
+		}
+	}	 // namespace details
+
+	/// \brief Inheriting this type in your component type allows you to designate a new component name.
+	/// \tparam Name Sets the new name for the given component.
+	template <psl::details::fixed_astring Name>
+		requires(details::is_valid_name<Name>())
+	struct component_name
+	{
+		static constexpr auto _ECS_COMPONENT_NAME {Name};
+	};
+
+	namespace details
+	{
+		template <typename T>
+		concept HasComponentNameOverride =
+		  requires() { T::_ECS_COMPONENT_NAME; } && std::is_base_of_v<component_name<T::_ECS_COMPONENT_NAME>, T>;
+	}	 // namespace details
+}	 // namespace psl::ecs

--- a/psl/inc/psl/ecs/details/component_key.hpp
+++ b/psl/inc/psl/ecs/details/component_key.hpp
@@ -4,6 +4,7 @@
 #include <string_view>
 #include <type_traits>
 
+#include "psl/ecs/component_name.hpp"
 #include "strtype/strtype.hpp"
 
 namespace psl::ecs::details
@@ -29,6 +30,12 @@ namespace psl::ecs::details
 		struct type_container
 		{
 			static constexpr auto name = strtype::stringify_typename<T>();
+		};
+
+		template <details::HasComponentNameOverride T>
+		struct type_container<T>
+		{
+			static constexpr auto name = T::_ECS_COMPONENT_NAME;
 		};
 
 		consteval std::uint32_t fnv1a_32(std::string_view value) const noexcept

--- a/tests/src/ecs.cpp
+++ b/tests/src/ecs.cpp
@@ -638,13 +638,18 @@ namespace
 
 		auto cfl_id	 = component_key_t::generate<const float>();
 		auto cint_id = component_key_t::generate<const int>();
-		require(cfl_id) == "float"sv;
-		require(cint_id) == "int"sv;
+		require(cfl_id.name()) == "float"sv;
+		require(cint_id.name()) == "int"sv;
 
 		constexpr auto cxfl_id	= component_key_t::generate<float>();
 		constexpr auto cxint_id = component_key_t::generate<int>();
 
-		require(cxfl_id) == "float"sv;
-		require(cxint_id) == "int"sv;
+		require(cxfl_id.name()) == "float"sv;
+		require(cxint_id.name()) == "int"sv;
+
+		struct foo_renamed : public psl::ecs::component_name<"SOMEOVERRIDE">
+		{};
+
+		require(component_key_t::generate<foo_renamed>().name()) == "SOMEOVERRIDE"sv;
 	};
 }	 // namespace


### PR DESCRIPTION
The following PR allows components to have a user set name if the component inherits from `psl::ecs::component_name<>`.

Note: this does suffer from the same issue when duplicate typenames are used, but as it's an issue that affects both typenames as well as this extension, it's not considered a blocker for now.