### PR TITLE
removed benchmark for non-all builds

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -28,7 +28,7 @@ jobs:
         include:
           - cc: gcc-12
             cxx: g++-12
-            benchmarks: ON
+            benchmarks: OFF
             tests: ON
             compiler: gcc
             target: gnu-linux
@@ -43,6 +43,9 @@ jobs:
             benchmarks: OFF
             tests: OFF
             compiler: clang
+          - compiler: gcc
+            graphics: all
+            benchmarks: ON
         exclude:
           - target: android
             compiler: clang
@@ -90,9 +93,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        graphics: [vulkan, all]
-        include:
-          - compiler: gcc
+        graphics: [ all ]
+        compiler: [ gcc ]
     name: benchmark
     needs: build
     runs-on: ubuntu-22.04

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,8 @@ jobs:
       run: |
             cd builds\x64\release\bin
             .\tests.exe --formatter compact --no-source
-    - name: finalize
+    - name: finalize    
+      if: ${{ matrix.benchmarks == 'ON' }}
       uses: actions/upload-artifact@v3
       with:
         name: windows-${{ matrix.graphics }}-bin

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,6 +8,10 @@ jobs:
       fail-fast: false
       matrix:
         graphics: [vulkan, all]
+        include:
+          - benchmarks: OFF
+          - graphics: all
+            benchmarks: ON
     name: build
     runs-on: windows-2022
     steps:
@@ -23,7 +27,7 @@ jobs:
     - name: initialize
       run: |
             python3 tools/generate_project_info.py
-            cmake --preset=windows-release-${{ matrix.graphics }} -DPE_BENCHMARKS=ON
+            cmake --preset=windows-release-${{ matrix.graphics }} -DPE_BENCHMARKS=${{ matrix.benchmarks }}
             python3 tools/patch.py --project ./project_files/x64/
     - name: compile
       run: cmake --build --preset=windows-release-${{ matrix.graphics }} -j ${{ steps.cpu-cores.outputs.count }}
@@ -42,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        graphics: [vulkan, all]
+        graphics: [ all ]
     name: benchmark
     needs: build
     runs-on: windows-2022


### PR DESCRIPTION
There is no reason to run the benchmark for every graphics permutation. So we'll disable them for the non-`all` permutation.