### PR TITLE
Fixes issue when saving file without a directory

### DIFF
--- a/psl/src/platform_utils.cpp
+++ b/psl/src/platform_utils.cpp
@@ -364,7 +364,7 @@ bool utility::platform::file::write(psl::string_view filename, psl::string_view 
 
 	std::size_t found = file_name.find_last_of(directory::seperator);
 
-	if(!directory::exists(file_name.substr(0, found)) && !directory::create(file_name.substr(0, found), true))
+	if(found != std::string::npos && !directory::exists(file_name.substr(0, found)) && !directory::create(file_name.substr(0, found), true))
 		return false;
 
 	psl::ofstream output;


### PR DESCRIPTION
When saving a file without a set directory (i.e. saving into the working directory), it would try to create a directory with the name of the file instead.

This PR resolves that issue, now we skip the directory check in case no path seperator was found.