### PR TITLE
Fixed error due to missing import

### DIFF
--- a/paradigm.py
+++ b/paradigm.py
@@ -1,19 +1,15 @@
 from tools import build
-from tools import test
 from tools import generate_project_info
 from argparse import ArgumentParser
 
 def main():
     parser = ArgumentParser(description='Generate build files for the current project.')
-    parser.add_argument("--run", action='store', default="build", type=str, nargs=None,choices=['build','header', 'test'],dest="run")
+    parser.add_argument("--run", action='store', default="build", type=str, nargs=None,choices=['build','header'],dest="run")
     args, remaining_argv = parser.parse_known_args()
     
     if args.run == "build":
         target = build.Paradigm()
         target()
-    elif args.run == "test":
-        target = test.Tester()
-        target(remaining_argv)
     elif args.run == "header":
         generate_project_info.generate_header()
 


### PR DESCRIPTION
When merging #71 we removed `tools/test.py`. As `paradigm.py` was still referencing it, this lead to an issue where the script could no longer be used.

This is resolved by removing the reference to the removed content in this PR.