### PR TITLE
Fixes some misc memory issues

### DIFF
--- a/psl/inc/psl/ecs/details/component_container.hpp
+++ b/psl/inc/psl/ecs/details/component_container.hpp
@@ -80,7 +80,8 @@ class component_container_t {
 
 	virtual void remap(const psl::sparse_array<entity>& mapping, std::function<bool(entity)> pred) noexcept = 0;
 	virtual bool merge(const component_container_t& other) noexcept											= 0;
-	virtual void clear() = 0;
+	virtual void clear()																					= 0;
+
   protected:
 	virtual void purge_impl() noexcept																	= 0;
 	virtual void add_impl(entity entity, void* data)													= 0;
@@ -227,9 +228,8 @@ class component_container_typed_t final : public component_container_t {
 	}
 	bool has_impl(entity entity, stage_range_t stage) const noexcept override { return m_Entities.has(entity, stage); }
 
-	void clear() override {
-		m_Entities.clear();
-	}
+	void clear() override { m_Entities.clear(); }
+
   private:
 	details::staged_sparse_array<T, entity> m_Entities;
 };
@@ -302,6 +302,7 @@ class component_container_flag_t : public component_container_t {
 		m_Entities.clear();
 		m_Serializable = false;
 	}
+
   private:
 	details::staged_sparse_array<void, entity> m_Entities;
 	bool m_Serializable {false};
@@ -377,6 +378,7 @@ class component_container_untyped_t : public component_container_t {
 		m_Entities.clear();
 		m_Serializable = false;
 	}
+
   protected:
 	void set_impl(entity entity, void* data) noexcept override {
 		auto* ptr = m_Entities.addressof(entity, stage_range_t::ALL);

--- a/psl/inc/psl/ecs/details/component_container.hpp
+++ b/psl/inc/psl/ecs/details/component_container.hpp
@@ -80,7 +80,7 @@ class component_container_t {
 
 	virtual void remap(const psl::sparse_array<entity>& mapping, std::function<bool(entity)> pred) noexcept = 0;
 	virtual bool merge(const component_container_t& other) noexcept											= 0;
-
+	virtual void clear() = 0;
   protected:
 	virtual void purge_impl() noexcept																	= 0;
 	virtual void add_impl(entity entity, void* data)													= 0;
@@ -110,6 +110,7 @@ class component_container_typed_t final : public component_container_t {
   public:
 	component_container_typed_t()
 		: component_container_t(details::component_key_t::generate<T>(), sizeof(T), std::alignment_of_v<T>) {};
+	~component_container_typed_t() override = default;
 	auto& entity_data() noexcept { return m_Entities; };
 
 
@@ -226,6 +227,9 @@ class component_container_typed_t final : public component_container_t {
 	}
 	bool has_impl(entity entity, stage_range_t stage) const noexcept override { return m_Entities.has(entity, stage); }
 
+	void clear() override {
+		m_Entities.clear();
+	}
   private:
 	details::staged_sparse_array<T, entity> m_Entities;
 };
@@ -234,6 +238,7 @@ class component_container_flag_t : public component_container_t {
   public:
 	component_container_flag_t(const psl::ecs::details::component_key_t& key, bool serializable = false)
 		: component_container_t(std::move(key), 0, 0) {};
+	~component_container_flag_t() override = default;
 
 	void* data() noexcept override { return nullptr; }
 	void* const data() const noexcept override { return nullptr; }
@@ -293,6 +298,10 @@ class component_container_flag_t : public component_container_t {
 	}
 	bool has_impl(entity entity, stage_range_t stage) const noexcept override { return m_Entities.has(entity, stage); }
 
+	void clear() override {
+		m_Entities.clear();
+		m_Serializable = false;
+	}
   private:
 	details::staged_sparse_array<void, entity> m_Entities;
 	bool m_Serializable {false};
@@ -307,7 +316,7 @@ class component_container_untyped_t : public component_container_t {
 								  size_t alignment,
 								  bool serializable = false)
 		: component_container_t(std::move(key), size, alignment), m_Entities(size), m_Serializable(serializable) {};
-
+	~component_container_untyped_t() override = default;
 	auto& entity_data() noexcept { return m_Entities; };
 
 
@@ -364,6 +373,10 @@ class component_container_untyped_t : public component_container_t {
 		return true;
 	}
 
+	void clear() override {
+		m_Entities.clear();
+		m_Serializable = false;
+	}
   protected:
 	void set_impl(entity entity, void* data) noexcept override {
 		auto* ptr = m_Entities.addressof(entity, stage_range_t::ALL);

--- a/psl/inc/psl/ecs/state.hpp
+++ b/psl/inc/psl/ecs/state.hpp
@@ -193,7 +193,7 @@ class state_t final {
 		return result;
 	}
 
-	void clear() noexcept;
+	void clear(bool release_memory = true) noexcept;
 
 	template <typename T>
 	T& get(entity entity) {
@@ -207,6 +207,15 @@ class state_t final {
 		// todo this should support filtering
 		auto cInfo = get_component_typed_info<T>();
 		return cInfo->entity_data().template at<T>(entity, details::stage_range_t::ALL);
+	}
+	
+	template <typename T>
+	psl::array<T> get(psl::array_view<entity> entities) const {
+		auto cInfo = get_component_typed_info<T>();
+		psl::array<T> result {};
+		result.resize(entities.size());
+		cInfo->copy_to(entities, result.data());
+		return result;
 	}
 
 	template <typename... Ts>
@@ -314,6 +323,17 @@ class state_t final {
 			return data.entities;
 		}
 	}
+
+	template <typename... Ts>
+	psl::array<entity> filter(psl::array_view<entity> entities) const noexcept {
+		auto filter_group = details::make_filter_group(psl::type_pack_t<psl::ecs::pack<Ts...>> {});
+		psl_assert(filter_group.size() == 1, "expected only one filter group");
+
+		filter_result data {{}, std::make_shared<details::filter_group>(filter_group[0])};
+		filter(data, entities);
+		return data.entities;
+	}
+
 	template <typename... Ts>
 	void set_components(psl::array_view<entity> entities, psl::array_view<Ts>... data) noexcept {
 		(set_component(entities, std::forward<Ts>(data)), ...);

--- a/psl/inc/psl/ecs/state.hpp
+++ b/psl/inc/psl/ecs/state.hpp
@@ -591,8 +591,10 @@ class state_t final {
 
 	// invocable based construction
 	template <typename Fn>
-		requires(std::is_invocable<Fn, std::uintptr_t, size_t>::value)
-	void add_component_impl(const details::component_key_t& key, psl::array_view<entity> entities, Fn&& invocable) {
+	requires(std::is_invocable<Fn, std::uintptr_t, size_t>::value) void add_component_impl(
+	  const details::component_key_t& key,
+	  psl::array_view<entity> entities,
+	  Fn&& invocable) {
 		auto cInfo = get_component_container(key);
 		psl_assert(cInfo != nullptr, "component info for key {} was not found", key);
 		const auto component_size = cInfo->component_size();

--- a/psl/inc/psl/ecs/state.hpp
+++ b/psl/inc/psl/ecs/state.hpp
@@ -208,7 +208,7 @@ class state_t final {
 		auto cInfo = get_component_typed_info<T>();
 		return cInfo->entity_data().template at<T>(entity, details::stage_range_t::ALL);
 	}
-	
+
 	template <typename T>
 	psl::array<T> get(psl::array_view<entity> entities) const {
 		auto cInfo = get_component_typed_info<T>();
@@ -591,10 +591,8 @@ class state_t final {
 
 	// invocable based construction
 	template <typename Fn>
-	requires(std::is_invocable<Fn, std::uintptr_t, size_t>::value) void add_component_impl(
-	  const details::component_key_t& key,
-	  psl::array_view<entity> entities,
-	  Fn&& invocable) {
+		requires(std::is_invocable<Fn, std::uintptr_t, size_t>::value)
+	void add_component_impl(const details::component_key_t& key, psl::array_view<entity> entities, Fn&& invocable) {
 		auto cInfo = get_component_container(key);
 		psl_assert(cInfo != nullptr, "component info for key {} was not found", key);
 		const auto component_size = cInfo->component_size();

--- a/psl/inc/psl/memory/raw_region.hpp
+++ b/psl/inc/psl/memory/raw_region.hpp
@@ -17,6 +17,7 @@ class raw_region {
 	size_t pageSize() const noexcept { return m_PageSize; }
 
   private:
+	void release() noexcept;
 	void* m_Base {nullptr};
 	size_t m_Size {0u};
 	size_t m_PageSize {0u};

--- a/psl/src/ecs/state.cpp
+++ b/psl/src/ecs/state.cpp
@@ -18,7 +18,7 @@ state_t::state_t(size_t workers, size_t cache_size)
 	m_ModifiedEntities.reserve(65536);
 }
 
-state_t::~state_t() {};
+state_t::~state_t() = default;
 
 constexpr auto align(std::uintptr_t& ptr, size_t alignment) noexcept {
 #pragma warning(push)
@@ -762,8 +762,15 @@ size_t state_t::size(psl::array_view<details::component_key_t> keys) const noexc
 	return 0;
 }
 
-void state_t::clear() noexcept {
-	m_Components.clear();
+void state_t::clear(bool release_memory) noexcept {
+	if(release_memory) {
+		m_Components = decltype(m_Components){};
+	} else {
+		for(auto& [key, storage] : m_Components) {
+			storage->clear();
+		}
+	}
+
 	m_Entities = 0;
 	m_Orphans.clear();
 	m_ToBeOrphans.clear();

--- a/psl/src/ecs/state.cpp
+++ b/psl/src/ecs/state.cpp
@@ -764,7 +764,7 @@ size_t state_t::size(psl::array_view<details::component_key_t> keys) const noexc
 
 void state_t::clear(bool release_memory) noexcept {
 	if(release_memory) {
-		m_Components = decltype(m_Components){};
+		m_Components = decltype(m_Components) {};
 	} else {
 		for(auto& [key, storage] : m_Components) {
 			storage->clear();


### PR DESCRIPTION
- raw_region fixed incorrect move constructor resulting in a memory corruption (but not leak)
- added the ability to clear a state_t's memory
- added filtering operations
