### PR TITLE
ECS support indirect packs

### DIFF
--- a/benchmarks/src/ecs.cpp
+++ b/benchmarks/src/ecs.cpp
@@ -199,10 +199,10 @@ BENCHMARK_REGISTER_F(filtering_fixture, trivial_filtering_on_condition)
 
 	#include <random>
 template <typename T, typename... Ts>
-auto read_only_system = [](info_t& info, pack_direct_full_t<T, const Ts...>) {};
+auto read_only_system = [](info_t& info, pack_t<T, direct_t, const Ts...>) {};
 
 template <typename T, typename... Ts>
-auto write_system = [](info_t& info, pack_direct_full_t<T, Ts...>) {};
+auto write_system = [](info_t& info, pack_t<T, direct_t, Ts...>) {};
 
 auto get_random_entities(const psl::array<entity>& source, size_t count, std::mt19937 g) {
 	auto copy = source;

--- a/benchmarks/src/ecs.cpp
+++ b/benchmarks/src/ecs.cpp
@@ -199,10 +199,10 @@ BENCHMARK_REGISTER_F(filtering_fixture, trivial_filtering_on_condition)
 
 	#include <random>
 template <typename T, typename... Ts>
-auto read_only_system = [](info_t& info, pack<T, const Ts...>) {};
+auto read_only_system = [](info_t& info, pack_direct_full_t<T, const Ts...>) {};
 
 template <typename T, typename... Ts>
-auto write_system = [](info_t& info, pack<T, Ts...>) {};
+auto write_system = [](info_t& info, pack_direct_full_t<T, Ts...>) {};
 
 auto get_random_entities(const psl::array<entity>& source, size_t count, std::mt19937 g) {
 	auto copy = source;

--- a/benchmarks/src/ecs.cpp
+++ b/benchmarks/src/ecs.cpp
@@ -232,25 +232,25 @@ const std::vector<std::vector<entity>> system_counts {{10'000, 300, 2'700, 1'200
 													  {1'000'000, 300'000, 210'700, 300'200, 680'700}};
 void trivial_read_only_seq_system(benchmark::State& gState) {
 	state_t state;
-	state.declare(threading::seq, read_only_system<full, char, int, float, uint64_t>);
+	state.declare(threading::seq, read_only_system<full_t, char, int, float, uint64_t>);
 	run_system<char, int, float, uint64_t>(gState, state, system_counts[gState.range()]);
 }
 
 void trivial_write_seq_system(benchmark::State& gState) {
 	state_t state;
-	state.declare(threading::seq, write_system<full, char, int, float, uint64_t>);
+	state.declare(threading::seq, write_system<full_t, char, int, float, uint64_t>);
 	run_system<char, int, float, uint64_t>(gState, state, system_counts[gState.range()]);
 }
 
 void trivial_read_only_par_system(benchmark::State& gState) {
 	state_t state;
-	state.declare(threading::seq, read_only_system<partial, char, int, float, uint64_t>);
+	state.declare(threading::seq, read_only_system<partial_t, char, int, float, uint64_t>);
 	run_system<char, int, float, uint64_t>(gState, state, system_counts[gState.range()]);
 }
 
 void trivial_write_par_system(benchmark::State& gState) {
 	state_t state;
-	state.declare(threading::seq, write_system<partial, char, int, float, uint64_t>);
+	state.declare(threading::seq, write_system<partial_t, char, int, float, uint64_t>);
 	run_system<char, int, float, uint64_t>(gState, state, system_counts[gState.range()]);
 }
 
@@ -262,25 +262,25 @@ using namespace core::ecs::components;
 
 void complex_read_only_seq_system(benchmark::State& gState) {
 	state_t state;
-	state.declare(threading::seq, read_only_system<full, camera, velocity, lifetime, transform>);
+	state.declare(threading::seq, read_only_system<full_t, camera, velocity, lifetime, transform>);
 	run_system<camera, velocity, lifetime, transform>(gState, state, system_counts[gState.range()]);
 }
 
 void complex_write_seq_system(benchmark::State& gState) {
 	state_t state;
-	state.declare(threading::seq, write_system<full, camera, velocity, lifetime, transform>);
+	state.declare(threading::seq, write_system<full_t, camera, velocity, lifetime, transform>);
 	run_system<camera, velocity, lifetime, transform>(gState, state, system_counts[gState.range()]);
 }
 
 void complex_read_only_par_system(benchmark::State& gState) {
 	state_t state;
-	state.declare(threading::seq, read_only_system<partial, camera, velocity, lifetime, transform>);
+	state.declare(threading::seq, read_only_system<partial_t, camera, velocity, lifetime, transform>);
 	run_system<camera, velocity, lifetime, transform>(gState, state, system_counts[gState.range()]);
 }
 
 void complex_write_par_system(benchmark::State& gState) {
 	state_t state;
-	state.declare(threading::seq, write_system<partial, camera, velocity, lifetime, transform>);
+	state.declare(threading::seq, write_system<partial_t, camera, velocity, lifetime, transform>);
 	run_system<camera, velocity, lifetime, transform>(gState, state, system_counts[gState.range()]);
 }
 

--- a/core/inc/ecs/systems/attractor.hpp
+++ b/core/inc/ecs/systems/attractor.hpp
@@ -16,25 +16,23 @@ struct attractor {
 }	 // namespace core::ecs::components
 
 namespace core::ecs::systems {
-auto attractor =
-  [](psl::ecs::info_t& info,
-	 psl::ecs::pack<psl::ecs::partial,
-					const core::ecs::components::transform,
-					core::ecs::components::velocity,
-					psl::ecs::filter<core::ecs::components::dynamic_tag>> movables,
-	 psl::ecs::pack<psl::ecs::full, const core::ecs::components::transform, const core::ecs::components::attractor>
-	   attractors) {
-	  using namespace psl::math;
+auto attractor = [](psl::ecs::info_t& info,
+					psl::ecs::pack_direct_partial_t<const core::ecs::components::transform,
+													core::ecs::components::velocity,
+													psl::ecs::filter<core::ecs::components::dynamic_tag>> movables,
+					psl::ecs::pack_direct_full_t<const core::ecs::components::transform,
+												 const core::ecs::components::attractor> attractors) {
+	using namespace psl::math;
 
-	  for(auto [movTrans, movVel] : movables) {
-		  for(auto [attrTransform, attractor] : attractors) {
-			  const auto mag = saturate((attractor.radius - magnitude(movTrans.position - attrTransform.position)) /
-										attractor.radius) *
-							   info.dTime.count();
-			  const auto direction = normalize(attrTransform.position - movTrans.position) * attractor.force;
+	for(auto [movTrans, movVel] : movables) {
+		for(auto [attrTransform, attractor] : attractors) {
+			const auto mag =
+			  saturate((attractor.radius - magnitude(movTrans.position - attrTransform.position)) / attractor.radius) *
+			  info.dTime.count();
+			const auto direction = normalize(attrTransform.position - movTrans.position) * attractor.force;
 
-			  movVel.direction = mix(movVel.direction, direction, mag);
-		  }
-	  }
-  };
+			movVel.direction = mix(movVel.direction, direction, mag);
+		}
+	}
+};
 }

--- a/core/inc/ecs/systems/death.hpp
+++ b/core/inc/ecs/systems/death.hpp
@@ -5,7 +5,7 @@
 namespace core::ecs::systems {
 auto death =
   [](psl::ecs::info_t& info,
-	 psl::ecs::pack<psl::ecs::partial, psl::ecs::entity, psl::ecs::on_add<core::ecs::components::dead_tag>> dead_pack) {
+	 psl::ecs::pack_direct_partial_t<psl::ecs::entity, psl::ecs::on_add<core::ecs::components::dead_tag>> dead_pack) {
 	  info.command_buffer.destroy(dead_pack.get<psl::ecs::entity>());
   };
 }

--- a/core/inc/ecs/systems/debug/grid.hpp
+++ b/core/inc/ecs/systems/debug/grid.hpp
@@ -45,10 +45,10 @@ class grid {
 
   private:
 	void tick(psl::ecs::info_t& info,
-			  psl::ecs::pack<psl::ecs::entity,
+			  psl::ecs::pack_direct_full_t<psl::ecs::entity,
 							 const core::ecs::components::transform,
 							 psl::ecs::filter<core::ecs::components::camera>> pack,
-			  psl::ecs::pack<core::ecs::components::transform, psl::ecs::filter<grid::tag>> grid_pack);
+			  psl::ecs::pack_direct_full_t<core::ecs::components::transform, psl::ecs::filter<grid::tag>> grid_pack);
 
 	core::resource::handle<core::gfx::bundle> m_Bundle;
 	core::resource::handle<core::gfx::geometry_t> m_Geometry;

--- a/core/inc/ecs/systems/debug/grid.hpp
+++ b/core/inc/ecs/systems/debug/grid.hpp
@@ -46,8 +46,8 @@ class grid {
   private:
 	void tick(psl::ecs::info_t& info,
 			  psl::ecs::pack_direct_full_t<psl::ecs::entity,
-							 const core::ecs::components::transform,
-							 psl::ecs::filter<core::ecs::components::camera>> pack,
+										   const core::ecs::components::transform,
+										   psl::ecs::filter<core::ecs::components::camera>> pack,
 			  psl::ecs::pack_direct_full_t<core::ecs::components::transform, psl::ecs::filter<grid::tag>> grid_pack);
 
 	core::resource::handle<core::gfx::bundle> m_Bundle;

--- a/core/inc/ecs/systems/fly.hpp
+++ b/core/inc/ecs/systems/fly.hpp
@@ -14,8 +14,7 @@ class fly {
 
 
   private:
-	void
-	tick(psl::ecs::info_t& info,
+	void tick(psl::ecs::info_t& info,
 			  psl::ecs::pack_direct_full_t<core::ecs::components::transform,
 										   psl::ecs::filter<core::ecs::components::input_tag>> movables);
 

--- a/core/inc/ecs/systems/fly.hpp
+++ b/core/inc/ecs/systems/fly.hpp
@@ -16,7 +16,8 @@ class fly {
   private:
 	void
 	tick(psl::ecs::info_t& info,
-		 psl::ecs::pack<core::ecs::components::transform, psl::ecs::filter<core::ecs::components::input_tag>> movables);
+			  psl::ecs::pack_direct_full_t<core::ecs::components::transform,
+										   psl::ecs::filter<core::ecs::components::input_tag>> movables);
 
 	void on_key_pressed(core::systems::input::keycode keyCode);
 	void on_key_released(core::systems::input::keycode keyCode);

--- a/core/inc/ecs/systems/geometry_instance.hpp
+++ b/core/inc/ecs/systems/geometry_instance.hpp
@@ -42,13 +42,13 @@ class geometry_instancing {
 									psl::ecs::filter<const core::ecs::components::dynamic_tag>,
 									psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> pack);
 	*/
-	void
-	dynamic_system(psl::ecs::info_t& info,
+	void dynamic_system(
+	  psl::ecs::info_t& info,
 	  psl::ecs::pack_direct_full_t<core::ecs::components::renderable,
-								  const core::ecs::components::transform,
-								  const core::ecs::components::dynamic_tag,
-								  psl::ecs::except<core::ecs::components::dont_render_tag>,
-								  psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> geometry_pack);
+								   const core::ecs::components::transform,
+								   const core::ecs::components::dynamic_tag,
+								   psl::ecs::except<core::ecs::components::dont_render_tag>,
+								   psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> geometry_pack);
 
 	void
 	static_add(psl::ecs::info_t& info,
@@ -59,27 +59,29 @@ class geometry_instancing {
 				 psl::ecs::except<core::ecs::components::dynamic_tag>,
 				 psl::ecs::on_combine<const core::ecs::components::renderable, const core::ecs::components::transform>,
 				 psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> geometry_pack);
-	void static_remove(psl::ecs::info_t& info,
+	void static_remove(
+	  psl::ecs::info_t& info,
 	  psl::ecs::pack_direct_full_t<psl::ecs::entity,
-									  core::ecs::components::renderable,
-									  const instance_id,
-									  psl::ecs::except<core::ecs::components::dynamic_tag>,
-									  psl::ecs::on_break<const core::ecs::components::renderable,
-														 const core::ecs::components::transform>> geometry_pack);
+								   core::ecs::components::renderable,
+								   const instance_id,
+								   psl::ecs::except<core::ecs::components::dynamic_tag>,
+								   psl::ecs::on_break<const core::ecs::components::renderable,
+													  const core::ecs::components::transform>> geometry_pack);
 
 	void static_geometry_add(psl::ecs::info_t& info,
 							 psl::ecs::pack_direct_full_t<psl::ecs::entity,
-											const core::ecs::components::renderable,
-											psl::ecs::except<core::ecs::components::transform>,
-											psl::ecs::on_add<core::ecs::components::renderable>> pack);
+														  const core::ecs::components::renderable,
+														  psl::ecs::except<core::ecs::components::transform>,
+														  psl::ecs::on_add<core::ecs::components::renderable>> pack);
 
 
-	void static_geometry_remove(psl::ecs::info_t& info,
+	void
+	static_geometry_remove(psl::ecs::info_t& info,
 						   psl::ecs::pack_direct_full_t<psl::ecs::entity,
-											   core::ecs::components::renderable,
-											   const instance_id,
-											   psl::ecs::except<core::ecs::components::transform>,
-											   psl::ecs::on_remove<core::ecs::components::renderable>> pack);
+														core::ecs::components::renderable,
+														const instance_id,
+														psl::ecs::except<core::ecs::components::transform>,
+														psl::ecs::on_remove<core::ecs::components::renderable>> pack);
 	// void static_disable();
 	// void static_enable(psl::ecs::info& info, psl::ecs::pack_direct_full_t<psl::ecs::entity, const
 	// core::ecs::components::renderable, const instance_id, core::ecs::components::dont_render_tag> dont_render);

--- a/core/inc/ecs/systems/geometry_instance.hpp
+++ b/core/inc/ecs/systems/geometry_instance.hpp
@@ -38,13 +38,13 @@ class geometry_instancing {
 
   private:
 	/* void dynamic_add(psl::ecs::info& info,
-					 psl::ecs::pack<core::ecs::components::renderable,
+					 psl::ecs::pack_direct_full_t<core::ecs::components::renderable,
 									psl::ecs::filter<const core::ecs::components::dynamic_tag>,
 									psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> pack);
 	*/
 	void
 	dynamic_system(psl::ecs::info_t& info,
-				   psl::ecs::pack<core::ecs::components::renderable,
+	  psl::ecs::pack_direct_full_t<core::ecs::components::renderable,
 								  const core::ecs::components::transform,
 								  const core::ecs::components::dynamic_tag,
 								  psl::ecs::except<core::ecs::components::dont_render_tag>,
@@ -52,7 +52,7 @@ class geometry_instancing {
 
 	void
 	static_add(psl::ecs::info_t& info,
-			   psl::ecs::pack<
+			   psl::ecs::pack_direct_full_t<
 				 psl::ecs::entity,
 				 const core::ecs::components::renderable,
 				 const core::ecs::components::transform,
@@ -60,7 +60,7 @@ class geometry_instancing {
 				 psl::ecs::on_combine<const core::ecs::components::renderable, const core::ecs::components::transform>,
 				 psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> geometry_pack);
 	void static_remove(psl::ecs::info_t& info,
-					   psl::ecs::pack<psl::ecs::entity,
+	  psl::ecs::pack_direct_full_t<psl::ecs::entity,
 									  core::ecs::components::renderable,
 									  const instance_id,
 									  psl::ecs::except<core::ecs::components::dynamic_tag>,
@@ -68,20 +68,20 @@ class geometry_instancing {
 														 const core::ecs::components::transform>> geometry_pack);
 
 	void static_geometry_add(psl::ecs::info_t& info,
-							 psl::ecs::pack<psl::ecs::entity,
+							 psl::ecs::pack_direct_full_t<psl::ecs::entity,
 											const core::ecs::components::renderable,
 											psl::ecs::except<core::ecs::components::transform>,
 											psl::ecs::on_add<core::ecs::components::renderable>> pack);
 
 
 	void static_geometry_remove(psl::ecs::info_t& info,
-								psl::ecs::pack<psl::ecs::entity,
+						   psl::ecs::pack_direct_full_t<psl::ecs::entity,
 											   core::ecs::components::renderable,
 											   const instance_id,
 											   psl::ecs::except<core::ecs::components::transform>,
 											   psl::ecs::on_remove<core::ecs::components::renderable>> pack);
 	// void static_disable();
-	// void static_enable(psl::ecs::info& info, psl::ecs::pack<psl::ecs::entity, const
+	// void static_enable(psl::ecs::info& info, psl::ecs::pack_direct_full_t<psl::ecs::entity, const
 	// core::ecs::components::renderable, const instance_id, core::ecs::components::dont_render_tag> dont_render);
 };
 }	 // namespace core::ecs::systems

--- a/core/inc/ecs/systems/gpu_camera.hpp
+++ b/core/inc/ecs/systems/gpu_camera.hpp
@@ -1,9 +1,9 @@
 #pragma once
 #include "gfx/context.hpp"
+#include "psl/ecs/pack.hpp"
 #include "psl/math/math.hpp"
 #include "psl/memory/segment.hpp"
 #include "resource/resource.hpp"
-#include "psl/ecs/pack.hpp"
 
 namespace core::gfx {
 class buffer_t;

--- a/core/inc/ecs/systems/gpu_camera.hpp
+++ b/core/inc/ecs/systems/gpu_camera.hpp
@@ -3,6 +3,7 @@
 #include "psl/math/math.hpp"
 #include "psl/memory/segment.hpp"
 #include "resource/resource.hpp"
+#include "psl/ecs/pack.hpp"
 
 namespace core::gfx {
 class buffer_t;
@@ -21,10 +22,8 @@ struct camera;
 namespace psl::ecs {
 class state_t;
 struct info_t;
-
-template <typename... Ts>
-class pack;
 }	 // namespace psl::ecs
+
 namespace core::ecs::systems {
 class gpu_camera {
 	const psl::mat4x4
@@ -52,7 +51,8 @@ class gpu_camera {
 			   core::resource::handle<core::gfx::shader_buffer_binding> binding,
 			   core::gfx::graphics_backend backend);
 	void tick(psl::ecs::info_t& info,
-			  psl::ecs::pack<const core::ecs::components::camera, const core::ecs::components::transform> cameras);
+			  psl::ecs::pack_direct_full_t<const core::ecs::components::camera, const core::ecs::components::transform>
+				cameras);
 
   private:
 	void update_buffer(size_t index,

--- a/core/inc/ecs/systems/lifetime.hpp
+++ b/core/inc/ecs/systems/lifetime.hpp
@@ -7,7 +7,7 @@
 
 namespace core::ecs::systems {
 auto lifetime = [](psl::ecs::info_t& info,
-				   psl::ecs::pack<psl::ecs::partial, psl::ecs::entity, core::ecs::components::lifetime> life_pack) {
+	 psl::ecs::pack_direct_partial_t<psl::ecs::entity, core::ecs::components::lifetime> life_pack) {
 	using namespace psl::ecs;
 	using namespace core::ecs::components;
 

--- a/core/inc/ecs/systems/lifetime.hpp
+++ b/core/inc/ecs/systems/lifetime.hpp
@@ -7,7 +7,7 @@
 
 namespace core::ecs::systems {
 auto lifetime = [](psl::ecs::info_t& info,
-	 psl::ecs::pack_direct_partial_t<psl::ecs::entity, core::ecs::components::lifetime> life_pack) {
+				   psl::ecs::pack_direct_partial_t<psl::ecs::entity, core::ecs::components::lifetime> life_pack) {
 	using namespace psl::ecs;
 	using namespace core::ecs::components;
 

--- a/core/inc/ecs/systems/lighting.hpp
+++ b/core/inc/ecs/systems/lighting.hpp
@@ -48,7 +48,7 @@ class lighting_system {
 
 	void create_dir(
 	  psl::ecs::info_t& info,
-	  psl::ecs::pack<psl::ecs::entity,
+	  psl::ecs::pack_direct_full_t<psl::ecs::entity,
 					 core::ecs::components::light,
 					 psl::ecs::on_combine<core::ecs::components::light, core::ecs::components::transform>> pack);
 

--- a/core/inc/ecs/systems/lighting.hpp
+++ b/core/inc/ecs/systems/lighting.hpp
@@ -49,8 +49,9 @@ class lighting_system {
 	void create_dir(
 	  psl::ecs::info_t& info,
 	  psl::ecs::pack_direct_full_t<psl::ecs::entity,
-					 core::ecs::components::light,
-					 psl::ecs::on_combine<core::ecs::components::light, core::ecs::components::transform>> pack);
+								   core::ecs::components::light,
+								   psl::ecs::on_combine<core::ecs::components::light, core::ecs::components::transform>>
+		pack);
 
   private:
 	psl::view_ptr<core::resource::cache_t> m_Cache;

--- a/core/inc/ecs/systems/movement.hpp
+++ b/core/inc/ecs/systems/movement.hpp
@@ -5,9 +5,9 @@
 
 namespace core::ecs::systems {
 auto movement =
-  [](psl::ecs::info_t& info,
-	 psl::ecs::pack<psl::ecs::partial, const core::ecs::components::velocity, core::ecs::components::transform>
-	   movables) {
+  [](
+	psl::ecs::info_t& info,
+	psl::ecs::pack_direct_partial_t<const core::ecs::components::velocity, core::ecs::components::transform> movables) {
 	  using namespace psl::math;
 	  using namespace core::ecs;
 	  using namespace core::ecs::components;

--- a/core/inc/ecs/systems/render.hpp
+++ b/core/inc/ecs/systems/render.hpp
@@ -34,9 +34,9 @@ class render {
 
   private:
 	void tick_draws(psl::ecs::info_t& info,
-					psl::ecs::pack<const core::ecs::components::renderable,
+					psl::ecs::pack_direct_full_t<const core::ecs::components::renderable,
 								   psl::ecs::on_add<core::ecs::components::renderable>> renderables,
-					psl::ecs::pack<const core::ecs::components::renderable,
+			   psl::ecs::pack_direct_full_t<const core::ecs::components::renderable,
 								   psl::ecs::on_remove<core::ecs::components::renderable>> broken_renderables);
 
 	psl::view_ptr<core::gfx::drawpass> m_Pass {nullptr};

--- a/core/inc/ecs/systems/render.hpp
+++ b/core/inc/ecs/systems/render.hpp
@@ -33,11 +33,12 @@ class render {
 	void remove_render_range(uint32_t begin, uint32_t end);
 
   private:
-	void tick_draws(psl::ecs::info_t& info,
-					psl::ecs::pack_direct_full_t<const core::ecs::components::renderable,
-								   psl::ecs::on_add<core::ecs::components::renderable>> renderables,
+	void
+	tick_draws(psl::ecs::info_t& info,
 			   psl::ecs::pack_direct_full_t<const core::ecs::components::renderable,
-								   psl::ecs::on_remove<core::ecs::components::renderable>> broken_renderables);
+											psl::ecs::on_add<core::ecs::components::renderable>> renderables,
+			   psl::ecs::pack_direct_full_t<const core::ecs::components::renderable,
+											psl::ecs::on_remove<core::ecs::components::renderable>> broken_renderables);
 
 	psl::view_ptr<core::gfx::drawpass> m_Pass {nullptr};
 

--- a/core/inc/ecs/systems/text.hpp
+++ b/core/inc/ecs/systems/text.hpp
@@ -8,10 +8,10 @@
 #include "fwd/gfx/texture.hpp"
 #include "psl/array.hpp"
 #include "psl/ecs/entity.hpp"
+#include "psl/ecs/pack.hpp"
 #include "psl/ecs/selectors.hpp"
 #include "psl/math/vec.hpp"
 #include "resource/handle.hpp"
-#include "psl/ecs/pack.hpp"
 
 namespace core::data {
 class geometry_t;

--- a/core/inc/ecs/systems/text.hpp
+++ b/core/inc/ecs/systems/text.hpp
@@ -11,6 +11,7 @@
 #include "psl/ecs/selectors.hpp"
 #include "psl/math/vec.hpp"
 #include "resource/handle.hpp"
+#include "psl/ecs/pack.hpp"
 
 namespace core::data {
 class geometry_t;
@@ -18,9 +19,6 @@ class geometry_t;
 namespace psl::ecs {
 class state_t;
 struct info_t;
-
-template <typename... Ts>
-class pack;
 }	 // namespace psl::ecs
 
 namespace core::ecs::components {
@@ -55,21 +53,18 @@ class text {
 
   private:
 	void update_dynamic(psl::ecs::info_t& info,
-						psl::ecs::pack<psl::ecs::partial,
-									   psl::ecs::entity,
-									   core::ecs::components::text,
-									   core::ecs::components::renderable,
-									   psl::ecs::filter<core::ecs::components::dynamic_tag>> pack);
+						psl::ecs::pack_direct_partial_t<psl::ecs::entity,
+														core::ecs::components::text,
+														core::ecs::components::renderable,
+														psl::ecs::filter<core::ecs::components::dynamic_tag>> pack);
 	void add(psl::ecs::info_t& info,
-			 psl::ecs::pack<psl::ecs::partial,
-							psl::ecs::entity,
-							core::ecs::components::text,
-							psl::ecs::on_add<core::ecs::components::text>> pack);
+			 psl::ecs::pack_direct_partial_t<psl::ecs::entity,
+											 core::ecs::components::text,
+											 psl::ecs::on_add<core::ecs::components::text>> pack);
 	void remove(psl::ecs::info_t& info,
-				psl::ecs::pack<psl::ecs::partial,
-							   psl::ecs::entity,
-							   core::ecs::components::text,
-							   psl::ecs::on_remove<core::ecs::components::text>> pack);
+				psl::ecs::pack_direct_partial_t<psl::ecs::entity,
+												core::ecs::components::text,
+												psl::ecs::on_remove<core::ecs::components::text>> pack);
 
 	core::resource::handle<core::data::geometry_t> create_text(psl::string_view text);
 

--- a/core/main/main.cpp
+++ b/core/main/main.cpp
@@ -828,8 +828,6 @@ ECSState.create(
 		  core::ecs::components::transform {psl::vec3 {}, psl::vec3::one * 1.f});
 	}
 
-	ECSState.declare([](psl::ecs::info_t& info, psl::ecs::pack_t<psl::ecs::partial, psl::ecs::direct_t, int> pack) {});
-
 	ECSState.create(1,
 					psl::ecs::empty<core::ecs::components::transform> {},
 					core::ecs::components::light {{}, 1.0f, core::ecs::components::light::type::DIRECTIONAL, true});

--- a/core/main/main.cpp
+++ b/core/main/main.cpp
@@ -750,11 +750,11 @@ int entry(gfx::graphics_backend backend, core::os::context& os_context) {
 	ECSState.declare<"lifetime">(psl::ecs::threading::par, core::ecs::systems::lifetime);
 	ECSState.declare<"downscale">(psl::ecs::threading::par,
 								  [](info_t& info, pack_direct_full_t<transform, const lifetime> pack) {
-		for(auto [transf, life] : pack) {
-			auto remainder = std::min(life.value * 2.0f, 1.0f);
-			transf.scale *= remainder;
-		}
-	});
+									  for(auto [transf, life] : pack) {
+										  auto remainder = std::min(life.value * 2.0f, 1.0f);
+										  transf.scale *= remainder;
+									  }
+								  });
 
 	ECSState.declare<"attractor">(psl::ecs::threading::par, core::ecs::systems::attractor);
 	core::ecs::systems::geometry_instancing geometry_instancing_system {ECSState};
@@ -885,7 +885,8 @@ ECSState.create(
 		{
 			next_spawn += std::chrono::milliseconds(spawnInterval);
 			ECSState.create(
-			  /*(iterations > 0) ? count + std::rand() % (swing + 1) : 0*/ static_cast<entity>((frame % 250 == 0) ? burst : 0),
+			  /*(iterations > 0) ? count + std::rand() % (swing + 1) : 0*/ static_cast<entity>(
+				(frame % 250 == 0) ? burst : 0),
 			  [&bundles, &geometryHandles, &matusage](core::ecs::components::renderable& renderable) {
 				  auto matIndex = 0;
 				  // (std::rand() % 2 == 0);

--- a/core/main/main.cpp
+++ b/core/main/main.cpp
@@ -1002,7 +1002,7 @@ int main(int argc, char* argv[]) {
 		core::log->info("Received the cli args:");
 		for(auto i = 0; i < argc; ++i) core::log->info(argv[i]);
 	}
-	auto backend = [](int argc, char* argv[]) noexcept {
+	auto backend = [](int argc, char* argv[]) {
 		for(auto i = 0; i < argc; ++i) {
 			std::string_view text {argv[i]};
 			if(text == "--vulkan") {

--- a/core/main/main.cpp
+++ b/core/main/main.cpp
@@ -4,8 +4,8 @@
 
 #define _CRT_SECURE_NO_WARNINGS
 #define _CRT_DISABLE_PERFCRIT_LOCKS
-//#include <Windows.h>
-//#include "stdafx.h"
+// #include <Windows.h>
+// #include "stdafx.h"
 #include "psl/application_utils.hpp"
 #include "psl/library.hpp"
 #include "psl/platform_utils.hpp"
@@ -748,7 +748,8 @@ int entry(gfx::graphics_backend backend, core::os::context& os_context) {
 
 	ECSState.declare<"movement">(psl::ecs::threading::par, core::ecs::systems::movement);
 	ECSState.declare<"lifetime">(psl::ecs::threading::par, core::ecs::systems::lifetime);
-	ECSState.declare<"downscale">(psl::ecs::threading::par, [](info_t& info, pack<transform, const lifetime> pack) {
+	ECSState.declare<"downscale">(psl::ecs::threading::par,
+								  [](info_t& info, pack_direct_full_t<transform, const lifetime> pack) {
 		for(auto [transf, life] : pack) {
 			auto remainder = std::min(life.value * 2.0f, 1.0f);
 			transf.scale *= remainder;
@@ -827,6 +828,8 @@ ECSState.create(
 		  core::ecs::components::transform {psl::vec3 {}, psl::vec3::one * 1.f});
 	}
 
+	ECSState.declare([](psl::ecs::info_t& info, psl::ecs::pack_t<psl::ecs::partial, psl::ecs::direct_t, int> pack) {});
+
 	ECSState.create(1,
 					psl::ecs::empty<core::ecs::components::transform> {},
 					core::ecs::components::light {{}, 1.0f, core::ecs::components::light::type::DIRECTIONAL, true});
@@ -884,7 +887,7 @@ ECSState.create(
 		{
 			next_spawn += std::chrono::milliseconds(spawnInterval);
 			ECSState.create(
-			  /*(iterations > 0) ? count + std::rand() % (swing + 1) : 0*/ (frame % 250 == 0) ? burst : 0,
+			  /*(iterations > 0) ? count + std::rand() % (swing + 1) : 0*/ static_cast<entity>((frame % 250 == 0) ? burst : 0),
 			  [&bundles, &geometryHandles, &matusage](core::ecs::components::renderable& renderable) {
 				  auto matIndex = 0;
 				  // (std::rand() % 2 == 0);

--- a/core/src/ecs/systems/debug/grid.cpp
+++ b/core/src/ecs/systems/debug/grid.cpp
@@ -116,8 +116,8 @@ grid::grid(state_t& state,
 }
 
 void grid::tick(info_t& info,
-				pack<entity, const transform, psl::ecs::filter<camera>> pack,
-				psl::ecs::pack<transform, psl::ecs::filter<grid::tag>> grid_pack) {
+				pack_direct_full_t<entity, const transform, psl::ecs::filter<camera>> pack,
+				psl::ecs::pack_direct_full_t<transform, psl::ecs::filter<grid::tag>> grid_pack) {
 	auto entities		 = pack.get<entity>();
 	auto transforms		 = pack.get<const transform>();
 	auto grid_transforms = grid_pack.get<transform>();

--- a/core/src/ecs/systems/fly.cpp
+++ b/core/src/ecs/systems/fly.cpp
@@ -18,7 +18,8 @@ fly::~fly() {
 
 void fly::tick(
   psl::ecs::info_t& info,
-  psl::ecs::pack<core::ecs::components::transform, psl::ecs::filter<core::ecs::components::input_tag>> movables) {
+			   psl::ecs::pack_direct_full_t<core::ecs::components::transform,
+											psl::ecs::filter<core::ecs::components::input_tag>> movables) {
 	bool bHasRotated = m_MouseX != m_MouseTargetX || m_MouseY != m_MouseTargetY;
 	if(bHasRotated) {
 		float mouseSpeed = .12f;

--- a/core/src/ecs/systems/fly.cpp
+++ b/core/src/ecs/systems/fly.cpp
@@ -16,8 +16,7 @@ fly::~fly() {
 	m_InputSystem.unsubscribe(this);
 }
 
-void fly::tick(
-  psl::ecs::info_t& info,
+void fly::tick(psl::ecs::info_t& info,
 			   psl::ecs::pack_direct_full_t<core::ecs::components::transform,
 											psl::ecs::filter<core::ecs::components::input_tag>> movables) {
 	bool bHasRotated = m_MouseX != m_MouseTargetX || m_MouseY != m_MouseTargetY;

--- a/core/src/ecs/systems/geometry_instance.cpp
+++ b/core/src/ecs/systems/geometry_instance.cpp
@@ -28,14 +28,12 @@ geometry_instancing::geometry_instancing(psl::ecs::state_t& state) {
 }
 
 
-void geometry_instancing::dynamic_system(
-  info_t& info,
+void geometry_instancing::dynamic_system(info_t& info,
 										 pack_direct_full_t<renderable,
 															const transform,
 															const dynamic_tag,
 															except<dont_render_tag>,
-															order_by<renderer_sort, renderable>>
-	geometry_pack) {
+															order_by<renderer_sort, renderable>> geometry_pack) {
 	// todo clean up in case the last renderable from a dynamic object is despawned. The instance will not be released
 	// todo this will trash static instances as well
 	core::log->warn("todo: instance leak");
@@ -106,11 +104,11 @@ void geometry_instancing::dynamic_system(
 
 void geometry_instancing::static_add(info_t& info,
 									 pack_direct_full_t<entity,
-										  const renderable,
-										  const transform,
-										  psl::ecs::except<dynamic_tag>,
-										  on_combine<const renderable, const transform>,
-										  order_by<renderer_sort, renderable>> geometry_pack) {
+														const renderable,
+														const transform,
+														psl::ecs::except<dynamic_tag>,
+														on_combine<const renderable, const transform>,
+														order_by<renderer_sort, renderable>> geometry_pack) {
 	if(geometry_pack.size() == 0)
 		return;
 
@@ -165,10 +163,10 @@ void geometry_instancing::static_add(info_t& info,
 }
 void geometry_instancing::static_remove(info_t& info,
 										pack_direct_full_t<entity,
-											 renderable,
-											 const instance_id,
-											 psl::ecs::except<dynamic_tag>,
-											 on_break<const renderable, const transform>> geometry_pack) {
+														   renderable,
+														   const instance_id,
+														   psl::ecs::except<dynamic_tag>,
+														   on_break<const renderable, const transform>> geometry_pack) {
 	if(geometry_pack.size() == 0)
 		return;
 	core::log->info("deallocating {} static instances", geometry_pack.size());
@@ -185,9 +183,9 @@ void geometry_instancing::static_remove(info_t& info,
 void geometry_instancing::static_geometry_add(
   psl::ecs::info_t& info,
   psl::ecs::pack_direct_full_t<psl::ecs::entity,
-				 const core::ecs::components::renderable,
-				 psl::ecs::except<core::ecs::components::transform>,
-				 psl::ecs::on_add<core::ecs::components::renderable>> pack) {
+							   const core::ecs::components::renderable,
+							   psl::ecs::except<core::ecs::components::transform>,
+							   psl::ecs::on_add<core::ecs::components::renderable>> pack) {
 	if(pack.size() == 0)
 		return;
 	psl::array<entity> eIds;
@@ -206,10 +204,10 @@ void geometry_instancing::static_geometry_add(
 void geometry_instancing::static_geometry_remove(
   psl::ecs::info_t& info,
   psl::ecs::pack_direct_full_t<psl::ecs::entity,
-				 core::ecs::components::renderable,
-				 const instance_id,
-				 psl::ecs::except<core::ecs::components::transform>,
-				 psl::ecs::on_remove<core::ecs::components::renderable>> pack) {
+							   core::ecs::components::renderable,
+							   const instance_id,
+							   psl::ecs::except<core::ecs::components::transform>,
+							   psl::ecs::on_remove<core::ecs::components::renderable>> pack) {
 	if(pack.size() == 0)
 		return;
 	for(auto [entity, renderable, instance_id] : pack) {

--- a/core/src/ecs/systems/geometry_instance.cpp
+++ b/core/src/ecs/systems/geometry_instance.cpp
@@ -30,7 +30,11 @@ geometry_instancing::geometry_instancing(psl::ecs::state_t& state) {
 
 void geometry_instancing::dynamic_system(
   info_t& info,
-  pack<renderable, const transform, const dynamic_tag, except<dont_render_tag>, order_by<renderer_sort, renderable>>
+										 pack_direct_full_t<renderable,
+															const transform,
+															const dynamic_tag,
+															except<dont_render_tag>,
+															order_by<renderer_sort, renderable>>
 	geometry_pack) {
 	// todo clean up in case the last renderable from a dynamic object is despawned. The instance will not be released
 	// todo this will trash static instances as well
@@ -101,7 +105,7 @@ void geometry_instancing::dynamic_system(
 }
 
 void geometry_instancing::static_add(info_t& info,
-									 pack<entity,
+									 pack_direct_full_t<entity,
 										  const renderable,
 										  const transform,
 										  psl::ecs::except<dynamic_tag>,
@@ -160,7 +164,7 @@ void geometry_instancing::static_add(info_t& info,
 	core::profiler.scope_end();
 }
 void geometry_instancing::static_remove(info_t& info,
-										pack<entity,
+										pack_direct_full_t<entity,
 											 renderable,
 											 const instance_id,
 											 psl::ecs::except<dynamic_tag>,
@@ -180,7 +184,7 @@ void geometry_instancing::static_remove(info_t& info,
 
 void geometry_instancing::static_geometry_add(
   psl::ecs::info_t& info,
-  psl::ecs::pack<psl::ecs::entity,
+  psl::ecs::pack_direct_full_t<psl::ecs::entity,
 				 const core::ecs::components::renderable,
 				 psl::ecs::except<core::ecs::components::transform>,
 				 psl::ecs::on_add<core::ecs::components::renderable>> pack) {
@@ -201,7 +205,7 @@ void geometry_instancing::static_geometry_add(
 
 void geometry_instancing::static_geometry_remove(
   psl::ecs::info_t& info,
-  psl::ecs::pack<psl::ecs::entity,
+  psl::ecs::pack_direct_full_t<psl::ecs::entity,
 				 core::ecs::components::renderable,
 				 const instance_id,
 				 psl::ecs::except<core::ecs::components::transform>,

--- a/core/src/ecs/systems/gpu_camera.cpp
+++ b/core/src/ecs/systems/gpu_camera.cpp
@@ -24,7 +24,7 @@ gpu_camera::gpu_camera(psl::ecs::state_t& state,
 
 void gpu_camera::tick(
   psl::ecs::info_t& info,
-  psl::ecs::pack<const core::ecs::components::camera, const core::ecs::components::transform> cameras) {
+  psl::ecs::pack_direct_full_t<const core::ecs::components::camera, const core::ecs::components::transform> cameras) {
 	size_t i {0};
 	if(cameras.size() >= m_Max)
 		throw std::runtime_error(

--- a/core/src/ecs/systems/lighting.cpp
+++ b/core/src/ecs/systems/lighting.cpp
@@ -43,7 +43,7 @@ lighting_system::lighting_system(psl::view_ptr<psl::ecs::state_t> state,
 	m_LightSegment = m_LightDataBuffer->reserve(m_LightDataBuffer->free_size()).value();
 }
 
-void lighting_system::create_dir(info_t& info, pack<entity, light, on_combine<light, transform>> pack) {
+void lighting_system::create_dir(info_t& info, pack_direct_full_t<entity, light, on_combine<light, transform>> pack) {
 	if(pack.size() == 0)
 		return;
 	// insertion_sort(std::begin(pack), std::end(pack), sort_impl<light_sort, light>{});

--- a/core/src/ecs/systems/render.cpp
+++ b/core/src/ecs/systems/render.cpp
@@ -20,8 +20,8 @@ render::render(state_t& state, psl::view_ptr<core::gfx::drawpass> pass) : m_Pass
 	state.declare<"render::tick_draws">(threading::seq, &render::tick_draws, this);
 }
 void render::tick_draws(info_t& info,
-						pack<const renderable, on_add<renderable>> renderables,
-						pack<const renderable, on_remove<renderable>> broken_renderables) {
+						pack_direct_full_t<const renderable, on_add<renderable>> renderables,
+						pack_direct_full_t<const renderable, on_remove<renderable>> broken_renderables) {
 	if(!renderables.size() && !broken_renderables.size())
 		return;
 	m_Pass->dirty(true);

--- a/core/src/ecs/systems/text.cpp
+++ b/core/src/ecs/systems/text.cpp
@@ -237,13 +237,13 @@ core::resource::handle<core::data::geometry_t> text::create_text(psl::string_vie
 
 void text::update_dynamic(
   info_t& info,
-  pack<partial, entity, comp::text, comp::renderable, psl::ecs::filter<comp::dynamic_tag>> pack) {
+  pack_direct_partial_t<entity, comp::text, comp::renderable, psl::ecs::filter<comp::dynamic_tag>> pack) {
 	for(auto [e, text, renderer] : pack) {
 		renderer.geometry->recreate(create_text(*text.value));
 	}
 }
 
-void text::add(info_t& info, pack<partial, entity, comp::text, on_add<comp::text>> pack) {
+void text::add(info_t& info, pack_direct_partial_t<entity, comp::text, on_add<comp::text>> pack) {
 	psl::array<entity> ents;
 	ents.resize(1);
 	for(auto [e, text] : pack) {
@@ -262,6 +262,6 @@ void text::add(info_t& info, pack<partial, entity, comp::text, on_add<comp::text
 	}
 }
 
-void text::remove(info_t& info, pack<partial, entity, comp::text, on_remove<comp::text>> pack) {
+void text::remove(info_t& info, pack_direct_partial_t<entity, comp::text, on_remove<comp::text>> pack) {
 	info.command_buffer.remove_components<comp::renderable>(pack.get<entity>());
 }

--- a/psl/inc/psl/array_view.hpp
+++ b/psl/inc/psl/array_view.hpp
@@ -172,7 +172,7 @@ class array_view {
 
 	pointer data() const noexcept { return first; };
 
-	array_view slice(size_t begin, size_t end) { return array_view<T> {first + begin, first + end}; }
+	array_view slice(size_t begin, size_t end) const noexcept { return array_view<T> {first + begin, first + end}; }
 
   private:
 	pointer first;

--- a/psl/inc/psl/assertions.hpp
+++ b/psl/inc/psl/assertions.hpp
@@ -216,6 +216,7 @@ namespace details {
 #endif
 
 #if defined(PE_DEBUG)
+	#define PE_ASSERT
 	 // _PSL_ASSERT_IMPL_(N) are added to inject a generic failed message in case none was provided.
 	#define _PSL_ASSERT_IMPL_(...) psl_print(psl::level_t::fatal, "assertion failed")
 	#define _PSL_ASSERT_IMPL_N(...) psl_print(psl::level_t::fatal, __VA_ARGS__)

--- a/psl/inc/psl/ecs/command_buffer.hpp
+++ b/psl/inc/psl/ecs/command_buffer.hpp
@@ -4,12 +4,12 @@
 #include "entity.hpp"
 #include "psl/array.hpp"
 #include "psl/array_view.hpp"
+#include "psl/ecs/pack.hpp"
 #include "psl/memory/sparse_array.hpp"
 #include "psl/sparse_array.hpp"
 #include "psl/sparse_indice_array.hpp"
 #include "psl/static_array.hpp"
 #include "psl/template_utils.hpp"
-#include "psl/ecs/pack.hpp"
 #include "psl/unique_ptr.hpp"
 
 namespace psl::ecs {
@@ -18,7 +18,7 @@ class state_t;
 class command_buffer_t {
 	friend class state_t;
 
-	template<IsPack PackType>
+	template <IsPack PackType>
 	psl::array_view<entity> pack_get_entities(PackType const& pack) {
 		psl::array_view<entity> entities {};
 		if constexpr(IsAccessDirect<typename PackType::access_type>) {
@@ -47,7 +47,7 @@ class command_buffer_t {
 		static_assert(sizeof...(Ts) > 0, "you need to supply at least one component to add");
 		(add_component<Ts>(entities), ...);
 	}
-	
+
 	template <typename... Ts>
 	void add_components(IsPack auto const& pack, psl::array_view<Ts>... data) {
 		psl::array_view<entity> entities = pack_get_entities(pack);

--- a/psl/inc/psl/ecs/command_buffer.hpp
+++ b/psl/inc/psl/ecs/command_buffer.hpp
@@ -9,6 +9,7 @@
 #include "psl/sparse_indice_array.hpp"
 #include "psl/static_array.hpp"
 #include "psl/template_utils.hpp"
+#include "psl/ecs/pack.hpp"
 #include "psl/unique_ptr.hpp"
 
 namespace psl::ecs {
@@ -17,8 +18,27 @@ class state_t;
 class command_buffer_t {
 	friend class state_t;
 
+	template<IsPack PackType>
+	psl::array_view<entity> pack_get_entities(PackType const& pack) {
+		psl::array_view<entity> entities {};
+		if constexpr(IsAccessDirect<typename PackType::access_type>) {
+			entities = pack.template get<entity>();
+		} else {
+			const auto& indirect_array = pack.template get<entity>();
+			// the internal data does not get modified, so const_cast'ing is safe here.
+			entities = psl::array_view<entity> {const_cast<entity*>(indirect_array.data()), indirect_array.size()};
+		}
+		return entities;
+	}
+
   public:
 	command_buffer_t(const state_t& state);
+
+	template <typename... Ts>
+	void add_components(IsPack auto const& pack) {
+		psl::array_view<entity> entities = pack_get_entities(pack);
+		(add_component<Ts>(entities), ...);
+	}
 
 	template <typename... Ts>
 	void add_components(psl::array_view<entity> entities) {
@@ -27,7 +47,12 @@ class command_buffer_t {
 		static_assert(sizeof...(Ts) > 0, "you need to supply at least one component to add");
 		(add_component<Ts>(entities), ...);
 	}
-
+	
+	template <typename... Ts>
+	void add_components(IsPack auto const& pack, psl::array_view<Ts>... data) {
+		psl::array_view<entity> entities = pack_get_entities(pack);
+		add_components<Ts...>(entities, data...);
+	}
 
 	template <typename... Ts>
 	void add_components(psl::array_view<entity> entities, psl::array_view<Ts>... data) {
@@ -38,11 +63,23 @@ class command_buffer_t {
 	}
 
 	template <typename... Ts>
+	void add_components(IsPack auto const& pack, Ts&&... prototype) {
+		psl::array_view<entity> entities = pack_get_entities(pack);
+		add_components<Ts...>(entities, std::forward<Ts>(prototype)...);
+	}
+
+	template <typename... Ts>
 	void add_components(psl::array_view<entity> entities, Ts&&... prototype) {
 		if(entities.size() == 0)
 			return;
 		static_assert(sizeof...(Ts) > 0, "you need to supply at least one component to add");
 		(add_component(entities, std::forward<Ts>(prototype)), ...);
+	}
+
+	template <typename... Ts>
+	void remove_components(IsPack auto const& pack) noexcept {
+		psl::array_view<entity> entities = pack_get_entities(pack);
+		remove_components<Ts...>(entities);
 	}
 
 	template <typename... Ts>
@@ -136,6 +173,7 @@ class command_buffer_t {
 	}
 
 	void destroy(psl::array_view<entity> entities) noexcept;
+	void destroy(psl::ecs::details::indirect_array_t<entity, entity> entities) noexcept;
 	void destroy(entity entity) noexcept;
 
   private:

--- a/psl/inc/psl/ecs/details/component_container.hpp
+++ b/psl/inc/psl/ecs/details/component_container.hpp
@@ -127,7 +127,8 @@ class component_container_typed_t final : public component_container_t {
 		psl::array<entity> result {};
 		result.reserve(entities.size());
 		for(auto e : entities) {
-			result.emplace_back(static_cast<entity>(m_Entities.addressof(e, stage_range_t::ALL) - (T*)m_Entities.data()));
+			result.emplace_back(
+			  static_cast<entity>(m_Entities.addressof(e, stage_range_t::ALL) - (T*)m_Entities.data()));
 		}
 		return result;
 	}

--- a/psl/inc/psl/ecs/details/system_information.hpp
+++ b/psl/inc/psl/ecs/details/system_information.hpp
@@ -278,14 +278,14 @@ class dependency_pack {
 		for(const auto& binding : m_IndirectReadBindings) {
 			auto size										  = cpy.m_Sizes[binding.first];
 			cpy.m_IndirectReadBindings[binding.first].indices = psl::array<entity>(
-			  std::next(binding.second.indices.begin(), begin), std::next(binding.second.indices.end(), end));
+			  std::next(binding.second.indices.begin(), begin), std::next(binding.second.indices.begin(), end));
 			cpy.m_IndirectReadBindings[binding.first].data = binding.second.data;
 		}
 
 		for(const auto& binding : m_IndirectReadWriteBindings) {
 			auto size											   = cpy.m_Sizes[binding.first];
 			cpy.m_IndirectReadWriteBindings[binding.first].indices = psl::array<entity>(
-			  std::next(binding.second.indices.begin(), begin), std::next(binding.second.indices.end(), end));
+			  std::next(binding.second.indices.begin(), begin), std::next(binding.second.indices.begin(), end));
 			cpy.m_IndirectReadWriteBindings[binding.first].data = binding.second.data;
 		}
 		return cpy;

--- a/psl/inc/psl/ecs/details/system_information.hpp
+++ b/psl/inc/psl/ecs/details/system_information.hpp
@@ -140,7 +140,7 @@ class dependency_pack {
 		filters.clear();
 		std::set_difference(
 		  std::begin(cpy), std::end(cpy), std::begin(except), std::end(except), std::back_inserter(filters));
-		if constexpr(std::is_same<psl::ecs::partial, typename pack_t::policy_type>::value) {
+		if constexpr(IsPackPartial<typename pack_t::policy_type>) {
 			m_IsPartial = true;
 		}
 	};

--- a/psl/inc/psl/ecs/details/system_information.hpp
+++ b/psl/inc/psl/ecs/details/system_information.hpp
@@ -39,17 +39,46 @@ namespace psl::ecs::details {
 /// `psl::ecs::components::transform`, but also needs to know all `psl::ecs::components::camera's`. So that
 /// system would require several dependency_pack's.
 class dependency_pack {
+	struct indirect_storage_t {
+		psl::array<entity> indices {};
+		void* data {nullptr};
+	};
 	friend class psl::ecs::state_t;
 	template <std::size_t... Is, typename T>
 	auto create_dependency_filters(std::index_sequence<Is...>, psl::type_pack_t<T>) {
-		if constexpr(IsPackFull<typename T::access_type>) {
-			(add(psl::type_pack_t<
-				 typename std::remove_reference<decltype(std::declval<T>().template get<Is>())>::type> {}),
-			 ...);
-		} else {
-			// todo we need to write an add for the indirect_array_t
-		}
+		(_create_dependency_filters_impl(
+		   typename std::remove_reference<decltype(std::declval<T>().template get<Is>())>::type {}),
+		 ...);
 	}
+
+	template <typename T>
+	auto _create_dependency_filters_impl(psl::array_view<T>) {
+		constexpr auto id = details::component_key_t::generate<T>();
+		m_RWBindings.emplace(id, psl::array_view<std::uintptr_t> {});
+	}
+
+	template <typename T>
+	auto _create_dependency_filters_impl(psl::array_view<T const>) {
+		constexpr auto id = details::component_key_t::generate<T>();
+		m_RBindings.emplace(id, psl::array_view<std::uintptr_t> {});
+	}
+
+	auto _create_dependency_filters_impl(psl::array_view<entity>) {}
+	auto _create_dependency_filters_impl(psl::array_view<entity const>) {}
+
+	template <typename T>
+	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<T, entity>) {
+		constexpr auto id = details::component_key_t::generate<T>();
+		m_IndirectReadWriteBindings.emplace(id, indirect_storage_t {});
+	}
+	template <typename T>
+	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<T const, entity>) {
+		constexpr auto id = details::component_key_t::generate<T>();
+		m_IndirectReadBindings.emplace(id, indirect_storage_t {});
+	}
+
+	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<entity, entity>) {}
+	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<entity const, entity>) {}
 
 	template <typename F>
 	void select_impl(std::vector<component_key_t>& target) {
@@ -85,27 +114,44 @@ class dependency_pack {
 	}
 
 	template <typename T>
-	psl::array_view<T> fill_in(psl::type_pack_t<psl::array_view<T>>) {
+	auto fill_in(psl::type_pack_t<psl::array_view<T>>) -> psl::array_view<T> {
 		if constexpr(std::is_same<T, psl::ecs::entity>::value) {
 			return m_Entities;
-		} else if constexpr(std::is_const<T>::value) {
-			constexpr component_key_t int_id = details::component_key_t::generate<T>();
-			return *(psl::array_view<T>*)&m_RBindings[int_id];
 		} else {
-			constexpr component_key_t int_id = details::component_key_t::generate<T>();
-			return *(psl::array_view<T>*)&m_RWBindings[int_id];
+			constexpr component_key_t id = details::component_key_t::generate<T>();
+			if constexpr(std::is_const<T>::value) {
+				return *(psl::array_view<T>*)&m_RBindings[id];
+			} else {
+				return *(psl::array_view<T>*)&m_RWBindings[id];
+			}
+		}
+	}
+
+	template <typename T>
+	auto fill_in(psl::type_pack_t<psl::ecs::details::indirect_array_t<T, psl::ecs::entity>>)
+	  -> psl::ecs::details::indirect_array_t<T, psl::ecs::entity> {
+		if constexpr(std::is_same<T, psl::ecs::entity>::value) {
+			return m_Entities;
+		} else {
+			constexpr component_key_t id = details::component_key_t::generate<T>();
+			if constexpr(std::is_const<T>::value) {
+				return psl::ecs::details::indirect_array_t<T, psl::ecs::entity>(m_IndirectReadBindings[id].indices,
+																				(T*)m_IndirectReadBindings[id].data);
+			} else {
+				return psl::ecs::details::indirect_array_t<T, psl::ecs::entity>(
+				  m_IndirectReadWriteBindings[id].indices, (T*)m_IndirectReadWriteBindings[id].data);
+			}
 		}
 	}
 
 	template <std::size_t... Is, typename T>
 	T to_pack_impl(std::index_sequence<Is...>, psl::type_pack_t<T>) {
-		using pack_type	  = typename T::pack_type;
-		using range_t	  = typename pack_type::range_t;
-		if constexpr(IsPackFull<typename T::access_type>) {
+		using pack_type = typename T::pack_type;
+		using range_t	= typename pack_type::range_t;
+		if constexpr(IsAccessDirect<typename T::access_type>) {
 			return T {pack_type(fill_in(psl::type_pack_t<typename std::tuple_element<Is, range_t>::type>())...)};
 		} else {
-			// todo return a fully formed pack_t of indirect values
-			return T {};
+			return T {pack_type(fill_in(psl::type_pack_t<typename std::tuple_element<Is, range_t>::type>())...)};
 		}
 	}
 
@@ -116,31 +162,32 @@ class dependency_pack {
 		: m_IsPartial(IsPackPartial<typename T::policy_type>), m_IsIndirect(IsAccessIndirect<typename T::access_type>) {
 		orderby =
 		  [](psl::array<entity>::iterator begin, psl::array<entity>::iterator end, const psl::ecs::state_t& state) {};
-		using pack_t = T;
-		create_dependency_filters(std::make_index_sequence<std::tuple_size_v<typename pack_t::pack_type::range_t>> {},
-								  psl::type_pack_t<T> {});
-		select(std::make_index_sequence<std::tuple_size<typename pack_t::filter_type>::value> {},
-			   typename pack_t::filter_type {},
+		using pack_type = T;
+		create_dependency_filters(
+		  std::make_index_sequence<std::tuple_size_v<typename pack_type::pack_type::range_t>> {},
+		  psl::type_pack_t<typename pack_type::pack_type> {});
+		select(std::make_index_sequence<std::tuple_size<typename pack_type::filter_type>::value> {},
+			   typename pack_type::filter_type {},
 			   filters);
-		select(std::make_index_sequence<std::tuple_size<typename pack_t::add_type>::value> {},
-			   typename pack_t::add_type {},
+		select(std::make_index_sequence<std::tuple_size<typename pack_type::add_type>::value> {},
+			   typename pack_type::add_type {},
 			   (seedWithPrevious) ? filters : on_add);
-		select(std::make_index_sequence<std::tuple_size<typename pack_t::remove_type>::value> {},
-			   typename pack_t::remove_type {},
+		select(std::make_index_sequence<std::tuple_size<typename pack_type::remove_type>::value> {},
+			   typename pack_type::remove_type {},
 			   on_remove);
-		select(std::make_index_sequence<std::tuple_size<typename pack_t::break_type>::value> {},
-			   typename pack_t::break_type {},
+		select(std::make_index_sequence<std::tuple_size<typename pack_type::break_type>::value> {},
+			   typename pack_type::break_type {},
 			   on_break);
-		select(std::make_index_sequence<std::tuple_size<typename pack_t::combine_type>::value> {},
-			   typename pack_t::combine_type {},
+		select(std::make_index_sequence<std::tuple_size<typename pack_type::combine_type>::value> {},
+			   typename pack_type::combine_type {},
 			   (seedWithPrevious) ? filters : on_combine);
-		select(std::make_index_sequence<std::tuple_size<typename pack_t::except_type>::value> {},
-			   typename pack_t::except_type {},
+		select(std::make_index_sequence<std::tuple_size<typename pack_type::except_type>::value> {},
+			   typename pack_type::except_type {},
 			   except);
-		select_ordering(typename pack_t::order_by_type {});
-		select_condition(typename pack_t::conditional_type {});
+		select_ordering(typename pack_type::order_by_type {});
+		select_condition(typename pack_type::conditional_type {});
 
-		static_assert(std::tuple_size<typename pack_t::order_by_type>::value < 2);
+		static_assert(std::tuple_size<typename pack_type::order_by_type>::value < 2);
 
 		std::sort(std::begin(filters), std::end(filters));
 		filters.erase(std::unique(std::begin(filters), std::end(filters)), std::end(filters));
@@ -169,15 +216,29 @@ class dependency_pack {
 	}
 
 	bool allow_partial() const noexcept { return m_IsPartial; };
+	constexpr inline bool is_partial_pack() const noexcept { return m_IsPartial; };
+	constexpr inline bool is_full_pack() const noexcept { return !m_IsPartial; };
+	constexpr inline bool is_direct_access() const noexcept { return !m_IsIndirect; };
+	constexpr inline bool is_indirect_access() const noexcept { return m_IsIndirect; };
 
 	size_t size_per_element() const noexcept {
 		size_t res {0};
-		for(const auto& binding : m_RBindings) {
-			res += m_Sizes.at(binding.first);
-		}
+		if(!m_IsIndirect) {
+			for(const auto& binding : m_RBindings) {
+				res += m_Sizes.at(binding.first);
+			}
 
-		for(const auto& binding : m_RWBindings) {
-			res += m_Sizes.at(binding.first);
+			for(const auto& binding : m_RWBindings) {
+				res += m_Sizes.at(binding.first);
+			}
+		} else {
+			for(const auto& binding : m_IndirectReadBindings) {
+				res += m_Sizes.at(binding.first);
+			}
+
+			for(const auto& binding : m_IndirectReadWriteBindings) {
+				res += m_Sizes.at(binding.first);
+			}
 		}
 		return res;
 	}
@@ -192,63 +253,83 @@ class dependency_pack {
 
 	size_t entities() const noexcept { return m_Entities.size(); }
 	dependency_pack slice(size_t begin, size_t end) const noexcept {
-		dependency_pack cpy {*this};
+		auto cpy = make_partial_copy();
 
-		cpy.m_Entities = cpy.m_Entities.slice(begin, end);
+		cpy.m_Entities =
+		  psl::array_view<entity>(std::next(m_Entities.begin(), begin), std::next(m_Entities.begin(), end));
 
-		for(auto& binding : cpy.m_RBindings) {
+		for(const auto& binding : m_RBindings) {
 			auto size = cpy.m_Sizes[binding.first];
 
 			std::uintptr_t begin_mem = (std::uintptr_t)binding.second.data() + (begin * size);
 			std::uintptr_t end_mem	 = (std::uintptr_t)binding.second.data() + (end * size);
-			binding.second = psl::array_view<std::uintptr_t> {(std::uintptr_t*)begin_mem, (std::uintptr_t*)end_mem};
+			cpy.m_RBindings[binding.first] =
+			  psl::array_view<std::uintptr_t> {(std::uintptr_t*)begin_mem, (std::uintptr_t*)end_mem};
 		}
-		for(auto& binding : cpy.m_RWBindings) {
+		for(const auto& binding : m_RWBindings) {
 			auto size = cpy.m_Sizes[binding.first];
 			// binding.second = binding.second.slice(size * begin, size * end);
 			std::uintptr_t begin_mem = (std::uintptr_t)binding.second.data() + (begin * size);
 			std::uintptr_t end_mem	 = (std::uintptr_t)binding.second.data() + (end * size);
-			binding.second = psl::array_view<std::uintptr_t> {(std::uintptr_t*)begin_mem, (std::uintptr_t*)end_mem};
+			cpy.m_RWBindings[binding.first] =
+			  psl::array_view<std::uintptr_t> {(std::uintptr_t*)begin_mem, (std::uintptr_t*)end_mem};
+		}
+
+		for(const auto& binding : m_IndirectReadBindings) {
+			auto size										  = cpy.m_Sizes[binding.first];
+			cpy.m_IndirectReadBindings[binding.first].indices = psl::array<entity>(
+			  std::next(binding.second.indices.begin(), begin), std::next(binding.second.indices.end(), end));
+			cpy.m_IndirectReadBindings[binding.first].data = binding.second.data;
+		}
+
+		for(const auto& binding : m_IndirectReadWriteBindings) {
+			auto size											   = cpy.m_Sizes[binding.first];
+			cpy.m_IndirectReadWriteBindings[binding.first].indices = psl::array<entity>(
+			  std::next(binding.second.indices.begin(), begin), std::next(binding.second.indices.end(), end));
+			cpy.m_IndirectReadWriteBindings[binding.first].data = binding.second.data;
 		}
 		return cpy;
 	}
 
   private:
-	template <typename T>
-	void add(psl::type_pack_t<psl::array_view<T>>) noexcept {
-		constexpr component_key_t int_id = details::component_key_t::generate<T>();
-		m_RWBindings.emplace(int_id, psl::array_view<std::uintptr_t> {});
+	dependency_pack() = default;
+	auto make_partial_copy() const noexcept -> dependency_pack {
+		dependency_pack cpy {};
+		cpy.m_Sizes		 = m_Sizes;
+		cpy.filters		 = filters;
+		cpy.on_add		 = on_add;
+		cpy.on_remove	 = on_remove;
+		cpy.except		 = except;
+		cpy.on_combine	 = on_combine;
+		cpy.on_break	 = on_break;
+		cpy.on_condition = on_condition;
+		cpy.orderby		 = orderby;
+		cpy.m_IsPartial	 = m_IsPartial;
+		cpy.m_IsIndirect = m_IsIndirect;
+		return cpy;
 	}
 
-	template <typename T>
-	void add(psl::type_pack_t<psl::array_view<const T>>) noexcept {
-		constexpr component_key_t int_id = details::component_key_t::generate<T>();
-		m_RBindings.emplace(int_id, psl::array_view<std::uintptr_t> {});
-	}
-
-
-	void add(psl::type_pack_t<psl::array_view<psl::ecs::entity>>) noexcept {}
-	void add(psl::type_pack_t<psl::array_view<const psl::ecs::entity>>) noexcept {}
-
-  private:
 	psl::array_view<psl::ecs::entity> m_Entities {};
-	std::unordered_map<component_key_t, size_t> m_Sizes;
+	std::unordered_map<component_key_t, size_t> m_Sizes {};
 	std::unordered_map<component_key_t, psl::array_view<std::uintptr_t>> m_RBindings;
 	std::unordered_map<component_key_t, psl::array_view<std::uintptr_t>> m_RWBindings;
+	std::unordered_map<component_key_t, indirect_storage_t> m_IndirectReadBindings;
+	std::unordered_map<component_key_t, indirect_storage_t> m_IndirectReadWriteBindings;
 
-	std::vector<component_key_t> filters;
-	std::vector<component_key_t> on_add;
-	std::vector<component_key_t> on_remove;
-	std::vector<component_key_t> except;
-	std::vector<component_key_t> on_combine;
-	std::vector<component_key_t> on_break;
+	std::vector<component_key_t> filters {};
+	std::vector<component_key_t> on_add {};
+	std::vector<component_key_t> on_remove {};
+	std::vector<component_key_t> except {};
+	std::vector<component_key_t> on_combine {};
+	std::vector<component_key_t> on_break {};
 
 	std::vector<std::function<psl::array<
 	  entity>::iterator(psl::array<entity>::iterator, psl::array<entity>::iterator, const psl::ecs::state_t&)>>
-	  on_condition;
+	  on_condition {};
 
-	std::function<void(psl::array<entity>::iterator, psl::array<entity>::iterator, const psl::ecs::state_t&)> orderby;
-	bool m_IsPartial = false;
+	std::function<void(psl::array<entity>::iterator, psl::array<entity>::iterator, const psl::ecs::state_t&)>
+	  orderby {};
+	bool m_IsPartial  = false;
 	bool m_IsIndirect = false;
 };
 
@@ -262,8 +343,8 @@ std::vector<dependency_pack> expand_to_dependency_pack(psl::type_pack_t<Ts...>, 
 namespace {
 	template <size_t... Is, typename... Ts>
 	auto compress_from_dependency_pack_impl(std::index_sequence<Is...>,
-														 psl::type_pack_t<Ts...>,
-														 std::vector<dependency_pack>& pack) {
+											psl::type_pack_t<Ts...>,
+											std::vector<dependency_pack>& pack) {
 		return std::make_tuple(pack[Is].to_pack(decode_pack_types_t<Ts> {})...);
 	}
 }	 // namespace

--- a/psl/inc/psl/ecs/details/system_information.hpp
+++ b/psl/inc/psl/ecs/details/system_information.hpp
@@ -130,7 +130,7 @@ class dependency_pack {
 	template <typename T>
 	auto fill_in(psl::type_pack_t<psl::ecs::details::indirect_array_t<T, psl::ecs::entity>>) {
 		if constexpr(std::is_same<T, psl::ecs::entity>::value) {
-			// todo: this is a temporary hack untill mixed packs can be done. Ideally entities are an array_view not an
+			// todo: this is a temporary hack until mixed packs can be done. Ideally entities are an array_view not an
 			// indirect_array_t
 			std::vector<entity> indices {};
 			indices.resize(m_Entities.size());

--- a/psl/inc/psl/ecs/details/system_information.hpp
+++ b/psl/inc/psl/ecs/details/system_information.hpp
@@ -128,20 +128,20 @@ class dependency_pack {
 	}
 
 	template <typename T>
-	auto fill_in(psl::type_pack_t<psl::ecs::details::indirect_array_t<T, psl::ecs::entity>>)
-	  {
+	auto fill_in(psl::type_pack_t<psl::ecs::details::indirect_array_t<T, psl::ecs::entity>>) {
 		if constexpr(std::is_same<T, psl::ecs::entity>::value) {
-			// todo: this is a temporary hack untill mixed packs can be done. Ideally entities are an array_view not an indirect_array_t
+			// todo: this is a temporary hack untill mixed packs can be done. Ideally entities are an array_view not an
+			// indirect_array_t
 			std::vector<entity> indices {};
 			indices.resize(m_Entities.size());
 			std::iota(std::begin(indices), std::end(indices), entity {0});
-			return psl::ecs::details::indirect_array_t<T, psl::ecs::entity>(indices, (psl::ecs::entity*)m_Entities.data());
+			return psl::ecs::details::indirect_array_t<T, psl::ecs::entity>(indices,
+																			(psl::ecs::entity*)m_Entities.data());
 		} else {
 			constexpr component_key_t id = details::component_key_t::generate<T>();
 			if constexpr(std::is_const<T>::value) {
 				auto it = m_IndirectReadBindings.find(id);
-				psl_assert(it != m_IndirectReadBindings.end(),
-						   "type wasn't present in `m_IndirectReadBindings`");
+				psl_assert(it != m_IndirectReadBindings.end(), "type wasn't present in `m_IndirectReadBindings`");
 				return psl::ecs::details::indirect_array_t<T, psl::ecs::entity>(it->second.indices,
 																				(T*)it->second.data);
 			} else {
@@ -155,7 +155,7 @@ class dependency_pack {
 	}
 
 	template <std::size_t... Is, typename T>
-	auto to_pack_impl(std::index_sequence<Is...>, psl::type_pack_t<T>) -> T{
+	auto to_pack_impl(std::index_sequence<Is...>, psl::type_pack_t<T>) -> T {
 		using pack_type = typename T::pack_type;
 		using range_t	= typename pack_type::range_t;
 		return T(pack_type(fill_in(psl::type_pack_t<typename std::tuple_element<Is, range_t>::type>())...));

--- a/psl/inc/psl/ecs/details/system_information.hpp
+++ b/psl/inc/psl/ecs/details/system_information.hpp
@@ -130,8 +130,12 @@ class dependency_pack {
 	template <typename T>
 	auto fill_in(psl::type_pack_t<psl::ecs::details::indirect_array_t<T, psl::ecs::entity>>)
 	  -> psl::ecs::details::indirect_array_t<T, psl::ecs::entity> {
-		if constexpr(std::is_same<T, psl::ecs::entity>::value) {
-			return m_Entities;
+		if constexpr(std::is_same<std::remove_const_t<T>, psl::ecs::entity>::value) {
+			// todo: this is a temporary hack untill mixed packs can be done. Ideally entities are an array_view not an indirect_array_t
+			std::vector<entity> indices {};
+			indices.resize(m_Entities.size());
+			std::iota(std::begin(indices), std::end(indices), entity {0});
+			return psl::ecs::details::indirect_array_t<T, psl::ecs::entity>(indices, m_Entities.data());
 		} else {
 			constexpr component_key_t id = details::component_key_t::generate<T>();
 			if constexpr(std::is_const<T>::value) {

--- a/psl/inc/psl/ecs/filtering.hpp
+++ b/psl/inc/psl/ecs/filtering.hpp
@@ -66,8 +66,7 @@ namespace details {
 	class filter_group {
 		template <typename T>
 		constexpr void selector(psl::type_pack_t<T>) noexcept {
-			if constexpr(!std::is_same_v<entity, T> && !std::is_same_v<psl::ecs::partial, T> &&
-						 !std::is_same_v<psl::ecs::full, T>)
+			if constexpr(!std::is_same_v<entity, T> && !IsPolicy<T> && !IsAccessType<T>)
 				filters.emplace_back(details::component_key_t::generate<T>());
 		}
 
@@ -260,18 +259,12 @@ namespace details {
 
 	template <typename... Ts>
 	auto make_filter_group(psl::type_pack_t<Ts...>) -> psl::array<filter_group> {
-		auto make_group = []<typename... Ys>(psl::type_pack_t<psl::ecs::pack<Ys...>>) -> filter_group {
-			return filter_group {psl::type_pack_t<Ys...> {}};
-		};
-		return psl::array<filter_group> {make_group(psl::type_pack_t<Ts> {})...};
+		return psl::array<filter_group> {filter_group(decode_pack_types_t<Ts> {})...};
 	}
 
 	template <typename... Ts>
 	auto make_transform_group(psl::type_pack_t<Ts...>) -> psl::array<transform_group> {
-		auto make_group = []<typename... Ys>(psl::type_pack_t<psl::ecs::pack<Ys...>>) -> transform_group {
-			return transform_group {psl::type_pack_t<Ys...> {}};
-		};
-		return psl::array<transform_group> {make_group(psl::type_pack_t<Ts> {})...};
+		return psl::array<transform_group> {transform_group(decode_pack_types_t<Ts> {})...};
 	}
 }	 // namespace details
 }	 // namespace psl::ecs

--- a/psl/inc/psl/ecs/pack.hpp
+++ b/psl/inc/psl/ecs/pack.hpp
@@ -240,7 +240,9 @@ namespace details {
 
 
 		template <typename... Ys>
-		indirect_pack_view_t(Ys&&... data) : m_Data(std::forward<Ys>(data)...) {
+		indirect_pack_view_t(Ys&&... data)
+			requires(sizeof...(Ys) > 0)
+			: m_Data(std::forward<Ys>(data)...) {
 // we hide the assert behind a check as the fold expression otherwise doesn't exist which leads to a compile error. This
 // approach is cleaner without adding more machinery.
 #if defined(PE_ASSERT)
@@ -279,20 +281,28 @@ namespace details {
 			return std::get<indirect_array_t<T, indice_type>>(m_Data);
 		}
 
-		constexpr inline auto size() const noexcept -> size_t {
-			if constexpr(sizeof...(Ts) > 0) {
-				return std::get<0>(m_Data).size();
-			} else {
-				return 0;
-			}
+		constexpr inline auto size() const noexcept -> size_t
+			requires(sizeof...(Ts) > 0)
+		{
+			return std::get<0>(m_Data).size();
 		}
 
-		constexpr inline auto empty() const noexcept -> bool {
-			if constexpr(sizeof...(Ts) > 0) {
-				return std::get<0>(m_Data).empty();
-			} else {
-				return true;
-			}
+		constexpr inline auto size() const noexcept -> size_t
+			requires(sizeof...(Ts) == 0)
+		{
+			return 0;
+		}
+
+		constexpr inline auto empty() const noexcept -> bool
+			requires(sizeof...(Ts) > 0)
+		{
+			return std::get<0>(m_Data).empty();
+		}
+
+		constexpr inline auto empty() const noexcept -> bool
+			requires(sizeof...(Ts) == 0)
+		{
+			return true;
 		}
 
 		constexpr inline auto operator[](size_t index) const noexcept {
@@ -316,12 +326,8 @@ namespace details {
 			return indirect_pack_view_iterator_t(std::get<indirect_array_t<Ts, indice_type>>(m_Data).end()...);
 		}
 
-		constexpr inline auto cbegin() const noexcept {
-			return begin();
-		}
-		constexpr inline auto cend() const noexcept {
-			return end();
-		}
+		constexpr inline auto cbegin() const noexcept { return begin(); }
+		constexpr inline auto cend() const noexcept { return end(); }
 		range_t m_Data {};
 	};
 
@@ -342,7 +348,8 @@ namespace details {
 }	 // namespace details
 
 template <IsPolicy Policy, IsAccessType Access, typename... Ts>
-requires(!IsPolicy<Ts> && ...) class pack_t {
+	requires(!IsPolicy<Ts> && ...)
+class pack_t {
   public:
 	using pack_type		   = typename details::typelist_to_pack_view<Ts...>::type;
 	using filter_type	   = typename details::typelist_to_pack<Ts...>::type;
@@ -389,7 +396,8 @@ requires(!IsPolicy<Ts> && ...) class pack_t {
 };
 
 template <IsPolicy Policy, typename... Ts>
-requires(!IsPolicy<Ts> && ...) class pack_t<Policy, indirect_t, Ts...> {
+	requires(!IsPolicy<Ts> && ...)
+class pack_t<Policy, indirect_t, Ts...> {
   public:
 	using pack_type		   = details::tuple_to_indirect_pack_view_t<typename details::typelist_to_tuple<Ts...>::type>;
 	using filter_type	   = typename details::typelist_to_pack<Ts...>::type;

--- a/psl/inc/psl/ecs/pack.hpp
+++ b/psl/inc/psl/ecs/pack.hpp
@@ -11,9 +11,39 @@ class state_t;
 namespace details {
 
 	template <typename T, typename SizeType = size_t>
-	struct indirect_array_iterator_t {
+	class indirect_array_iterator_t;
+
+	template <typename T>
+	struct is_indirect_array_iterator : std::false_type {};
+
+	template <typename T, typename SizeType>
+	struct is_indirect_array_iterator<indirect_array_iterator_t<T, SizeType>> : std::true_type {};
+
+	template <typename T, typename Y>
+	struct is_compatible_indirect_array_iterator : std::false_type {};
+
+	template <typename T, typename Y, typename SizeType>
+	requires(
+	  std::is_same_v<
+		std::remove_const_t<T>,
+		std::remove_const_t<Y>>) struct is_compatible_indirect_array_iterator<indirect_array_iterator_t<T, SizeType>,
+																			  indirect_array_iterator_t<Y, SizeType>>
+		: std::true_type {};
+
+	template <typename T, typename SizeType>
+	class indirect_array_iterator_t {
+	  private:
+		static constexpr bool _is_const = std::is_const_v<T>;
+
+		// give access to the const/non-const version of itself so we can have the logical operators access internals.
+		friend class indirect_array_iterator_t<
+		  std::conditional_t<_is_const, std::remove_cvref_t<T>, std::remove_cvref_t<T> const>,
+		  SizeType>;
+
+	  public:
 		using size_type			   = SizeType;
 		using value_type		   = std::remove_cvref_t<T>;
+		using const_value_type	   = value_type const;
 		using reference_type	   = value_type&;
 		using const_reference_type = value_type const&;
 		using pointer_type		   = value_type*;
@@ -22,42 +52,54 @@ namespace details {
 		using difference_type		   = std::ptrdiff_t;
 		using unpack_iterator_category = std::random_access_iterator_tag;
 
+
 		indirect_array_iterator_t(size_type* it, pointer_type data) : m_It(it), m_Data(data) {}
+		indirect_array_iterator_t(size_type* it, const_pointer_type data) requires(_is_const)
+			: m_It(it), m_Data(const_cast<pointer_type>(data)) {}
 		indirect_array_iterator_t(size_type const* it, pointer_type data)
 			: m_It(const_cast<size_type*>(it)), m_Data(data) {}
 
-		// operator T&() noexcept { return m_Data[*m_It]; }
-		// operator T const&() const noexcept { return m_Data[*m_It]; }
+		indirect_array_iterator_t(size_type const* it, const_pointer_type data) requires(_is_const)
+			: m_It(const_cast<size_type*>(it)), m_Data(const_cast<pointer_type>(data)) {}
 
-
-		reference_type operator*() noexcept { return m_Data[*m_It]; }
+		reference_type operator*() noexcept requires(!_is_const) { return m_Data[*m_It]; }
 		const_reference_type operator*() const noexcept { return m_Data[*m_It]; }
-		pointer_type operator->() noexcept { return &(m_Data[*m_It]); }
+		pointer_type operator->() noexcept requires(!_is_const) { return &(m_Data[*m_It]); }
 		const_pointer_type operator->() const noexcept { return &m_Data[*m_It]; }
 
-		constexpr friend bool operator==(const indirect_array_iterator_t& lhs,
-										 const indirect_array_iterator_t& rhs) noexcept {
+		template <typename Y>
+		requires(is_compatible_indirect_array_iterator<indirect_array_iterator_t, Y>::value) constexpr friend bool
+		operator==(indirect_array_iterator_t const& lhs, Y const& rhs) noexcept {
 			return lhs.m_It == rhs.m_It && lhs.m_Data == rhs.m_Data;
 		}
-		constexpr friend bool operator!=(const indirect_array_iterator_t& lhs,
-										 const indirect_array_iterator_t& rhs) noexcept {
+
+		template <typename Y>
+		requires(is_compatible_indirect_array_iterator<indirect_array_iterator_t, Y>::value) constexpr friend bool
+		operator!=(indirect_array_iterator_t const& lhs, Y const& rhs) noexcept {
 			return lhs.m_It != rhs.m_It || lhs.m_Data != rhs.m_Data;
 		}
 
-		constexpr friend bool operator<(const indirect_array_iterator_t& lhs,
-										const indirect_array_iterator_t& rhs) noexcept {
+		template <typename Y>
+		requires(is_compatible_indirect_array_iterator<indirect_array_iterator_t, Y>::value) constexpr friend bool
+		operator<(indirect_array_iterator_t const& lhs, Y const& rhs) noexcept {
 			return *lhs.m_It < *rhs.m_It;
 		}
-		constexpr friend bool operator>(const indirect_array_iterator_t& lhs,
-										const indirect_array_iterator_t& rhs) noexcept {
+
+		template <typename Y>
+		requires(is_compatible_indirect_array_iterator<indirect_array_iterator_t, Y>::value) constexpr friend bool
+		operator>(indirect_array_iterator_t const& lhs, Y const& rhs) noexcept {
 			return *lhs.m_It > *rhs.m_It;
 		}
-		constexpr friend bool operator<=(const indirect_array_iterator_t& lhs,
-										 const indirect_array_iterator_t& rhs) noexcept {
+
+		template <typename Y>
+		requires(is_compatible_indirect_array_iterator<indirect_array_iterator_t, Y>::value) constexpr friend bool
+		operator<=(indirect_array_iterator_t const& lhs, Y const& rhs) noexcept {
 			return *lhs.m_It <= *rhs.m_It;
 		}
-		constexpr friend bool operator>=(const indirect_array_iterator_t& lhs,
-										 const indirect_array_iterator_t& rhs) noexcept {
+
+		template <typename Y>
+		requires(is_compatible_indirect_array_iterator<indirect_array_iterator_t, Y>::value) constexpr friend bool
+		operator>=(indirect_array_iterator_t const& lhs, Y const& rhs) noexcept {
 			return *lhs.m_It >= *rhs.m_It;
 		}
 
@@ -98,46 +140,58 @@ namespace details {
 			return tmp;
 		}
 
+	  private:
 		size_type* m_It {};
 		pointer_type m_Data {nullptr};
 	};
 
-	/// @brief
-	/// @tparam T
-	/// @tparam SizeType
 	template <typename T, typename SizeType = size_t>
-	struct indirect_array_t {
+	class indirect_array_t {
+	  private:
+		static constexpr bool _is_const = std::is_const_v<T>;
+
+	  public:
 		using size_type			 = SizeType;
 		using value_type		 = std::remove_cvref_t<T>;
+		using const_value_type	 = value_type const;
 		using pointer_type		 = value_type*;
 		using const_pointer_type = value_type const*;
 
-		using iterator_type = indirect_array_iterator_t<T, size_type>;
+		using iterator_type		  = indirect_array_iterator_t<value_type, size_type>;
+		using const_iterator_type = indirect_array_iterator_t<const_value_type, size_type>;
 
 		template <typename Y>
 		indirect_array_t(Y&& indices, pointer_type data) : m_Indices(std::forward<Y>(indices)), m_Data(data) {}
+		template <typename Y>
+		indirect_array_t(Y&& indices, const_pointer_type data) requires(_is_const)
+			: m_Indices(std::forward<Y>(indices)), m_Data(const_cast<pointer_type>(data)) {}
 		indirect_array_t() = default;
 
-		constexpr inline auto& operator[](size_t index) noexcept { return *(m_Data + m_Indices[index]); }
+		constexpr inline auto& operator[](size_t index) noexcept requires(!_is_const) {
+			return *(m_Data + m_Indices[index]);
+		}
 		constexpr inline auto const& operator[](size_t index) const noexcept { return *(m_Data + m_Indices[index]); }
-		constexpr inline auto& at(size_t index) noexcept { return *(m_Data + m_Indices[index]); }
+		constexpr inline auto& at(size_t index) noexcept requires(!_is_const) { return *(m_Data + m_Indices[index]); }
 		constexpr inline auto const& at(size_t index) const noexcept { return *(m_Data + m_Indices[index]); }
 
 		constexpr inline auto size() const noexcept { return m_Indices.size(); }
-		constexpr inline auto begin() noexcept { return iterator_type(m_Indices.data(), m_Data); }
-		constexpr inline auto end() noexcept { return iterator_type(m_Indices.data() + m_Indices.size(), m_Data); }
-		constexpr inline auto begin() const noexcept { return iterator_type(m_Indices.data(), m_Data); }
-		constexpr inline auto end() const noexcept {
+		constexpr inline auto begin() noexcept requires(!_is_const) { return iterator_type(m_Indices.data(), m_Data); }
+		constexpr inline auto end() noexcept requires(!_is_const) {
 			return iterator_type(m_Indices.data() + m_Indices.size(), m_Data);
+		}
+		constexpr inline auto begin() const noexcept { return const_iterator_type(m_Indices.data(), m_Data); }
+		constexpr inline auto end() const noexcept {
+			return const_iterator_type(m_Indices.data() + m_Indices.size(), m_Data);
 		}
 		constexpr inline auto cbegin() const noexcept { return begin(); }
 		constexpr inline auto cend() const noexcept { return end(); }
 		constexpr inline auto empty() const noexcept -> bool { return m_Indices.empty(); }
 
-		constexpr inline auto data() noexcept -> pointer_type { return m_Data; }
+		constexpr inline auto data() noexcept -> pointer_type requires(!_is_const) { return m_Data; }
 		constexpr inline auto data() const noexcept -> const_pointer_type { return m_Data; }
 		constexpr inline auto cdata() const noexcept -> const_pointer_type { return m_Data; }
 
+	  private:
 		psl::array<size_type> m_Indices {};
 		pointer_type m_Data {};
 	};
@@ -146,7 +200,8 @@ namespace details {
 	indirect_array_t(Container<IndiceType, Rest...>, T*) -> indirect_array_t<T, IndiceType>;
 
 	template <typename... Ts>
-	struct indirect_pack_view_iterator_t {
+	class indirect_pack_view_iterator_t {
+	  public:
 		using size_type = psl::ecs::entity;
 		template <typename T>
 		using value_element_type   = indirect_array_iterator_t<T, size_type>;
@@ -239,10 +294,12 @@ namespace details {
 			return tmp;
 		}
 
+	  private:
 		value_type m_Data {};
 	};
 	template <typename IndiceType, typename... Ts>
-	struct indirect_pack_view_t {
+	class indirect_pack_view_t {
+	  public:
 		using indice_type = IndiceType;
 		template <typename Y>
 		using _indice_tuple_machinery = psl::array<indice_type>;
@@ -333,6 +390,8 @@ namespace details {
 		constexpr inline auto cend() const noexcept {
 			return end();
 		}
+
+	  private:
 		range_t m_Data {};
 	};
 

--- a/psl/inc/psl/ecs/pack.hpp
+++ b/psl/inc/psl/ecs/pack.hpp
@@ -7,26 +7,6 @@
 namespace psl::ecs {
 class state_t;
 
-template <typename T>
-concept IsPackPartial = std::is_same_v<std::remove_cvref_t<T>, psl::ecs::partial_t>;
-template <typename T>
-concept IsPackFull = std::is_same_v<std::remove_cvref_t<T>, psl::ecs::full_t>;
-template <typename T>
-concept IsPolicy = IsPackFull<T> || IsPackPartial<T>;
-
-struct direct_t {};
-struct indirect_t {};
-
-static constexpr direct_t direct {};
-static constexpr indirect_t indirect {};
-
-template <typename T>
-concept IsAccessDirect = std::is_same_v<std::remove_cvref_t<T>, psl::ecs::direct_t>;
-template <typename T>
-concept IsAccessIndirect = std::is_same_v<std::remove_cvref_t<T>, psl::ecs::indirect_t>;
-template <typename T>
-concept IsAccessType = IsAccessDirect<T> || IsAccessIndirect<T>;
-
 // internal details for non-owning views
 namespace details {
 
@@ -377,32 +357,32 @@ class pack_t {
 	static_assert(std::tuple_size<order_by_type>::value <= 1, "multiple order_by statements make no sense");
 
   public:
-	pack_t() : m_Pack() {};
-	pack_t(pack_type views) : m_Pack(views) {}
+	constexpr pack_t() = default;
+	constexpr pack_t(pack_type views) : m_Pack(views) {}
 
 	template <typename... Ys>
-	pack_t(Ys&&... values) : m_Pack(std::forward<Ys>(values)...) {}
-	pack_type view() { return m_Pack; }
+	constexpr pack_t(Ys&&... values) : m_Pack(std::forward<Ys>(values)...) {}
+	constexpr inline pack_type view() { return m_Pack; }
 
 	template <typename T>
-	psl::array_view<T> get() const noexcept {
+	constexpr inline psl::array_view<T> get() const noexcept {
 		return m_Pack.template get<T>();
 	}
 
 	template <size_t N>
-	auto get() const noexcept -> decltype(std::declval<pack_type>().template get<N>()) {
+	constexpr inline auto get() const noexcept -> decltype(std::declval<pack_type>().template get<N>()) {
 		return m_Pack.template get<N>();
 	}
 
-	auto operator[](size_t index) const noexcept { return m_Pack.unpack(index); }
-	auto operator[](size_t index) noexcept { return m_Pack.unpack(index); }
-	auto begin() const noexcept { return m_Pack.unpack_begin(); }
-	auto end() const noexcept { return m_Pack.unpack_end(); }
-	constexpr auto size() const noexcept -> size_t { return m_Pack.size(); }
-	constexpr auto empty() const noexcept -> bool { return m_Pack.size() == 0; }
+	constexpr inline auto operator[](size_t index) const noexcept { return m_Pack.unpack(index); }
+	constexpr inline auto operator[](size_t index) noexcept { return m_Pack.unpack(index); }
+	constexpr inline auto begin() const noexcept { return m_Pack.unpack_begin(); }
+	constexpr inline auto end() const noexcept { return m_Pack.unpack_end(); }
+	constexpr inline auto size() const noexcept -> size_t { return m_Pack.size(); }
+	constexpr inline auto empty() const noexcept -> bool { return m_Pack.size() == 0; }
 
   private:
-	pack_type m_Pack;
+	pack_type m_Pack {};
 };
 
 template <IsPolicy Policy, typename... Ts>

--- a/psl/inc/psl/ecs/pack.hpp
+++ b/psl/inc/psl/ecs/pack.hpp
@@ -464,22 +464,22 @@ class view_t {
 
 	template <size_t N>
 	constexpr inline auto const& get() const noexcept {
-		return m_Pack.get<N>();
+		return m_Pack.template get<N>();
 	}
 
 	template <size_t N>
 	constexpr inline auto get() noexcept {
-		return m_Pack.get<N>();
+		return m_Pack.template get<N>();
 	}
 
 	template <typename T>
 	constexpr inline auto const& get() const noexcept {
-		return m_Pack.get<T>();
+		return m_Pack.template get<T>();
 	}
 
 	template <typename T>
 	constexpr inline auto get() noexcept {
-		return m_Pack.get<T>();
+		return m_Pack.template get<T>();
 	}
 
 	constexpr inline auto size() const noexcept -> size_t { return m_Pack.size(); }

--- a/psl/inc/psl/ecs/pack.hpp
+++ b/psl/inc/psl/ecs/pack.hpp
@@ -316,8 +316,12 @@ namespace details {
 			return indirect_pack_view_iterator_t(std::get<indirect_array_t<Ts, indice_type>>(m_Data).end()...);
 		}
 
-		constexpr inline auto cbegin() const noexcept { return begin(); }
-		constexpr inline auto cend() const noexcept { return end(); }
+		constexpr inline auto cbegin() const noexcept {
+			return begin();
+		}
+		constexpr inline auto cend() const noexcept {
+			return end();
+		}
 		range_t m_Data {};
 	};
 
@@ -338,8 +342,7 @@ namespace details {
 }	 // namespace details
 
 template <IsPolicy Policy, IsAccessType Access, typename... Ts>
-	requires(!IsPolicy<Ts> && ...)
-class pack_t {
+requires(!IsPolicy<Ts> && ...) class pack_t {
   public:
 	using pack_type		   = typename details::typelist_to_pack_view<Ts...>::type;
 	using filter_type	   = typename details::typelist_to_pack<Ts...>::type;
@@ -386,8 +389,7 @@ class pack_t {
 };
 
 template <IsPolicy Policy, typename... Ts>
-	requires(!IsPolicy<Ts> && ...)
-class pack_t<Policy, indirect_t, Ts...> {
+requires(!IsPolicy<Ts> && ...) class pack_t<Policy, indirect_t, Ts...> {
   public:
 	using pack_type		   = details::tuple_to_indirect_pack_view_t<typename details::typelist_to_tuple<Ts...>::type>;
 	using filter_type	   = typename details::typelist_to_pack<Ts...>::type;

--- a/psl/inc/psl/ecs/pack.hpp
+++ b/psl/inc/psl/ecs/pack.hpp
@@ -67,8 +67,10 @@ class pack : public pack_base<Ts...> {
 	pack() : m_Pack() { check_policy<Ts...>(); };
 	pack(pack_t views) : m_Pack(views) { check_policy<Ts...>(); }
 
-	template<typename... Ys>
-	pack(Ys&&... values) : m_Pack(std::forward<Ys>(values)...) { check_policy<Ts...>(); }
+	template <typename... Ys>
+	pack(Ys&&... values) : m_Pack(std::forward<Ys>(values)...) {
+		check_policy<Ts...>();
+	}
 	pack_t view() { return m_Pack; }
 
 	template <typename T>
@@ -434,7 +436,7 @@ namespace details {
 
 	template <typename T>
 	using tuple_to_indirect_pack_view_t = typename tuple_to_indirect_pack_view<T>::type;
-}	 // namespace
+}	 // namespace details
 
 
 template <IsPolicy Policy, typename... Ts>
@@ -520,7 +522,7 @@ class pack_t<Policy, indirect_t, Ts...> : public view_t<Policy, Ts...> {
 	using base_type = view_t<Policy, Ts...>;
 
   public:
-	template<typename... Ys>
+	template <typename... Ys>
 	pack_t(Policy, Ys&&... values) : base_type(std::forward<Ys>(values)...) {}
 };
 

--- a/psl/inc/psl/ecs/pack.hpp
+++ b/psl/inc/psl/ecs/pack.hpp
@@ -8,7 +8,11 @@ namespace psl::ecs {
 class state_t;
 
 template <typename T>
-concept IsPolicy = std::is_same_v<T, psl::ecs::partial> || std::is_same_v<T, psl::ecs::full>;
+concept IsPackPartial = std::is_same_v<std::remove_cvref_t<T>, psl::ecs::partial_t>;
+template <typename T>
+concept IsPackFull = std::is_same_v<std::remove_cvref_t<T>, psl::ecs::full_t>;
+template <typename T>
+concept IsPolicy = IsPackFull<T> || IsPackPartial<T>;
 
 struct direct_t {};
 struct indirect_t {};
@@ -17,7 +21,11 @@ static constexpr direct_t direct {};
 static constexpr indirect_t indirect {};
 
 template <typename T>
-concept IsAccessType = std::is_same_v<T, psl::ecs::direct_t> || std::is_same_v<T, psl::ecs::indirect_t>;
+concept IsAccessDirect = std::is_same_v<std::remove_cvref_t<T>, psl::ecs::direct_t>;
+template <typename T>
+concept IsAccessIndirect = std::is_same_v<std::remove_cvref_t<T>, psl::ecs::indirect_t>;
+template <typename T>
+concept IsAccessType = IsAccessDirect<T> || IsAccessIndirect<T>;
 
 // internal details for non-owning views
 namespace details {
@@ -469,16 +477,16 @@ template <IsPolicy Policy, typename... Ts>
 pack_t(Policy, psl::array<Ts>...) -> pack_t<Policy, direct_t, Ts...>;
 
 template <typename... Ts>
-using pack_indirect_partial_t = pack_t<psl::ecs::partial, indirect_t, Ts...>;
+using pack_indirect_partial_t = pack_t<psl::ecs::partial_t, indirect_t, Ts...>;
 
 template <typename... Ts>
-using pack_indirect_full_t = pack_t<psl::ecs::full, indirect_t, Ts...>;
+using pack_indirect_full_t = pack_t<psl::ecs::full_t, indirect_t, Ts...>;
 
 template <typename... Ts>
-using pack_direct_partial_t = pack_t<psl::ecs::partial, direct_t, Ts...>;
+using pack_direct_partial_t = pack_t<psl::ecs::partial_t, direct_t, Ts...>;
 
 template <typename... Ts>
-using pack_direct_full_t = pack_t<psl::ecs::full, direct_t, Ts...>;
+using pack_direct_full_t = pack_t<psl::ecs::full_t, direct_t, Ts...>;
 
 template <typename T>
 struct is_pack : std::false_type {};

--- a/psl/inc/psl/ecs/pack.hpp
+++ b/psl/inc/psl/ecs/pack.hpp
@@ -107,16 +107,15 @@ namespace details {
 	/// @tparam SizeType
 	template <typename T, typename SizeType = size_t>
 	struct indirect_array_t {
-		using size_type	   = SizeType;
-		using value_type   = std::remove_cvref_t<T>;
-		using pointer_type = value_type*;
+		using size_type			 = SizeType;
+		using value_type		 = std::remove_cvref_t<T>;
+		using pointer_type		 = value_type*;
 		using const_pointer_type = value_type const*;
 
 		using iterator_type = indirect_array_iterator_t<T, size_type>;
 
 		template <typename Y>
-		indirect_array_t(Y&& indices, pointer_type data)
-			: m_Indices(std::forward<Y>(indices)), m_Data(data) {}
+		indirect_array_t(Y&& indices, pointer_type data) : m_Indices(std::forward<Y>(indices)), m_Data(data) {}
 		indirect_array_t() = default;
 
 		constexpr inline auto& operator[](size_t index) noexcept { return *(m_Data + m_Indices[index]); }
@@ -128,7 +127,9 @@ namespace details {
 		constexpr inline auto begin() noexcept { return iterator_type(m_Indices.data(), m_Data); }
 		constexpr inline auto end() noexcept { return iterator_type(m_Indices.data() + m_Indices.size(), m_Data); }
 		constexpr inline auto begin() const noexcept { return iterator_type(m_Indices.data(), m_Data); }
-		constexpr inline auto end() const noexcept { return iterator_type(m_Indices.data() + m_Indices.size(), m_Data); }
+		constexpr inline auto end() const noexcept {
+			return iterator_type(m_Indices.data() + m_Indices.size(), m_Data);
+		}
 		constexpr inline auto cbegin() const noexcept { return begin(); }
 		constexpr inline auto cend() const noexcept { return end(); }
 		constexpr inline auto empty() const noexcept -> bool { return m_Indices.empty(); }
@@ -250,9 +251,7 @@ namespace details {
 
 
 		template <typename... Ys>
-		indirect_pack_view_t(Ys&&... data)
-			requires(sizeof...(Ys) > 0)
-			: m_Data(std::forward<Ys>(data)...) {
+		indirect_pack_view_t(Ys&&... data) requires(sizeof...(Ys) > 0) : m_Data(std::forward<Ys>(data)...) {
 // we hide the assert behind a check as the fold expression otherwise doesn't exist which leads to a compile error. This
 // approach is cleaner without adding more machinery.
 #if defined(PE_ASSERT)
@@ -291,27 +290,19 @@ namespace details {
 			return std::get<indirect_array_t<T, indice_type>>(m_Data);
 		}
 
-		constexpr inline auto size() const noexcept -> size_t
-			requires(sizeof...(Ts) > 0)
-		{
+		constexpr inline auto size() const noexcept -> size_t requires(sizeof...(Ts) > 0) {
 			return std::get<0>(m_Data).size();
 		}
 
-		constexpr inline auto size() const noexcept -> size_t
-			requires(sizeof...(Ts) == 0)
-		{
+		constexpr inline auto size() const noexcept -> size_t requires(sizeof...(Ts) == 0) {
 			return 0;
 		}
 
-		constexpr inline auto empty() const noexcept -> bool
-			requires(sizeof...(Ts) > 0)
-		{
+		constexpr inline auto empty() const noexcept -> bool requires(sizeof...(Ts) > 0) {
 			return std::get<0>(m_Data).empty();
 		}
 
-		constexpr inline auto empty() const noexcept -> bool
-			requires(sizeof...(Ts) == 0)
-		{
+		constexpr inline auto empty() const noexcept -> bool requires(sizeof...(Ts) == 0) {
 			return true;
 		}
 
@@ -336,8 +327,12 @@ namespace details {
 			return indirect_pack_view_iterator_t(std::get<indirect_array_t<Ts, indice_type>>(m_Data).end()...);
 		}
 
-		constexpr inline auto cbegin() const noexcept { return begin(); }
-		constexpr inline auto cend() const noexcept { return end(); }
+		constexpr inline auto cbegin() const noexcept {
+			return begin();
+		}
+		constexpr inline auto cend() const noexcept {
+			return end();
+		}
 		range_t m_Data {};
 	};
 
@@ -358,8 +353,7 @@ namespace details {
 }	 // namespace details
 
 template <IsPolicy Policy, IsAccessType Access, typename... Ts>
-	requires(!IsPolicy<Ts> && ...)
-class pack_t {
+requires(!IsPolicy<Ts> && ...) class pack_t {
   public:
 	using pack_type		   = typename details::typelist_to_pack_view<Ts...>::type;
 	using filter_type	   = typename details::typelist_to_pack<Ts...>::type;
@@ -406,8 +400,7 @@ class pack_t {
 };
 
 template <IsPolicy Policy, typename... Ts>
-	requires(!IsPolicy<Ts> && ...)
-class pack_t<Policy, indirect_t, Ts...> {
+requires(!IsPolicy<Ts> && ...) class pack_t<Policy, indirect_t, Ts...> {
   public:
 	using pack_type		   = details::tuple_to_indirect_pack_view_t<typename details::typelist_to_tuple<Ts...>::type>;
 	using filter_type	   = typename details::typelist_to_pack<Ts...>::type;

--- a/psl/inc/psl/ecs/pack.hpp
+++ b/psl/inc/psl/ecs/pack.hpp
@@ -240,9 +240,7 @@ namespace details {
 
 
 		template <typename... Ys>
-		indirect_pack_view_t(Ys&&... data)
-			requires(sizeof...(Ys) > 0)
-			: m_Data(std::forward<Ys>(data)...) {
+		indirect_pack_view_t(Ys&&... data) requires(sizeof...(Ys) > 0) : m_Data(std::forward<Ys>(data)...) {
 // we hide the assert behind a check as the fold expression otherwise doesn't exist which leads to a compile error. This
 // approach is cleaner without adding more machinery.
 #if defined(PE_ASSERT)
@@ -281,27 +279,19 @@ namespace details {
 			return std::get<indirect_array_t<T, indice_type>>(m_Data);
 		}
 
-		constexpr inline auto size() const noexcept -> size_t
-			requires(sizeof...(Ts) > 0)
-		{
+		constexpr inline auto size() const noexcept -> size_t requires(sizeof...(Ts) > 0) {
 			return std::get<0>(m_Data).size();
 		}
 
-		constexpr inline auto size() const noexcept -> size_t
-			requires(sizeof...(Ts) == 0)
-		{
+		constexpr inline auto size() const noexcept -> size_t requires(sizeof...(Ts) == 0) {
 			return 0;
 		}
 
-		constexpr inline auto empty() const noexcept -> bool
-			requires(sizeof...(Ts) > 0)
-		{
+		constexpr inline auto empty() const noexcept -> bool requires(sizeof...(Ts) > 0) {
 			return std::get<0>(m_Data).empty();
 		}
 
-		constexpr inline auto empty() const noexcept -> bool
-			requires(sizeof...(Ts) == 0)
-		{
+		constexpr inline auto empty() const noexcept -> bool requires(sizeof...(Ts) == 0) {
 			return true;
 		}
 
@@ -326,8 +316,12 @@ namespace details {
 			return indirect_pack_view_iterator_t(std::get<indirect_array_t<Ts, indice_type>>(m_Data).end()...);
 		}
 
-		constexpr inline auto cbegin() const noexcept { return begin(); }
-		constexpr inline auto cend() const noexcept { return end(); }
+		constexpr inline auto cbegin() const noexcept {
+			return begin();
+		}
+		constexpr inline auto cend() const noexcept {
+			return end();
+		}
 		range_t m_Data {};
 	};
 
@@ -348,8 +342,7 @@ namespace details {
 }	 // namespace details
 
 template <IsPolicy Policy, IsAccessType Access, typename... Ts>
-	requires(!IsPolicy<Ts> && ...)
-class pack_t {
+requires(!IsPolicy<Ts> && ...) class pack_t {
   public:
 	using pack_type		   = typename details::typelist_to_pack_view<Ts...>::type;
 	using filter_type	   = typename details::typelist_to_pack<Ts...>::type;
@@ -396,8 +389,7 @@ class pack_t {
 };
 
 template <IsPolicy Policy, typename... Ts>
-	requires(!IsPolicy<Ts> && ...)
-class pack_t<Policy, indirect_t, Ts...> {
+requires(!IsPolicy<Ts> && ...) class pack_t<Policy, indirect_t, Ts...> {
   public:
 	using pack_type		   = details::tuple_to_indirect_pack_view_t<typename details::typelist_to_tuple<Ts...>::type>;
 	using filter_type	   = typename details::typelist_to_pack<Ts...>::type;

--- a/psl/inc/psl/ecs/pack.hpp
+++ b/psl/inc/psl/ecs/pack.hpp
@@ -66,6 +66,9 @@ class pack : public pack_base<Ts...> {
   public:
 	pack() : m_Pack() { check_policy<Ts...>(); };
 	pack(pack_t views) : m_Pack(views) { check_policy<Ts...>(); }
+
+	template<typename... Ys>
+	pack(Ys&&... values) : m_Pack(std::forward<Ys>(values)...) { check_policy<Ts...>(); }
 	pack_t view() { return m_Pack; }
 
 	template <typename T>
@@ -88,4 +91,445 @@ class pack : public pack_base<Ts...> {
   private:
 	pack_t m_Pack;
 };
+
+template <typename T>
+concept IsPolicy = std::is_same_v<T, psl::ecs::partial> || std::is_same_v<T, psl::ecs::full>;
+
+struct direct_t {};
+struct indirect_t {};
+
+static constexpr direct_t direct {};
+static constexpr indirect_t indirect {};
+
+template <typename T>
+concept IsAccessType = std::is_same_v<T, psl::ecs::direct_t> || std::is_same_v<T, psl::ecs::indirect_t>;
+//
+// template<typename T>
+// concept IsValidPack = std::tuple_size<typename T::order_by_t>::value <= 1;
+
+// internal details for non-owning views
+namespace details {
+
+	template <typename T, typename SizeType = size_t>
+	struct indirect_array_iterator_t {
+		using size_type			   = SizeType;
+		using value_type		   = std::remove_cvref_t<T>;
+		using reference_type	   = value_type&;
+		using const_reference_type = value_type const&;
+		using pointer_type		   = value_type*;
+		using const_pointer_type   = value_type const*;
+
+		using difference_type		   = std::ptrdiff_t;
+		using unpack_iterator_category = std::random_access_iterator_tag;
+
+		indirect_array_iterator_t(size_type* it, pointer_type data) : m_It(it), m_Data(data) {}
+		indirect_array_iterator_t(size_type const* it, pointer_type data)
+			: m_It(const_cast<size_type*>(it)), m_Data(data) {}
+
+		// operator T&() noexcept { return m_Data[*m_It]; }
+		// operator T const&() const noexcept { return m_Data[*m_It]; }
+
+
+		reference_type operator*() noexcept { return m_Data[*m_It]; }
+		const_reference_type operator*() const noexcept { return m_Data[*m_It]; }
+		pointer_type operator->() noexcept { return &(m_Data[*m_It]); }
+		const_pointer_type operator->() const noexcept { return &m_Data[*m_It]; }
+
+		constexpr friend bool operator==(const indirect_array_iterator_t& lhs,
+										 const indirect_array_iterator_t& rhs) noexcept {
+			return lhs.m_It == rhs.m_It && lhs.m_Data == rhs.m_Data;
+		}
+		constexpr friend bool operator!=(const indirect_array_iterator_t& lhs,
+										 const indirect_array_iterator_t& rhs) noexcept {
+			return lhs.m_It != rhs.m_It || lhs.m_Data != rhs.m_Data;
+		}
+
+		constexpr friend bool operator<(const indirect_array_iterator_t& lhs,
+										const indirect_array_iterator_t& rhs) noexcept {
+			return *lhs.m_It < *rhs.m_It;
+		}
+		constexpr friend bool operator>(const indirect_array_iterator_t& lhs,
+										const indirect_array_iterator_t& rhs) noexcept {
+			return *lhs.m_It > *rhs.m_It;
+		}
+		constexpr friend bool operator<=(const indirect_array_iterator_t& lhs,
+										 const indirect_array_iterator_t& rhs) noexcept {
+			return *lhs.m_It <= *rhs.m_It;
+		}
+		constexpr friend bool operator>=(const indirect_array_iterator_t& lhs,
+										 const indirect_array_iterator_t& rhs) noexcept {
+			return *lhs.m_It >= *rhs.m_It;
+		}
+
+		constexpr indirect_array_iterator_t& operator++() noexcept {
+			++m_It;
+			return *this;
+		}
+
+		constexpr indirect_array_iterator_t& operator--() noexcept {
+			--m_It;
+			return *this;
+		}
+
+		constexpr indirect_array_iterator_t operator++(int) noexcept {
+			auto tmp = *this;
+			++(*this);
+			return tmp;
+		}
+
+		constexpr indirect_array_iterator_t operator--(int) noexcept {
+			auto tmp = *this;
+			--(*this);
+			return tmp;
+		}
+
+		constexpr indirect_array_iterator_t& operator+=(difference_type offset) noexcept {
+			m_It = std::next(m_It, offset);
+			return *this;
+		}
+		constexpr indirect_array_iterator_t operator+(difference_type offset) const noexcept {
+			auto tmp = *this;
+			tmp += offset;
+			return tmp;
+		}
+		constexpr indirect_array_iterator_t operator-(difference_type offset) {
+			auto tmp = *this;
+			tmp -= offset;
+			return tmp;
+		}
+
+		size_type* m_It {};
+		pointer_type m_Data {nullptr};
+	};
+
+	/// @brief
+	/// @tparam T
+	/// @tparam SizeType
+	template <typename T, typename SizeType = size_t>
+	struct indirect_array_t {
+		using size_type	   = SizeType;
+		using value_type   = std::remove_cvref_t<T>;
+		using pointer_type = value_type*;
+
+		using iterator_type = indirect_array_iterator_t<T, size_type>;
+
+		template <template <typename> typename Y = psl::array>
+		indirect_array_t(Y<size_type>&& indices, pointer_type data)
+			: m_Indices(std::forward<Y<size_type>>(indices)), m_Data(data) {}
+		indirect_array_t(psl::array_view<size_type> indices, pointer_type data) : m_Indices(indices), m_Data(data) {}
+		indirect_array_t() = default;
+
+		constexpr auto size() const noexcept { return m_Indices.size(); }
+		constexpr auto begin() noexcept { return iterator_type(m_Indices.data(), m_Data); }
+		constexpr auto end() noexcept { return iterator_type(m_Indices.data() + m_Indices.size(), m_Data); }
+		constexpr auto begin() const noexcept { return iterator_type(m_Indices.data(), m_Data); }
+		constexpr auto end() const noexcept { return iterator_type(m_Indices.data() + m_Indices.size(), m_Data); }
+		constexpr auto cbegin() const noexcept { return begin(); }
+		constexpr auto cend() const noexcept { return end(); }
+
+		psl::array<size_type> m_Indices {};
+		pointer_type m_Data {};
+	};
+
+	template <typename T, typename IndiceType, template <typename, typename...> typename Container, typename... Rest>
+	indirect_array_t(Container<IndiceType, Rest...>, T*) -> indirect_array_t<T, IndiceType>;
+
+	template <typename... Ts>
+	struct indirect_pack_view_iterator_t {
+		using size_type = psl::ecs::entity;
+		template <typename T>
+		using value_element_type   = indirect_array_iterator_t<T, size_type>;
+		using value_type		   = std::tuple<value_element_type<Ts>...>;
+		using reference_type	   = value_type&;
+		using const_reference_type = value_type const&;
+		using pointer_type		   = value_type*;
+		using const_pointer_type   = value_type const*;
+
+		using difference_type		   = std::ptrdiff_t;
+		using unpack_iterator_category = std::random_access_iterator_tag;
+
+		indirect_pack_view_iterator_t() = default;
+		indirect_pack_view_iterator_t(indirect_array_iterator_t<Ts, size_type>... data) : m_Data(data...) {}
+
+		std::tuple<Ts&...> operator*() noexcept {
+			return std::tuple<Ts&...>(*std::get<value_element_type<Ts>>(m_Data)...);
+		}
+		std::tuple<Ts const&...> operator*() const noexcept {
+			return std::tuple<Ts const&...> {*std::get<value_element_type<Ts>>(m_Data)...};
+		}
+		pointer_type operator->() noexcept { return &m_Data; }
+		const_pointer_type operator->() const noexcept { return &m_Data; }
+
+		constexpr friend bool operator==(const indirect_pack_view_iterator_t& lhs,
+										 const indirect_pack_view_iterator_t& rhs) noexcept {
+			return std::get<0>(lhs.m_Data) == std::get<0>(rhs.m_Data);
+		}
+		constexpr friend bool operator!=(const indirect_pack_view_iterator_t& lhs,
+										 const indirect_pack_view_iterator_t& rhs) noexcept {
+			return std::get<0>(lhs.m_Data) != std::get<0>(rhs.m_Data);
+		}
+
+		constexpr friend bool operator<(const_reference_type lhs, const_reference_type rhs) noexcept {
+			return std::get<0>(lhs.m_Data) < std::get<0>(rhs.m_Data);
+		}
+		constexpr friend bool operator>(const_reference_type lhs, const_reference_type rhs) noexcept {
+			return std::get<0>(lhs.m_Data) > std::get<0>(rhs.m_Data);
+		}
+		constexpr friend bool operator<=(const_reference_type lhs, const_reference_type rhs) noexcept {
+			return std::get<0>(lhs.m_Data) <= std::get<0>(rhs.m_Data);
+		}
+		constexpr friend bool operator>=(const_reference_type lhs, const_reference_type rhs) noexcept {
+			return std::get<0>(lhs.m_Data) >= std::get<0>(rhs.m_Data);
+		}
+
+		constexpr indirect_pack_view_iterator_t& operator++() noexcept {
+			[](auto&... iterators) { (void(++iterators), ...); }(std::get<value_element_type<Ts>>(m_Data)...);
+			return *this;
+		}
+
+		constexpr indirect_pack_view_iterator_t operator--() noexcept {
+			[](auto&... iterators) { (void(--iterators), ...); }(std::get<value_element_type<Ts>>(m_Data)...);
+			return *this;
+		}
+
+		constexpr indirect_pack_view_iterator_t operator++(int) noexcept {
+			auto tmp = *this;
+			++(*this);
+			return tmp;
+		}
+
+		constexpr indirect_pack_view_iterator_t operator--(int) noexcept {
+			auto tmp = *this;
+			--(*this);
+			return tmp;
+		}
+
+		constexpr indirect_pack_view_iterator_t& operator+=(difference_type offset) noexcept {
+			[](auto offset, auto&... iterators) {
+				([offset](auto& iterator) { iterator += offset; }(iterators), ...);
+			}(std::get<value_element_type<Ts>>(m_Data)...);
+			return *this;
+		}
+
+		constexpr indirect_pack_view_iterator_t& operator-=(difference_type offset) noexcept {
+			[](auto offset, auto&... iterators) {
+				([offset](auto& iterator) { iterator -= offset; }(iterators), ...);
+			}(std::get<value_element_type<Ts>>(m_Data)...);
+			return *this;
+		}
+		constexpr indirect_pack_view_iterator_t operator+(difference_type offset) const noexcept {
+			auto tmp = *this;
+			tmp += offset;
+			return tmp;
+		}
+		constexpr indirect_pack_view_iterator_t operator-(difference_type offset) {
+			auto tmp = *this;
+			tmp -= offset;
+			return tmp;
+		}
+
+		value_type m_Data {};
+	};
+	template <typename IndiceType, typename... Ts>
+	struct indirect_pack_view_t {
+		using indice_type = IndiceType;
+		template <typename Y>
+		using _indice_tuple_machinery = psl::array<indice_type>;
+		using indices_tuple_t		  = std::tuple<_indice_tuple_machinery<Ts>...>;
+
+
+		template <typename... Ys>
+		indirect_pack_view_t(Ys&&... data) : m_Data(std::forward<Ys>(data)...) {
+// we hide the assert behind a check as the fold expression otherwise doesn't exist which leads to a compile error. This
+// approach is cleaner without adding more machinery.
+#if defined(PE_ASSERT)
+			if constexpr((sizeof...(Ts)) > 0) {
+				[&]<size_t... Indices>(std::index_sequence<Indices...>) {
+					(void(psl_assert(std::get<Indices>(m_Data).size() == std::get<0>(m_Data).size(),
+									 "Indices size mismatch in pack. Expected size '{}' but got '{}'",
+									 std::get<0>(m_Data).size(),
+									 std::get<Indices>(m_Data).size())),
+					 ...);
+				}
+				(std::make_index_sequence<sizeof...(Ts)> {});
+			}
+#endif
+		}
+
+		indirect_pack_view_t() = default;
+
+		template <size_t N>
+		constexpr inline auto const& get() const noexcept {
+			return std::get<N>(m_Data);
+		}
+
+		template <size_t N>
+		constexpr inline auto get() noexcept {
+			return std::get<N>(m_Data);
+		}
+
+		template <typename T>
+		constexpr inline auto const& get() const noexcept {
+			return std::get<indirect_array_t<T, indice_type>>(m_Data);
+		}
+
+		template <typename T>
+		constexpr inline auto get() noexcept {
+			return std::get<indirect_array_t<T, indice_type>>(m_Data);
+		}
+
+		constexpr inline auto size() const noexcept -> size_t {
+			if constexpr(sizeof...(Ts) > 0) {
+				return std::get<0>(m_Data).size();
+			} else {
+				return 0;
+			}
+		}
+
+		constexpr inline auto empty() const noexcept -> bool {
+			if constexpr(sizeof...(Ts) > 0) {
+				return std::get<0>(m_Data).empty();
+			} else {
+				return true;
+			}
+		}
+
+		constexpr inline auto operator[](size_t index) const noexcept {
+			return indirect_pack_view_iterator_t(
+			  std::next(std::get<indirect_array_t<Ts, indice_type>>(m_Data).begin(), index)...);
+		}
+		constexpr inline auto operator[](size_t index) noexcept {
+			return indirect_pack_view_iterator_t(
+			  std::next(std::get<indirect_array_t<Ts, indice_type>>(m_Data).begin(), index)...);
+		}
+		constexpr inline auto begin() noexcept {
+			return indirect_pack_view_iterator_t(std::get<indirect_array_t<Ts, indice_type>>(m_Data).begin()...);
+		}
+		constexpr inline auto end() noexcept {
+			return indirect_pack_view_iterator_t(std::get<indirect_array_t<Ts, indice_type>>(m_Data).end()...);
+		}
+		constexpr inline auto begin() const noexcept {
+			return indirect_pack_view_iterator_t(std::get<indirect_array_t<Ts, indice_type>>(m_Data).begin()...);
+		}
+		constexpr inline auto end() const noexcept {
+			return indirect_pack_view_iterator_t(std::get<indirect_array_t<Ts, indice_type>>(m_Data).end()...);
+		}
+
+		constexpr inline auto cbegin() const noexcept { return begin(); }
+		constexpr inline auto cend() const noexcept { return end(); }
+		std::tuple<indirect_array_t<Ts, indice_type>...> m_Data {};
+	};
+
+	template <typename IndiceType, typename... Ts>
+	indirect_pack_view_t(indirect_array_t<Ts, IndiceType>...) -> indirect_pack_view_t<IndiceType, Ts...>;
+
+	template <typename T>
+	struct tuple_to_indirect_pack_view {};
+
+
+	template <typename... Ts>
+	struct tuple_to_indirect_pack_view<std::tuple<Ts...>> {
+		using type = indirect_pack_view_t<psl::ecs::entity, Ts...>;
+	};
+
+	template <typename T>
+	using tuple_to_indirect_pack_view_t = typename tuple_to_indirect_pack_view<T>::type;
+}	 // namespace
+
+
+template <IsPolicy Policy, typename... Ts>
+class view_t {
+  public:
+	using pack_t		= details::tuple_to_indirect_pack_view_t<typename details::typelist_to_tuple<Ts...>::type>;
+	using filter_t		= typename details::typelist_to_pack<Ts...>::type;
+	using combine_t		= typename details::typelist_to_combine_pack<Ts...>::type;
+	using break_t		= typename details::typelist_to_break_pack<Ts...>::type;
+	using add_t			= typename details::typelist_to_add_pack<Ts...>::type;
+	using remove_t		= typename details::typelist_to_remove_pack<Ts...>::type;
+	using except_t		= typename details::typelist_to_except_pack<Ts...>::type;
+	using conditional_t = typename details::typelist_to_conditional_pack<Ts...>::type;
+	using order_by_t	= typename details::typelist_to_orderby_pack<Ts...>::type;
+	using policy_t		= Policy;
+	static constexpr bool has_entities {std::disjunction<std::is_same<psl::ecs::entity, Ts>...>::value};
+
+	static_assert(std::tuple_size<order_by_t>::value <= 1, "multiple order_by statements make no sense");
+
+	constexpr view_t() = default;
+
+	template <typename... Ys>
+	constexpr view_t(Policy, Ys&&... data) : m_Pack(std::forward<Ys>(data)...) {}
+
+	template <typename... Ys>
+	constexpr view_t(Ys&&... data) : m_Pack(std::forward<Ys>(data)...) {}
+
+	template <size_t N>
+	constexpr inline auto const& get() const noexcept {
+		return m_Pack.get<N>();
+	}
+
+	template <size_t N>
+	constexpr inline auto get() noexcept {
+		return m_Pack.get<N>();
+	}
+
+	template <typename T>
+	constexpr inline auto const& get() const noexcept {
+		return m_Pack.get<T>();
+	}
+
+	template <typename T>
+	constexpr inline auto get() noexcept {
+		return m_Pack.get<T>();
+	}
+
+	constexpr inline auto size() const noexcept -> size_t { return m_Pack.size(); }
+	constexpr inline auto empty() const noexcept -> bool { return m_Pack.empty(); }
+	constexpr inline auto const& operator[](size_t index) const noexcept { return m_Pack[index]; }
+	constexpr inline auto& operator[](size_t index) noexcept { return m_Pack[index]; }
+	constexpr inline auto begin() noexcept { return m_Pack.begin(); }
+	constexpr inline auto end() noexcept { return m_Pack.end(); }
+	constexpr inline auto begin() const noexcept { return m_Pack.begin(); }
+	constexpr inline auto end() const noexcept { return m_Pack.end(); }
+	constexpr inline auto cbegin() const noexcept { return begin(); }
+	constexpr inline auto cend() const noexcept { return end(); }
+
+  private:
+	pack_t m_Pack {};
+};
+
+template <IsPolicy Policy, typename... Ts>
+view_t(Policy, details::indirect_array_t<Ts, psl::ecs::entity>...) -> view_t<Policy, Ts...>;
+
+template <typename... Ts>
+using view_partial_t = view_t<psl::ecs::partial, Ts...>;
+
+template <typename... Ts>
+using view_full_t = view_t<psl::ecs::full, Ts...>;
+
+template <IsPolicy Policy, IsAccessType Access, typename... Ts>
+class pack_t : pack<Policy, Ts...> {
+	using base_type = pack<Policy, Ts...>;
+
+  public:
+	template <typename... Ys>
+	pack_t(Policy, Ys&&... values) : base_type(std::forward<Ys>(values)...) {}
+};
+
+template <IsPolicy Policy, typename... Ts>
+class pack_t<Policy, indirect_t, Ts...> : public view_t<Policy, Ts...> {
+	using base_type = view_t<Policy, Ts...>;
+
+  public:
+	template<typename... Ys>
+	pack_t(Policy, Ys&&... values) : base_type(std::forward<Ys>(values)...) {}
+};
+
+template <IsPolicy Policy, typename... Ts>
+pack_t(Policy, details::indirect_array_t<Ts, psl::ecs::entity>...) -> pack_t<Policy, indirect_t, Ts...>;
+
+template <IsPolicy Policy, typename... Ts>
+pack_t(Policy, psl::array_view<Ts>...) -> pack_t<Policy, direct_t, Ts...>;
+
+template <IsPolicy Policy, typename... Ts>
+pack_t(Policy, psl::array<Ts>...) -> pack_t<Policy, direct_t, Ts...>;
 }	 // namespace psl::ecs

--- a/psl/inc/psl/ecs/selectors.hpp
+++ b/psl/inc/psl/ecs/selectors.hpp
@@ -86,4 +86,10 @@ struct partial {};
 /// Certain packs require their data to be fully available to the system.
 /// Using this tag you can guarantee this is the case.
 struct full {};
+
+static constexpr full full_v {};
+static constexpr partial partial_v {};
+
+struct contiguous {};
+struct indirect {};
 }	 // namespace psl::ecs

--- a/psl/inc/psl/ecs/selectors.hpp
+++ b/psl/inc/psl/ecs/selectors.hpp
@@ -79,16 +79,16 @@ struct order_by {};
 ///
 /// Special tag type that signifies that a pack can be split
 /// up into smaller sub-packs by the scheduler when ticking systems
-struct partial {};
+struct partial_t {};
 
 /// \brief requires a pack to be whole when filled in
 ///
 /// Certain packs require their data to be fully available to the system.
 /// Using this tag you can guarantee this is the case.
-struct full {};
+struct full_t {};
 
-static constexpr full full_v {};
-static constexpr partial partial_v {};
+static constexpr full_t full_v {};
+static constexpr partial_t partial_v {};
 
 struct contiguous {};
 struct indirect {};

--- a/psl/inc/psl/ecs/selectors.hpp
+++ b/psl/inc/psl/ecs/selectors.hpp
@@ -90,6 +90,33 @@ struct full_t {};
 static constexpr full_t full_v {};
 static constexpr partial_t partial_v {};
 
-struct contiguous {};
-struct indirect {};
+template <typename T>
+concept IsPackPartial = std::is_same_v<std::remove_cvref_t<T>, psl::ecs::partial_t>;
+template <typename T>
+concept IsPackFull = std::is_same_v<std::remove_cvref_t<T>, psl::ecs::full_t>;
+template <typename T>
+concept IsPolicy = IsPackFull<T> || IsPackPartial<T>;
+
+/// \brief Guarantees direct access to the underlying data
+/// \details The underlying data is guaranteed to be accessible without indirections contiguously and sequentially
+/// in memory
+struct direct_t {};
+
+/// \brief The data is not optimized for direct access
+/// \details In contrast to `direct_t` the data is only accessible through indirection. Sequential elements are not
+/// guaranteed to be sequential in memory, and the data is not guaranteed to be contiguous. It is possible that the
+/// data does satisfy those conditions, but there won't be any guarantee, or facilities to check so.
+/// This access type's advantage to `direct_t` is less bookeeping and setup required so unless your system is
+/// computationally heavy (and so would benefit from memory locality guarantees), it is usually better to use this.
+struct indirect_t {};
+
+static constexpr direct_t direct {};
+static constexpr indirect_t indirect {};
+
+template <typename T>
+concept IsAccessDirect = std::is_same_v<std::remove_cvref_t<T>, psl::ecs::direct_t>;
+template <typename T>
+concept IsAccessIndirect = std::is_same_v<std::remove_cvref_t<T>, psl::ecs::indirect_t>;
+template <typename T>
+concept IsAccessType = IsAccessDirect<T> || IsAccessIndirect<T>;
 }	 // namespace psl::ecs

--- a/psl/inc/psl/ecs/state.hpp
+++ b/psl/inc/psl/ecs/state.hpp
@@ -686,7 +686,7 @@ class state_t final {
 											   psl::array<entity>::iterator& begin,
 											   psl::array<entity>::iterator& end) const noexcept;
 
-	psl::array<entity> filter(details::dependency_pack& pack, bool seed_with_previous) const noexcept;
+	psl::array<entity> filter(const details::dependency_pack& pack, bool seed_with_previous) const noexcept;
 	void filter(filter_result& data, psl::array_view<entity> source) const noexcept;
 	void filter(filter_result& data, bool seed_with_previous = false) const noexcept;
 

--- a/psl/inc/psl/pack_view.hpp
+++ b/psl/inc/psl/pack_view.hpp
@@ -402,7 +402,9 @@ class pack_view {
 
   public:
 	pack_view() = default;
-	pack_view(psl::array_view<Ts>... views) : m_Pack(std::make_tuple(std::forward<psl::array_view<Ts>>(views)...)) {
+	pack_view(psl::array_view<Ts>... views)
+		requires(sizeof...(Ts) > 0)
+		: m_Pack(std::make_tuple(std::forward<psl::array_view<Ts>>(views)...)) {
 #ifdef PE_DEBUG
 		// todo this needs further verification, seems tag types are present here, should they be?
 		auto test = [](size_t size1, size_t size2) {
@@ -412,9 +414,7 @@ class pack_view {
 #endif
 	}
 
-	range_t view() {
-		return m_Pack;
-	}
+	range_t view() { return m_Pack; }
 
 	template <typename T>
 	psl::array_view<T> get() const noexcept {
@@ -430,20 +430,12 @@ class pack_view {
 		return std::get<N>(m_Pack);
 	}
 
-	auto operator[](size_t index) const noexcept {
-		return *(iterator_begin(m_Pack, index));
-	}
+	auto operator[](size_t index) const noexcept { return *(iterator_begin(m_Pack, index)); }
 
-	auto operator[](size_t index) noexcept {
-		return *(iterator_begin(m_Pack, index));
-	}
+	auto operator[](size_t index) noexcept { return *(iterator_begin(m_Pack, index)); }
 
-	iterator begin() const noexcept {
-		return iterator {iterator_begin(m_Pack)};
-	}
-	iterator end() const noexcept {
-		return iterator {iterator_end(m_Pack)};
-	}
+	iterator begin() const noexcept { return iterator {iterator_begin(m_Pack)}; }
+	iterator end() const noexcept { return iterator {iterator_end(m_Pack)}; }
 
 
 	auto unpack(size_t index) const noexcept {
@@ -454,14 +446,17 @@ class pack_view {
 		auto x {unpack_iterator_begin(m_Pack, index)};
 		return *unpack_iterator(x);
 	}
-	unpack_iterator unpack_begin() const noexcept {
-		return {unpack_iterator_begin(m_Pack)};
-	}
-	unpack_iterator unpack_end() const noexcept {
-		return {unpack_iterator_end(m_Pack)};
-	}
-	constexpr size_t size() const noexcept {
+	unpack_iterator unpack_begin() const noexcept { return {unpack_iterator_begin(m_Pack)}; }
+	unpack_iterator unpack_end() const noexcept { return {unpack_iterator_end(m_Pack)}; }
+	constexpr size_t size() const noexcept
+		requires(sizeof...(Ts) > 0)
+	{
 		return std::get<0>(m_Pack).size();
+	}
+	constexpr size_t size() const noexcept
+		requires(sizeof...(Ts) == 0)
+	{
+		return 0;
 	}
 
   private:

--- a/psl/inc/psl/pack_view.hpp
+++ b/psl/inc/psl/pack_view.hpp
@@ -402,8 +402,7 @@ class pack_view {
 
   public:
 	pack_view() = default;
-	pack_view(psl::array_view<Ts>... views)
-		requires(sizeof...(Ts) > 0)
+	pack_view(psl::array_view<Ts>... views) requires(sizeof...(Ts) > 0)
 		: m_Pack(std::make_tuple(std::forward<psl::array_view<Ts>>(views)...)) {
 #ifdef PE_DEBUG
 		// todo this needs further verification, seems tag types are present here, should they be?
@@ -414,7 +413,9 @@ class pack_view {
 #endif
 	}
 
-	range_t view() { return m_Pack; }
+	range_t view() {
+		return m_Pack;
+	}
 
 	template <typename T>
 	psl::array_view<T> get() const noexcept {
@@ -430,12 +431,20 @@ class pack_view {
 		return std::get<N>(m_Pack);
 	}
 
-	auto operator[](size_t index) const noexcept { return *(iterator_begin(m_Pack, index)); }
+	auto operator[](size_t index) const noexcept {
+		return *(iterator_begin(m_Pack, index));
+	}
 
-	auto operator[](size_t index) noexcept { return *(iterator_begin(m_Pack, index)); }
+	auto operator[](size_t index) noexcept {
+		return *(iterator_begin(m_Pack, index));
+	}
 
-	iterator begin() const noexcept { return iterator {iterator_begin(m_Pack)}; }
-	iterator end() const noexcept { return iterator {iterator_end(m_Pack)}; }
+	iterator begin() const noexcept {
+		return iterator {iterator_begin(m_Pack)};
+	}
+	iterator end() const noexcept {
+		return iterator {iterator_end(m_Pack)};
+	}
 
 
 	auto unpack(size_t index) const noexcept {
@@ -446,16 +455,16 @@ class pack_view {
 		auto x {unpack_iterator_begin(m_Pack, index)};
 		return *unpack_iterator(x);
 	}
-	unpack_iterator unpack_begin() const noexcept { return {unpack_iterator_begin(m_Pack)}; }
-	unpack_iterator unpack_end() const noexcept { return {unpack_iterator_end(m_Pack)}; }
-	constexpr size_t size() const noexcept
-		requires(sizeof...(Ts) > 0)
-	{
+	unpack_iterator unpack_begin() const noexcept {
+		return {unpack_iterator_begin(m_Pack)};
+	}
+	unpack_iterator unpack_end() const noexcept {
+		return {unpack_iterator_end(m_Pack)};
+	}
+	constexpr size_t size() const noexcept requires(sizeof...(Ts) > 0) {
 		return std::get<0>(m_Pack).size();
 	}
-	constexpr size_t size() const noexcept
-		requires(sizeof...(Ts) == 0)
-	{
+	constexpr size_t size() const noexcept requires(sizeof...(Ts) == 0) {
 		return 0;
 	}
 

--- a/psl/inc/psl/pack_view.hpp
+++ b/psl/inc/psl/pack_view.hpp
@@ -401,6 +401,7 @@ class pack_view {
 	}
 
   public:
+	pack_view() = default;
 	pack_view(psl::array_view<Ts>... views) : m_Pack(std::make_tuple(std::forward<psl::array_view<Ts>>(views)...)) {
 #ifdef PE_DEBUG
 		// todo this needs further verification, seems tag types are present here, should they be?

--- a/psl/inc/psl/template_utils.hpp
+++ b/psl/inc/psl/template_utils.hpp
@@ -57,7 +57,9 @@ constexpr std::array<T, N> make_array(const T& v) noexcept {
 }
 
 template <typename... Ts>
-struct type_pack_t {};
+struct type_pack_t {
+	static constexpr size_t size = sizeof...(Ts);
+};
 
 template <typename T>
 struct type_pack_size_t {};

--- a/psl/src/ecs/command_buffer.cpp
+++ b/psl/src/ecs/command_buffer.cpp
@@ -155,6 +155,18 @@ void command_buffer_t::destroy(psl::array_view<entity> entities) noexcept {
 	}
 }
 
+void command_buffer_t::destroy(psl::ecs::details::indirect_array_t<entity, entity> entities) noexcept {
+	for(auto e : entities) {
+		if(e < m_First) {
+			m_DestroyedEntities.emplace_back(e);
+			continue;
+		}
+		++m_Orphans;
+		m_Entities[e] = m_Next;
+		m_Next		  = e;
+	}
+}
+
 void command_buffer_t::destroy(entity entity) noexcept {
 	/*for(auto& cInfo : m_Components)
 	{

--- a/psl/src/ecs/state.cpp
+++ b/psl/src/ecs/state.cpp
@@ -673,6 +673,9 @@ size_t state_t::prepare_data(psl::array_view<entity> entities, void* cache, comp
 	psl_assert(
 	  std::all_of(std::begin(entities), std::end(entities), [&cInfo](auto e) { return cInfo->has_storage_for(e); }),
 	  "some components failed to have storage for the entities");
+	psl_assert(static_cast<std::uintptr_t>(cache) + (cInfo->component_size() * entities.size()) <=
+				 static_cast<std::uintptr_t>(m_Cache.data()) + m_Cache.size(),
+			   "Cache ran out of memory");
 	return cInfo->copy_to(entities, cache);
 }
 
@@ -680,7 +683,9 @@ size_t state_t::prepare_bindings(psl::array_view<entity> entities,
 								 void* cache,
 								 details::dependency_pack& dep_pack) const noexcept {
 	size_t offset_start = (std::uintptr_t)cache;
-
+	psl_assert(static_cast<std::uintptr_t>(cache) + (sizeof(entity) * entities.size()) <=
+				 static_cast<std::uintptr_t>(m_Cache.data()) + m_Cache.size(),
+			   "Cache ran out of memory");
 	std::memcpy(cache, entities.data(), sizeof(entity) * entities.size());
 	dep_pack.m_Entities =
 	  psl::array_view<entity>((entity*)cache, (entity*)((std::uintptr_t)cache + (sizeof(entity) * entities.size())));

--- a/psl/src/ecs/state.cpp
+++ b/psl/src/ecs/state.cpp
@@ -381,7 +381,7 @@ psl::array<entity>::iterator state_t::on_combine_op(psl::array<details::componen
 	});
 }
 
-psl::array<entity> state_t::filter(details::dependency_pack& pack, bool seed_with_previous) const noexcept {
+psl::array<entity> state_t::filter(const details::dependency_pack& pack, bool seed_with_previous) const noexcept {
 	auto pack_filters = pack.filters;
 	for(const auto& [key, arr] : pack.m_RBindings) pack_filters.emplace_back(key);
 	for(const auto& [key, arr] : pack.m_RWBindings) pack_filters.emplace_back(key);

--- a/psl/src/ecs/state.cpp
+++ b/psl/src/ecs/state.cpp
@@ -33,7 +33,7 @@ constexpr auto align(std::uintptr_t& ptr, size_t alignment) noexcept {
 
 psl::array<psl::array<details::dependency_pack>> slice(psl::array<details::dependency_pack>& source,
 													   size_t workers = std::numeric_limits<size_t>::max()) {
-	psl::array<psl::array<details::dependency_pack>> packs;
+	psl::array<psl::array<details::dependency_pack>> packs {};
 
 	if(source.size() == 0)
 		return packs;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,3 +26,7 @@ target_include_directories(tests
 
 target_compile_features(tests PUBLIC ${PROJECT_COMPILER_FEATURES} PRIVATE ${PROJECT_COMPILER_FEATURES_PRIVATE})
 target_compile_options(tests PRIVATE ${COMPILE_OPTIONS} ${COMPILE_OPTIONS_EXE})
+
+if (MSVC)
+	target_compile_options(tests PRIVATE /bigobj)
+endif()

--- a/tests/src/ecs.cpp
+++ b/tests/src/ecs.cpp
@@ -419,23 +419,23 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 		  require(e_list2.size()) == state.filter<on_add<type>>().size();
 		  require(e_list2.size()) == state.filter<type>().size();
 
-		  token = state.declare([&lock, &total_pack1, &total_pack2](
-								  psl::ecs::info_t& info,
+		  token = state.declare(
+			[&lock, &total_pack1, &total_pack2](psl::ecs::info_t& info,
 												pack_t<policy, access, entity, /*const*/ type, on_remove<type>> pack1,
-								  pack_t<policy, access, entity, /*const*/ type, filter<type>> pack2) {
-			  for(auto [e, i] : pack1) {
-				  require(e) == i;
-			  }
-			  require(pack1.template get<entity>()[0]) == 0;
-			  // if this shows 0, then the previous deleted components of tick #1 are still present
-			  require(pack2.template get<entity>()[0]) == 10;
-			  for(auto [e, i] : pack2) {
-				  require(e) == i;
-			  }
-			  std::lock_guard<std::mutex> guard(lock);
-			  total_pack1 += pack1.size();
-			  total_pack2 += pack2.size();
-		  });
+												pack_t<policy, access, entity, /*const*/ type, filter<type>> pack2) {
+				for(auto [e, i] : pack1) {
+					require(e) == i;
+				}
+				require(pack1.template get<entity>()[0]) == 0;
+				// if this shows 0, then the previous deleted components of tick #1 are still present
+				require(pack2.template get<entity>()[0]) == 10;
+				for(auto [e, i] : pack2) {
+					require(e) == i;
+				}
+				std::lock_guard<std::mutex> guard(lock);
+				total_pack1 += pack1.size();
+				total_pack2 += pack2.size();
+			});
 
 		  // tick #2
 		  // we verify the elements of e_list1 are deleted and their data is intact

--- a/tests/src/ecs.cpp
+++ b/tests/src/ecs.cpp
@@ -353,7 +353,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
   []<typename type, typename policy, typename access>() {
 	  state_t state;
 
-	  auto group = details::make_filter_group(psl::type_pack_t<pack_direct_full_t<entity, type>> {});
+	  auto group = details::make_filter_group(psl::type_pack_t<pack_t<psl::ecs::full_t, access, entity, type>> {});
 
 
 	  section<"lifetime test">() = [&]() {
@@ -369,8 +369,9 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 		  state.declare([](psl::ecs::info_t& info, pack_direct_full_t<entity, filter<type>> pack) {
 			  info.command_buffer.destroy(pack.template get<entity>());
 		  });
-		  auto token = state.declare(
-			[size_1 = e_list1.size()](psl::ecs::info_t& info, pack_direct_full_t<entity, const type> pack1) {
+		  auto token =
+			state.declare([size_1 = e_list1.size()](psl::ecs::info_t& info,
+													pack_t<psl::ecs::full_t, access, entity, /*const*/ type> pack1) {
 				for(auto [e, i] : pack1) {
 					require(e) == i;
 				}
@@ -430,12 +431,13 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 		  // we verify that no int component is present anymore in the system aside from the previously removed ones
 		  require(e_list2.size()) == state.filter<on_remove<type>>().size();
 		  require(0) == state.filter<type>().size();
-		  token = state.declare([size_2 = e_list2.size()](psl::ecs::info_t& info,
-														  pack_t<psl::ecs::full_t, access, type, on_remove<type>> pack1,
-														  pack_t<psl::ecs::full_t, access, type, filter<type>> pack2) {
-			  require(pack1.size()) == size_2;
-			  require(pack2.size()) == 0;
-		  });
+		  token =
+			state.declare([size_2 = e_list2.size()](psl::ecs::info_t& info,
+													pack_t<psl::ecs::full_t, access, entity, on_remove<type>> pack1,
+													pack_t<psl::ecs::full_t, access, entity, filter<type>> pack2) {
+				require(pack1.size()) == size_2;
+				require(pack2.size()) == 0;
+			});
 
 		  // tick #3
 		  state.tick(std::chrono::duration<float>(0.1f));
@@ -466,7 +468,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 		  state.add_components<type>(e_list2, values);
 		  auto expected = e_list2.size();
 
-		  state.declare([&expected](psl::ecs::info_t& info, pack_direct_full_t<entity, type> pack) {
+		  state.declare([&expected](psl::ecs::info_t& info, pack_t<psl::ecs::full_t, access, entity, type> pack) {
 			  require(pack.size()) == expected;
 			  psl::array<entity> entities;
 			  for(auto [e, i] : pack) {
@@ -491,7 +493,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 		  state.add_components<type>(e_list2, values);
 		  auto expected = e_list2.size();
 
-		  state.declare([&expected](psl::ecs::info_t& info, pack_direct_full_t<entity, type> pack) {
+		  state.declare([&expected](psl::ecs::info_t& info, pack_t<psl::ecs::full_t, access, entity, type> pack) {
 			  require(pack.size()) == expected;
 			  for(auto [e, i] : pack) {
 				  require(type(e)) == i;
@@ -517,7 +519,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 		  state.add_components<type>(e_list2, values);
 		  auto expected = e_list2.size();
 
-		  state.declare([&expected](psl::ecs::info_t& info, pack_direct_full_t<entity, type> pack) {
+		  state.declare([&expected](psl::ecs::info_t& info, pack_t<psl::ecs::full_t, access, entity, type> pack) {
 			  require(pack.size()) == expected;
 
 			  for(auto [e, i] : pack) {
@@ -545,7 +547,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 		  }
 		  auto expected = e_list2.size();
 
-		  state.declare([&expected](psl::ecs::info_t& info, pack_direct_full_t<entity, type> pack) {
+		  state.declare([&expected](psl::ecs::info_t& info, pack_t<psl::ecs::full_t, access, entity, type> pack) {
 			  require(pack.size()) == expected;
 
 			  for(auto [e, i] : pack) {

--- a/tests/src/ecs.cpp
+++ b/tests/src/ecs.cpp
@@ -276,13 +276,15 @@ auto t2 = suite<"filtering", "ecs", "psl">()
 
 		  auto on_condition_func = [](const position& pos) { return (pos.x + pos.y) > 100; };
 
-		  state.declare([elist1_size = e_list1.size()](
-						  info_t& info,
+		  state.declare(
+			[elist1_size = e_list1.size()](
+			  info_t& info,
 			  pack_t<psl::ecs::full_t, access, position, on_condition<decltype(on_condition_func), position>> pack) {
-			  expect(pack.size()) == elist1_size;
-		  });
+				expect(pack.size()) == elist1_size;
+			});
 
-		  state.declare([total_size = e_list1.size() + e_list2.size()](info_t& info, pack_t<psl::ecs::full_t, access, position> pack) {
+		  state.declare([total_size = e_list1.size() +
+									  e_list2.size()](info_t& info, pack_t<psl::ecs::full_t, access, position> pack) {
 			  expect(pack.size()) == total_size;
 		  });
 
@@ -400,10 +402,10 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 		  state.add_components(e_list2, [&incrementer](type& target) { target = type(incrementer++); });
 		  require(e_list2.size()) == state.filter<on_add<type>>().size();
 		  require(e_list2.size()) == state.filter<type>().size();
-		  token = state.declare([size_1 = e_list1.size(), size_2 = e_list2.size()](
-								  psl::ecs::info_t& info,
-								  pack_direct_full_t<entity, const type, on_remove<type>> pack1,
-								  pack_direct_full_t<entity, const type, filter<type>> pack2) {
+		  token = state.declare([size_1 = e_list1.size(),
+								 size_2 = e_list2.size()](psl::ecs::info_t& info,
+														  pack_direct_full_t<entity, const type, on_remove<type>> pack1,
+														  pack_direct_full_t<entity, const type, filter<type>> pack2) {
 			  for(auto [e, i] : pack1) {
 				  require(e) == i;
 			  }
@@ -596,7 +598,8 @@ auto t5 = suite<"declaring system signatures", "ecs", "psl", "regression">() = [
 };
 
 auto t7 =
-  suite<"filtering over multiple frames", "ecs", "psl", "regression">().templates<float_tpack, policy_tpack, access_tpack>() = []<typename type, typename policy, typename access>() {
+  suite<"filtering over multiple frames", "ecs", "psl", "regression">()
+	.templates<float_tpack, policy_tpack, access_tpack>() = []<typename type, typename policy, typename access>() {
 	  state_t state {1u};
 	  section<"regression 1">() = [&] {
 		  // issue: non-unique entry in filtering operation

--- a/tests/src/ecs.cpp
+++ b/tests/src/ecs.cpp
@@ -16,7 +16,7 @@ void registration_test(psl::ecs::info_t& info) {}
 
 namespace tests::ecs {
 template <IsPolicy Policy, IsAccessType Access>
-void float_iteration_test(psl::ecs::info_t& info, psl::ecs::pack_t<Policy, Access, /*const*/ float, int> pack) {
+void float_iteration_test(psl::ecs::info_t& info, psl::ecs::pack_t<Policy, Access, const float, int> pack) {
 	for(auto [fl, i] : pack) {
 		i += 5;
 	}
@@ -381,7 +381,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 		  std::mutex lock {};
 
 		  auto token = state.declare(
-			[&lock, &total_pack1](psl::ecs::info_t& info, pack_t<policy, access, entity, /*const*/ type> pack1) {
+			[&lock, &total_pack1](psl::ecs::info_t& info, pack_t<policy, access, entity, const type> pack1) {
 				for(auto [e, i] : pack1) {
 					require(e) == i;
 				}
@@ -421,8 +421,8 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 
 		  token = state.declare(
 			[&lock, &total_pack1, &total_pack2](psl::ecs::info_t& info,
-												pack_t<policy, access, entity, /*const*/ type, on_remove<type>> pack1,
-												pack_t<policy, access, entity, /*const*/ type, filter<type>> pack2) {
+												pack_t<policy, access, entity, const type, on_remove<type>> pack1,
+												pack_t<policy, access, entity, const type, filter<type>> pack2) {
 				for(auto [e, i] : pack1) {
 					require(e) == i;
 				}


### PR DESCRIPTION
PR adds indirect packs to the ECS. Indirect packs are a method to avoid copying the data over to the state's cache before systems are invoked.

Note: mixed packs are not part of this PR.