### PR TITLE
added entity_t as a strong type

### DIFF
--- a/benchmarks/src/ecs.cpp
+++ b/benchmarks/src/ecs.cpp
@@ -39,7 +39,7 @@ void entity_creation(benchmark::State& gState) {
 
 void entity_creation_with_destruction(benchmark::State& gState) {
 	auto eCount		= gState.range(0);
-	auto eHalfCount = static_cast<ecs::entity>(eCount / 2);
+	auto eHalfCount = static_cast<ecs::entity_t::size_type>(eCount / 2);
 
 	ecs::state_t state;
 	for(auto _ : gState) {
@@ -108,12 +108,13 @@ class filtering_fixture : public ::benchmark::Fixture {
 
 		auto entities = state.create(eCount);
 
-		state.add_components<float>(psl::array<entity> {std::begin(entities), std::next(std::begin(entities), eCount)});
+		state.add_components<float>(
+		  psl::array<entity_t> {std::begin(entities), std::next(std::begin(entities), eCount)});
 		state.add_components<char>(
-		  psl::array<entity> {std::next(std::begin(entities), char_beg), std::next(std::begin(entities), char_end)});
+		  psl::array<entity_t> {std::next(std::begin(entities), char_beg), std::next(std::begin(entities), char_end)});
 
 		state.add_components(
-		  psl::array<entity> {std::next(std::begin(entities), int_beg), std::next(std::begin(entities), int_end)},
+		  psl::array<entity_t> {std::next(std::begin(entities), int_beg), std::next(std::begin(entities), int_end)},
 		  [](int& i) { i = std::rand() % 1000; });
 	}
 
@@ -204,7 +205,7 @@ auto read_only_system = [](info_t& info, pack_t<T, direct_t, const Ts...>) {};
 template <typename T, typename... Ts>
 auto write_system = [](info_t& info, pack_t<T, direct_t, Ts...>) {};
 
-auto get_random_entities(const psl::array<entity>& source, size_t count, std::mt19937 g) {
+auto get_random_entities(const psl::array<entity_t>& source, size_t count, std::mt19937 g) {
 	auto copy = source;
 	std::shuffle(std::begin(copy), std::end(copy), g);
 	copy.resize(std::min(copy.size(), count));
@@ -212,7 +213,7 @@ auto get_random_entities(const psl::array<entity>& source, size_t count, std::mt
 }
 
 template <typename... Ts>
-void run_system(benchmark::State& gState, state_t& state, const std::vector<entity>& count) {
+void run_system(benchmark::State& gState, state_t& state, const std::vector<entity_t::size_type>& count) {
 	psl_assert(count.size() == 5, "expected size to be 5");
 	auto entities = state.create(count[0]);
 	std::random_device rd;
@@ -226,10 +227,10 @@ void run_system(benchmark::State& gState, state_t& state, const std::vector<enti
 }
 
 
-const std::vector<std::vector<entity>> system_counts {{10'000, 300, 2'700, 1'200, 6'700},
-													  {100'000, 3'000, 21'700, 10'200, 68'700},
-													  {1'000'000, 3'000, 20'700, 30'200, 60'700},
-													  {1'000'000, 300'000, 210'700, 300'200, 680'700}};
+const std::vector<std::vector<entity_t::size_type>> system_counts {{10'000, 300, 2'700, 1'200, 6'700},
+																   {100'000, 3'000, 21'700, 10'200, 68'700},
+																   {1'000'000, 3'000, 20'700, 30'200, 60'700},
+																   {1'000'000, 300'000, 210'700, 300'200, 680'700}};
 void trivial_read_only_seq_system(benchmark::State& gState) {
 	state_t state;
 	state.declare(threading::seq, read_only_system<full_t, char, int, float, uint64_t>);

--- a/core/inc/ecs/systems/death.hpp
+++ b/core/inc/ecs/systems/death.hpp
@@ -5,7 +5,7 @@
 namespace core::ecs::systems {
 auto death =
   [](psl::ecs::info_t& info,
-	 psl::ecs::pack_direct_partial_t<psl::ecs::entity, psl::ecs::on_add<core::ecs::components::dead_tag>> dead_pack) {
-	  info.command_buffer.destroy(dead_pack.get<psl::ecs::entity>());
+	 psl::ecs::pack_direct_partial_t<psl::ecs::entity_t, psl::ecs::on_add<core::ecs::components::dead_tag>> dead_pack) {
+	  info.command_buffer.destroy(dead_pack.get<psl::ecs::entity_t>());
   };
 }

--- a/core/inc/ecs/systems/debug/grid.hpp
+++ b/core/inc/ecs/systems/debug/grid.hpp
@@ -26,7 +26,7 @@ class grid {
 
   public:
 	grid(psl::ecs::state_t& state,
-		 psl::ecs::entity target,
+		 psl::ecs::entity_t target,
 		 core::resource::cache_t& cache,
 		 core::resource::handle<core::gfx::context> context,
 		 core::resource::handle<core::gfx::buffer_t> vertexBuffer,
@@ -45,15 +45,15 @@ class grid {
 
   private:
 	void tick(psl::ecs::info_t& info,
-			  psl::ecs::pack_direct_full_t<psl::ecs::entity,
+			  psl::ecs::pack_direct_full_t<psl::ecs::entity_t,
 										   const core::ecs::components::transform,
 										   psl::ecs::filter<core::ecs::components::camera>> pack,
 			  psl::ecs::pack_direct_full_t<core::ecs::components::transform, psl::ecs::filter<grid::tag>> grid_pack);
 
 	core::resource::handle<core::gfx::bundle> m_Bundle;
 	core::resource::handle<core::gfx::geometry_t> m_Geometry;
-	std::vector<psl::ecs::entity> m_Entities;
-	psl::ecs::entity m_Target;
+	std::vector<psl::ecs::entity_t> m_Entities;
+	psl::ecs::entity_t m_Target;
 	psl::vec3 m_Scale;
 	psl::vec3 m_Offset;
 };

--- a/core/inc/ecs/systems/geometry_instance.hpp
+++ b/core/inc/ecs/systems/geometry_instance.hpp
@@ -53,7 +53,7 @@ class geometry_instancing {
 	void
 	static_add(psl::ecs::info_t& info,
 			   psl::ecs::pack_direct_full_t<
-				 psl::ecs::entity,
+				 psl::ecs::entity_t,
 				 const core::ecs::components::renderable,
 				 const core::ecs::components::transform,
 				 psl::ecs::except<core::ecs::components::dynamic_tag>,
@@ -61,7 +61,7 @@ class geometry_instancing {
 				 psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> geometry_pack);
 	void static_remove(
 	  psl::ecs::info_t& info,
-	  psl::ecs::pack_direct_full_t<psl::ecs::entity,
+	  psl::ecs::pack_direct_full_t<psl::ecs::entity_t,
 								   core::ecs::components::renderable,
 								   const instance_id,
 								   psl::ecs::except<core::ecs::components::dynamic_tag>,
@@ -69,7 +69,7 @@ class geometry_instancing {
 													  const core::ecs::components::transform>> geometry_pack);
 
 	void static_geometry_add(psl::ecs::info_t& info,
-							 psl::ecs::pack_direct_full_t<psl::ecs::entity,
+							 psl::ecs::pack_direct_full_t<psl::ecs::entity_t,
 														  const core::ecs::components::renderable,
 														  psl::ecs::except<core::ecs::components::transform>,
 														  psl::ecs::on_add<core::ecs::components::renderable>> pack);
@@ -77,13 +77,13 @@ class geometry_instancing {
 
 	void
 	static_geometry_remove(psl::ecs::info_t& info,
-						   psl::ecs::pack_direct_full_t<psl::ecs::entity,
+						   psl::ecs::pack_direct_full_t<psl::ecs::entity_t,
 														core::ecs::components::renderable,
 														const instance_id,
 														psl::ecs::except<core::ecs::components::transform>,
 														psl::ecs::on_remove<core::ecs::components::renderable>> pack);
 	// void static_disable();
-	// void static_enable(psl::ecs::info& info, psl::ecs::pack_direct_full_t<psl::ecs::entity, const
+	// void static_enable(psl::ecs::info& info, psl::ecs::pack_direct_full_t<psl::ecs::entity_t, const
 	// core::ecs::components::renderable, const instance_id, core::ecs::components::dont_render_tag> dont_render);
 };
 }	 // namespace core::ecs::systems

--- a/core/inc/ecs/systems/lifetime.hpp
+++ b/core/inc/ecs/systems/lifetime.hpp
@@ -7,11 +7,11 @@
 
 namespace core::ecs::systems {
 auto lifetime = [](psl::ecs::info_t& info,
-				   psl::ecs::pack_direct_partial_t<psl::ecs::entity, core::ecs::components::lifetime> life_pack) {
+				   psl::ecs::pack_direct_partial_t<psl::ecs::entity_t, core::ecs::components::lifetime> life_pack) {
 	using namespace psl::ecs;
 	using namespace core::ecs::components;
 
-	std::vector<entity> dead_entities;
+	std::vector<entity_t> dead_entities;
 	for(auto [entity, lifetime] : life_pack) {
 		lifetime.value -= info.dTime.count();
 		if(lifetime.value <= 0.0f)

--- a/core/inc/ecs/systems/lighting.hpp
+++ b/core/inc/ecs/systems/lighting.hpp
@@ -48,7 +48,7 @@ class lighting_system {
 
 	void create_dir(
 	  psl::ecs::info_t& info,
-	  psl::ecs::pack_direct_full_t<psl::ecs::entity,
+	  psl::ecs::pack_direct_full_t<psl::ecs::entity_t,
 								   core::ecs::components::light,
 								   psl::ecs::on_combine<core::ecs::components::light, core::ecs::components::transform>>
 		pack);
@@ -63,8 +63,8 @@ class lighting_system {
 	core::resource::handle<core::gfx::buffer_t> m_LightDataBuffer;
 	memory::segment m_LightSegment;
 
-	// std::unordered_map<psl::ecs::entity, psl::view_ptr<core::gfx::drawpass>> m_Passes;
-	std::unordered_map<psl::ecs::entity, psl::unique_ptr<core::ecs::systems::render>> m_Systems;
+	// std::unordered_map<psl::ecs::entity_t, psl::view_ptr<core::gfx::drawpass>> m_Passes;
+	std::unordered_map<psl::ecs::entity_size_type, psl::unique_ptr<core::ecs::systems::render>> m_Systems;
 };
 
 }	 // namespace core::ecs::systems

--- a/core/inc/ecs/systems/lighting.hpp
+++ b/core/inc/ecs/systems/lighting.hpp
@@ -64,7 +64,7 @@ class lighting_system {
 	memory::segment m_LightSegment;
 
 	// std::unordered_map<psl::ecs::entity_t, psl::view_ptr<core::gfx::drawpass>> m_Passes;
-	std::unordered_map<psl::ecs::entity_size_type, psl::unique_ptr<core::ecs::systems::render>> m_Systems;
+	std::unordered_map<psl::ecs::entity_t::size_type, psl::unique_ptr<core::ecs::systems::render>> m_Systems;
 };
 
 }	 // namespace core::ecs::systems

--- a/core/inc/ecs/systems/text.hpp
+++ b/core/inc/ecs/systems/text.hpp
@@ -53,16 +53,16 @@ class text {
 
   private:
 	void update_dynamic(psl::ecs::info_t& info,
-						psl::ecs::pack_direct_partial_t<psl::ecs::entity,
+						psl::ecs::pack_direct_partial_t<psl::ecs::entity_t,
 														core::ecs::components::text,
 														core::ecs::components::renderable,
 														psl::ecs::filter<core::ecs::components::dynamic_tag>> pack);
 	void add(psl::ecs::info_t& info,
-			 psl::ecs::pack_direct_partial_t<psl::ecs::entity,
+			 psl::ecs::pack_direct_partial_t<psl::ecs::entity_t,
 											 core::ecs::components::text,
 											 psl::ecs::on_add<core::ecs::components::text>> pack);
 	void remove(psl::ecs::info_t& info,
-				psl::ecs::pack_direct_partial_t<psl::ecs::entity,
+				psl::ecs::pack_direct_partial_t<psl::ecs::entity_t,
 												core::ecs::components::text,
 												psl::ecs::on_remove<core::ecs::components::text>> pack);
 

--- a/core/main/main.cpp
+++ b/core/main/main.cpp
@@ -885,7 +885,7 @@ ECSState.create(
 		{
 			next_spawn += std::chrono::milliseconds(spawnInterval);
 			ECSState.create(
-			  /*(iterations > 0) ? count + std::rand() % (swing + 1) : 0*/ static_cast<entity_size_type>(
+			  /*(iterations > 0) ? count + std::rand() % (swing + 1) : 0*/ static_cast<entity_t::size_type>(
 				(frame % 250 == 0) ? burst : 0),
 			  [&bundles, &geometryHandles, &matusage](core::ecs::components::renderable& renderable) {
 				  auto matIndex = 0;

--- a/core/main/main.cpp
+++ b/core/main/main.cpp
@@ -885,7 +885,7 @@ ECSState.create(
 		{
 			next_spawn += std::chrono::milliseconds(spawnInterval);
 			ECSState.create(
-			  /*(iterations > 0) ? count + std::rand() % (swing + 1) : 0*/ static_cast<entity>(
+			  /*(iterations > 0) ? count + std::rand() % (swing + 1) : 0*/ static_cast<entity_size_type>(
 				(frame % 250 == 0) ? burst : 0),
 			  [&bundles, &geometryHandles, &matusage](core::ecs::components::renderable& renderable) {
 				  auto matIndex = 0;

--- a/core/src/ecs/systems/debug/grid.cpp
+++ b/core/src/ecs/systems/debug/grid.cpp
@@ -29,7 +29,7 @@ using namespace core::gfx;
 
 
 grid::grid(state_t& state,
-		   entity target,
+		   entity_t target,
 		   resource::cache_t& cache,
 		   resource::handle<context> context,
 		   resource::handle<buffer_t> vertexBuffer,
@@ -116,9 +116,9 @@ grid::grid(state_t& state,
 }
 
 void grid::tick(info_t& info,
-				pack_direct_full_t<entity, const transform, psl::ecs::filter<camera>> pack,
+				pack_direct_full_t<entity_t, const transform, psl::ecs::filter<camera>> pack,
 				psl::ecs::pack_direct_full_t<transform, psl::ecs::filter<grid::tag>> grid_pack) {
-	auto entities		 = pack.get<entity>();
+	auto entities		 = pack.get<entity_t>();
 	auto transforms		 = pack.get<const transform>();
 	auto grid_transforms = grid_pack.get<transform>();
 	for(auto i = 0; i < entities.size(); ++i) {

--- a/core/src/ecs/systems/geometry_instance.cpp
+++ b/core/src/ecs/systems/geometry_instance.cpp
@@ -103,7 +103,7 @@ void geometry_instancing::dynamic_system(info_t& info,
 }
 
 void geometry_instancing::static_add(info_t& info,
-									 pack_direct_full_t<entity,
+									 pack_direct_full_t<entity_t,
 														const renderable,
 														const transform,
 														psl::ecs::except<dynamic_tag>,
@@ -127,7 +127,7 @@ void geometry_instancing::static_add(info_t& info,
 
 	core::profiler.scope_begin("create_all");
 	std::vector<psl::mat4x4> modelMats;
-	psl::array<entity> eIds;
+	psl::array<entity_t> eIds;
 	eIds.resize(1);
 	for(const auto& unique_bundle : UniqueCombinations) {
 		modelMats.clear();
@@ -149,7 +149,7 @@ void geometry_instancing::static_add(info_t& info,
 					const psl::mat4x4 scaleMat		 = scale(transform.scale);
 					modelMats.emplace_back(translationMat * rotationMat * scaleMat);
 
-					eIds[0] = std::get<entity&>(geometry_pack[indicesCompleted + geometryData.startIndex]);
+					eIds[0] = std::get<entity_t&>(geometry_pack[indicesCompleted + geometryData.startIndex]);
 					info.command_buffer.add_components<instance_id>(eIds, instance_id {i});
 				}
 				bundleHandle->set(
@@ -162,7 +162,7 @@ void geometry_instancing::static_add(info_t& info,
 	core::profiler.scope_end();
 }
 void geometry_instancing::static_remove(info_t& info,
-										pack_direct_full_t<entity,
+										pack_direct_full_t<entity_t,
 														   renderable,
 														   const instance_id,
 														   psl::ecs::except<dynamic_tag>,
@@ -176,19 +176,19 @@ void geometry_instancing::static_remove(info_t& info,
 			renderable.bundle->release(renderable.geometry, instance_id.id);
 	}
 
-	info.command_buffer.remove_components<instance_id>(geometry_pack.get<entity>());
+	info.command_buffer.remove_components<instance_id>(geometry_pack.get<entity_t>());
 	core::profiler.scope_end();
 }
 
 void geometry_instancing::static_geometry_add(
   psl::ecs::info_t& info,
-  psl::ecs::pack_direct_full_t<psl::ecs::entity,
+  psl::ecs::pack_direct_full_t<psl::ecs::entity_t,
 							   const core::ecs::components::renderable,
 							   psl::ecs::except<core::ecs::components::transform>,
 							   psl::ecs::on_add<core::ecs::components::renderable>> pack) {
 	if(pack.size() == 0)
 		return;
-	psl::array<entity> eIds;
+	psl::array<entity_t> eIds;
 	eIds.resize(1);
 	for(auto [entity, render] : pack) {
 		auto bundleHandle	= render.bundle;
@@ -203,7 +203,7 @@ void geometry_instancing::static_geometry_add(
 
 void geometry_instancing::static_geometry_remove(
   psl::ecs::info_t& info,
-  psl::ecs::pack_direct_full_t<psl::ecs::entity,
+  psl::ecs::pack_direct_full_t<psl::ecs::entity_t,
 							   core::ecs::components::renderable,
 							   const instance_id,
 							   psl::ecs::except<core::ecs::components::transform>,
@@ -215,5 +215,5 @@ void geometry_instancing::static_geometry_remove(
 			renderable.bundle->release(renderable.geometry, instance_id.id);
 	}
 
-	info.command_buffer.remove_components<instance_id>(pack.get<entity>());
+	info.command_buffer.remove_components<instance_id>(pack.get<entity_t>());
 }

--- a/core/src/ecs/systems/lighting.cpp
+++ b/core/src/ecs/systems/lighting.cpp
@@ -43,7 +43,7 @@ lighting_system::lighting_system(psl::view_ptr<psl::ecs::state_t> state,
 	m_LightSegment = m_LightDataBuffer->reserve(m_LightDataBuffer->free_size()).value();
 }
 
-void lighting_system::create_dir(info_t& info, pack_direct_full_t<entity, light, on_combine<light, transform>> pack) {
+void lighting_system::create_dir(info_t& info, pack_direct_full_t<entity_t, light, on_combine<light, transform>> pack) {
 	if(pack.size() == 0)
 		return;
 	// insertion_sort(std::begin(pack), std::end(pack), sort_impl<light_sort, light>{});

--- a/core/src/ecs/systems/lighting.cpp
+++ b/core/src/ecs/systems/lighting.cpp
@@ -87,8 +87,8 @@ void lighting_system::create_dir(info_t& info, pack_direct_full_t<entity_t, ligh
 		auto depthPass = m_Cache->create<gfx::framebuffer_t>(m_Context, fbdata);
 
 		auto pass											  = m_RenderGraph->create_drawpass(m_Context, depthPass);
-		m_Systems[static_cast<psl::ecs::entity_size_type>(e)] = new core::ecs::systems::render {*m_State, pass};
-		m_Systems[static_cast<psl::ecs::entity_size_type>(e)]->add_render_range(1000, 1500);
+		m_Systems[static_cast<psl::ecs::entity_t::size_type>(e)] = new core::ecs::systems::render {*m_State, pass};
+		m_Systems[static_cast<psl::ecs::entity_t::size_type>(e)]->add_render_range(1000, 1500);
 
 		m_RenderGraph->connect(pass, m_DependsPass);
 	}

--- a/core/src/ecs/systems/lighting.cpp
+++ b/core/src/ecs/systems/lighting.cpp
@@ -86,9 +86,9 @@ void lighting_system::create_dir(info_t& info, pack_direct_full_t<entity_t, ligh
 
 		auto depthPass = m_Cache->create<gfx::framebuffer_t>(m_Context, fbdata);
 
-		auto pass	 = m_RenderGraph->create_drawpass(m_Context, depthPass);
-		m_Systems[e] = new core::ecs::systems::render {*m_State, pass};
-		m_Systems[e]->add_render_range(1000, 1500);
+		auto pass											  = m_RenderGraph->create_drawpass(m_Context, depthPass);
+		m_Systems[static_cast<psl::ecs::entity_size_type>(e)] = new core::ecs::systems::render {*m_State, pass};
+		m_Systems[static_cast<psl::ecs::entity_size_type>(e)]->add_render_range(1000, 1500);
 
 		m_RenderGraph->connect(pass, m_DependsPass);
 	}

--- a/core/src/ecs/systems/lighting.cpp
+++ b/core/src/ecs/systems/lighting.cpp
@@ -86,7 +86,7 @@ void lighting_system::create_dir(info_t& info, pack_direct_full_t<entity_t, ligh
 
 		auto depthPass = m_Cache->create<gfx::framebuffer_t>(m_Context, fbdata);
 
-		auto pass											  = m_RenderGraph->create_drawpass(m_Context, depthPass);
+		auto pass												 = m_RenderGraph->create_drawpass(m_Context, depthPass);
 		m_Systems[static_cast<psl::ecs::entity_t::size_type>(e)] = new core::ecs::systems::render {*m_State, pass};
 		m_Systems[static_cast<psl::ecs::entity_t::size_type>(e)]->add_render_range(1000, 1500);
 

--- a/core/src/ecs/systems/text.cpp
+++ b/core/src/ecs/systems/text.cpp
@@ -237,14 +237,14 @@ core::resource::handle<core::data::geometry_t> text::create_text(psl::string_vie
 
 void text::update_dynamic(
   info_t& info,
-  pack_direct_partial_t<entity, comp::text, comp::renderable, psl::ecs::filter<comp::dynamic_tag>> pack) {
+  pack_direct_partial_t<entity_t, comp::text, comp::renderable, psl::ecs::filter<comp::dynamic_tag>> pack) {
 	for(auto [e, text, renderer] : pack) {
 		renderer.geometry->recreate(create_text(*text.value));
 	}
 }
 
-void text::add(info_t& info, pack_direct_partial_t<entity, comp::text, on_add<comp::text>> pack) {
-	psl::array<entity> ents;
+void text::add(info_t& info, pack_direct_partial_t<entity_t, comp::text, on_add<comp::text>> pack) {
+	psl::array<entity_t> ents;
 	ents.resize(1);
 	for(auto [e, text] : pack) {
 		ents[0]			= e;
@@ -262,6 +262,6 @@ void text::add(info_t& info, pack_direct_partial_t<entity, comp::text, on_add<co
 	}
 }
 
-void text::remove(info_t& info, pack_direct_partial_t<entity, comp::text, on_remove<comp::text>> pack) {
-	info.command_buffer.remove_components<comp::renderable>(pack.get<entity>());
+void text::remove(info_t& info, pack_direct_partial_t<entity_t, comp::text, on_remove<comp::text>> pack) {
+	info.command_buffer.remove_components<comp::renderable>(pack.get<entity_t>());
 }

--- a/psl/inc/psl/ecs/command_buffer.hpp
+++ b/psl/inc/psl/ecs/command_buffer.hpp
@@ -92,14 +92,14 @@ class command_buffer_t {
 	}
 
 	template <typename... Ts>
-	void add_components(psl::array_view<std::pair<entity_size_type, entity_size_type>> entities) {
+	void add_components(psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities) {
 		if(entities.size() == 0)
 			return;
 		static_assert(sizeof...(Ts) > 0, "you need to supply at least one component to add");
 		(add_component<Ts>(entities), ...);
 	}
 	template <typename... Ts>
-	void add_components(psl::array_view<std::pair<entity_size_type, entity_size_type>> entities, Ts&&... prototype) {
+	void add_components(psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities, Ts&&... prototype) {
 		if(entities.size() == 0)
 			return;
 		static_assert(sizeof...(Ts) > 0, "you need to supply at least one component to add");
@@ -107,7 +107,7 @@ class command_buffer_t {
 	}
 
 	template <typename... Ts>
-	void remove_components(psl::array_view<std::pair<entity_size_type, entity_size_type>> entities) noexcept {
+	void remove_components(psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities) noexcept {
 		if(entities.size() == 0)
 			return;
 		static_assert(sizeof...(Ts) > 0, "you need to supply at least one component to remove");
@@ -116,9 +116,9 @@ class command_buffer_t {
 	}
 
 	template <typename... Ts>
-	psl::array<entity_t> create(entity_size_type count) {
+	psl::array<entity_t> create(entity_t::size_type count) {
 		psl::array<entity_t> entities;
-		const auto recycled = std::min<entity_size_type>(static_cast<entity_size_type>(count), m_Orphans);
+		const auto recycled = std::min<entity_t::size_type>(static_cast<entity_t::size_type>(count), m_Orphans);
 		m_Orphans -= recycled;
 		const auto remainder = count - recycled;
 
@@ -130,13 +130,13 @@ class command_buffer_t {
 		for(size_t i = 0; i < recycled; ++i) {
 			const auto orphan = m_Next;
 			entities.emplace_back(orphan);
-			m_Next					   = static_cast<entity_size_type>(m_Entities[m_Next]);
+			m_Next					   = static_cast<entity_t::size_type>(m_Entities[m_Next]);
 			m_Entities[(size_t)orphan] = orphan;
 		}
 
 		for(size_t i = 0; i < remainder; ++i) {
-			entities.emplace_back(entity_t {static_cast<entity_size_type>(m_Entities.size()) + m_First});
-			m_Entities.emplace_back(entity_t {static_cast<entity_size_type>(m_Entities.size()) + m_First});
+			entities.emplace_back(entity_t {static_cast<entity_t::size_type>(m_Entities.size()) + m_First});
+			m_Entities.emplace_back(entity_t {static_cast<entity_t::size_type>(m_Entities.size()) + m_First});
 		}
 
 		if constexpr(sizeof...(Ts) > 0) {
@@ -146,9 +146,9 @@ class command_buffer_t {
 	}
 
 	template <typename... Ts>
-	psl::array<entity_t> create(entity_size_type count, Ts&&... prototype) {
+	psl::array<entity_t> create(entity_t::size_type count, Ts&&... prototype) {
 		psl::array<entity_t> entities;
-		const auto recycled = std::min<entity_size_type>(count, m_Orphans);
+		const auto recycled = std::min<entity_t::size_type>(count, m_Orphans);
 		m_Orphans -= recycled;
 		const auto remainder = count - recycled;
 
@@ -173,7 +173,7 @@ class command_buffer_t {
 	}
 
 	void destroy(psl::array_view<entity_t> entities) noexcept;
-	void destroy(psl::ecs::details::indirect_array_t<entity_t, entity_size_type> entities) noexcept;
+	void destroy(psl::ecs::details::indirect_array_t<entity_t, entity_t::size_type> entities) noexcept;
 	void destroy(entity_t entity) noexcept;
 
   private:
@@ -200,7 +200,7 @@ class command_buffer_t {
 	// add_component
 	//------------------------------------------------------------
 	template <typename T>
-	void add_component(psl::array_view<std::pair<entity_size_type, entity_size_type>> entities, T&& prototype) {
+	void add_component(psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities, T&& prototype) {
 		if constexpr(std::is_trivially_copyable<T>::value && std::is_standard_layout<T>::value &&
 					 std::is_trivially_destructible<T>::value) {
 			static_assert(!std::is_empty_v<T>,
@@ -241,7 +241,7 @@ class command_buffer_t {
 	}
 
 	template <typename T>
-	void add_component(psl::array_view<std::pair<entity_size_type, entity_size_type>> entities) {
+	void add_component(psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities) {
 		create_storage<T>();
 
 		if constexpr(details::DoesComponentTypeNeedPrototypeCall<T>) {
@@ -319,14 +319,14 @@ class command_buffer_t {
 	}
 
 	void add_component_impl(const details::component_key_t& key,
-							psl::array_view<std::pair<entity_size_type, entity_size_type>> entities,
+							psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities,
 							size_t size);
 	void add_component_impl(const details::component_key_t& key,
-							psl::array_view<std::pair<entity_size_type, entity_size_type>> entities,
+							psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities,
 							size_t size,
 							std::function<void(std::uintptr_t, size_t)> invocable);
 	void add_component_impl(const details::component_key_t& key,
-							psl::array_view<std::pair<entity_size_type, entity_size_type>> entities,
+							psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities,
 							size_t size,
 							void* prototype);
 
@@ -346,17 +346,17 @@ class command_buffer_t {
 	// remove_component
 	//------------------------------------------------------------
 	void remove_component(const details::component_key_t& key,
-						  psl::array_view<std::pair<entity_size_type, entity_size_type>> entities) noexcept;
+						  psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities) noexcept;
 	void remove_component(const details::component_key_t& key, psl::array_view<entity_t> entities) noexcept;
 
 	state_t const* m_State {nullptr};
 	psl::array<std::unique_ptr<details::component_container_t>> m_Components {};
-	entity_size_type m_First {0};
+	entity_t::size_type m_First {0};
 	psl::array<entity_t> m_Entities {};
 
 	psl::array<entity_t> m_DestroyedEntities {};
 
-	entity_size_type m_Next {0};
-	entity_size_type m_Orphans {0};
+	entity_t::size_type m_Next {0};
+	entity_t::size_type m_Orphans {0};
 };
 }	 // namespace psl::ecs

--- a/psl/inc/psl/ecs/command_buffer.hpp
+++ b/psl/inc/psl/ecs/command_buffer.hpp
@@ -99,7 +99,8 @@ class command_buffer_t {
 		(add_component<Ts>(entities), ...);
 	}
 	template <typename... Ts>
-	void add_components(psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities, Ts&&... prototype) {
+	void add_components(psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities,
+						Ts&&... prototype) {
 		if(entities.size() == 0)
 			return;
 		static_assert(sizeof...(Ts) > 0, "you need to supply at least one component to add");

--- a/psl/inc/psl/ecs/command_buffer.hpp
+++ b/psl/inc/psl/ecs/command_buffer.hpp
@@ -165,8 +165,8 @@ class command_buffer_t {
 		}
 
 		for(size_t i = 0; i < remainder; ++i) {
-			entities.emplace_back(entity_t {m_Entities.size() + m_First});
-			m_Entities.emplace_back(entity_t {m_Entities.size() + m_First});
+			entities.emplace_back(entity_t {static_cast<entity_t::size_type>(m_Entities.size()) + m_First});
+			m_Entities.emplace_back(entity_t {static_cast<entity_t::size_type>(m_Entities.size()) + m_First});
 		}
 		add_components(entities, std::forward<Ts>(prototype)...);
 

--- a/psl/inc/psl/ecs/command_buffer.hpp
+++ b/psl/inc/psl/ecs/command_buffer.hpp
@@ -130,7 +130,7 @@ class command_buffer_t {
 		for(size_t i = 0; i < recycled; ++i) {
 			const auto orphan = m_Next;
 			entities.emplace_back(orphan);
-			m_Next					   = m_Entities[(size_t)m_Next];
+			m_Next					   = static_cast<entity_size_type>(m_Entities[m_Next]);
 			m_Entities[(size_t)orphan] = orphan;
 		}
 

--- a/psl/inc/psl/ecs/details/component_container.hpp
+++ b/psl/inc/psl/ecs/details/component_container.hpp
@@ -126,7 +126,9 @@ class component_container_typed_t final : public component_container_t {
 	void* data() noexcept override { return m_Entities.data(); }
 	void* const data() const noexcept override { return m_Entities.data(); }
 
-	bool has_storage_for(entity_t entity) const noexcept override { return m_Entities.has(entity, stage_range_t::ALL); }
+	bool has_storage_for(entity_t entity) const noexcept override {
+		return m_Entities.has(static_cast<entity_size_type>(entity), stage_range_t::ALL);
+	}
 
 	psl::array<entity_size_type>
 	memory_location_offsets_for(psl::array_view<entity_t> entities) const noexcept override {
@@ -248,7 +250,7 @@ class component_container_typed_t final : public component_container_t {
 
 	void remove_impl(entity_t entity) override { m_Entities.erase(static_cast<entity_size_type>(entity)); }
 	void remove_impl(psl::array_view<entity_t> entities) override {
-		for(size_t i = 0; i < entities.size(); ++i) m_Entities.erase(entities[i]);
+		for(size_t i = 0; i < entities.size(); ++i) m_Entities.erase(static_cast<entity_size_type>(entities[i]));
 	}
 	void remove_impl(psl::array_view<std::pair<entity_size_type, entity_size_type>> entities) override {
 		for(auto range : entities) {
@@ -375,7 +377,8 @@ class component_container_untyped_t : public component_container_t {
 		const auto base = reinterpret_cast<std::uintptr_t>(m_Entities.data());
 		result.reserve(entities.size());
 		for(auto e : entities) {
-			const auto address = reinterpret_cast<std::uintptr_t>(m_Entities.addressof(e, stage_range_t::ALL));
+			const auto address = reinterpret_cast<std::uintptr_t>(
+			  m_Entities.addressof(static_cast<entity_size_type>(e), stage_range_t::ALL));
 			result.emplace_back(
 			  static_cast<entity_size_type>((address - base) / static_cast<entity_size_type>(m_Size)));
 		}

--- a/psl/inc/psl/ecs/details/component_container.hpp
+++ b/psl/inc/psl/ecs/details/component_container.hpp
@@ -46,7 +46,9 @@ class component_container_t {
 			 bool repeat = false) {
 		add_impl(entities, data, repeat);
 	}
-	void destroy(psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities) { remove_impl(entities); };
+	void destroy(psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities) {
+		remove_impl(entities);
+	};
 	void destroy(psl::array_view<entity_t> entities) noexcept { remove_impl(entities); }
 	void destroy(entity_t entity) noexcept { remove_impl(entity); }
 	virtual void* data() noexcept			  = 0;
@@ -90,17 +92,18 @@ class component_container_t {
 	virtual void clear()											= 0;
 
   protected:
-	virtual void purge_impl() noexcept												   = 0;
-	virtual void add_impl(entity_t entity, void* data)								   = 0;
-	virtual void add_impl(psl::array_view<entity_t> entities, void* data, bool repeat) = 0;
-	virtual void
-	add_impl(psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities, void* data, bool repeat) = 0;
-	virtual psl::array_view<entity_t> entities_impl(stage_range_t stage) const noexcept						   = 0;
-	virtual void set_impl(entity_t entity, void* data) noexcept												   = 0;
-	virtual void remove_impl(entity_t entity)																   = 0;
-	virtual void remove_impl(psl::array_view<entity_t> entities)											   = 0;
-	virtual void remove_impl(psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities)		   = 0;
-	virtual bool has_impl(entity_t entity, stage_range_t stage) const noexcept								   = 0;
+	virtual void purge_impl() noexcept																		= 0;
+	virtual void add_impl(entity_t entity, void* data)														= 0;
+	virtual void add_impl(psl::array_view<entity_t> entities, void* data, bool repeat)						= 0;
+	virtual void add_impl(psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities,
+						  void* data,
+						  bool repeat)																		= 0;
+	virtual psl::array_view<entity_t> entities_impl(stage_range_t stage) const noexcept						= 0;
+	virtual void set_impl(entity_t entity, void* data) noexcept												= 0;
+	virtual void remove_impl(entity_t entity)																= 0;
+	virtual void remove_impl(psl::array_view<entity_t> entities)											= 0;
+	virtual void remove_impl(psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities) = 0;
+	virtual bool has_impl(entity_t entity, stage_range_t stage) const noexcept								= 0;
 
   protected:
 	component_key_t m_ID;

--- a/psl/inc/psl/ecs/details/component_container.hpp
+++ b/psl/inc/psl/ecs/details/component_container.hpp
@@ -37,37 +37,40 @@ class component_container_t {
 
 	bool is_tag() const noexcept;
 
-	void add(psl::array_view<entity> entities, void* data = nullptr, bool repeat = false) {
+	void add(psl::array_view<entity_t> entities, void* data = nullptr, bool repeat = false) {
 		add_impl(entities, data, repeat);
 	}
-	void add(entity entity, void* data = nullptr) { add_impl(entity, data); }
-	void add(psl::array_view<std::pair<entity, entity>> entities, void* data = nullptr, bool repeat = false) {
+	void add(entity_t entity, void* data = nullptr) { add_impl(entity, data); }
+	void add(psl::array_view<std::pair<entity_size_type, entity_size_type>> entities,
+			 void* data	 = nullptr,
+			 bool repeat = false) {
 		add_impl(entities, data, repeat);
 	}
-	void destroy(psl::array_view<std::pair<entity, entity>> entities) { remove_impl(entities); };
-	void destroy(psl::array_view<entity> entities) noexcept { remove_impl(entities); }
-	void destroy(entity entity) noexcept { remove_impl(entity); }
+	void destroy(psl::array_view<std::pair<entity_size_type, entity_size_type>> entities) { remove_impl(entities); };
+	void destroy(psl::array_view<entity_t> entities) noexcept { remove_impl(entities); }
+	void destroy(entity_t entity) noexcept { remove_impl(entity); }
 	virtual void* data() noexcept			  = 0;
 	virtual void* const data() const noexcept = 0;
-	bool has_component(entity entity) const noexcept { return has_impl(entity, stage_range_t::ALIVE); }
-	bool has_added(entity entity) const noexcept { return has_impl(entity, stage_range_t::ADDED); }
-	bool has_removed(entity entity) const noexcept { return has_impl(entity, stage_range_t::REMOVED); }
-	virtual bool has_storage_for(entity entity) const noexcept = 0;
-	psl::array_view<entity> entities(bool include_removed = false) const noexcept {
+	bool has_component(entity_t entity) const noexcept { return has_impl(entity, stage_range_t::ALIVE); }
+	bool has_added(entity_t entity) const noexcept { return has_impl(entity, stage_range_t::ADDED); }
+	bool has_removed(entity_t entity) const noexcept { return has_impl(entity, stage_range_t::REMOVED); }
+	virtual bool has_storage_for(entity_t entity) const noexcept = 0;
+	psl::array_view<entity_t> entities(bool include_removed = false) const noexcept {
 		return entities_impl((include_removed) ? stage_range_t::ALL : stage_range_t::ALIVE);
 	}
 
 	void purge() noexcept { purge_impl(); }
 	const component_key_t& id() const noexcept;
 
-	psl::array_view<entity> added_entities() const noexcept { return entities_impl(stage_range_t::ADDED); };
-	psl::array_view<entity> removed_entities() const noexcept { return entities_impl(stage_range_t::REMOVED); };
+	psl::array_view<entity_t> added_entities() const noexcept { return entities_impl(stage_range_t::ADDED); };
+	psl::array_view<entity_t> removed_entities() const noexcept { return entities_impl(stage_range_t::REMOVED); };
 
-	virtual psl::array<entity> memory_location_offsets_for(psl::array_view<entity> entities) const noexcept {
+	virtual psl::array<entity_size_type>
+	memory_location_offsets_for(psl::array_view<entity_t> entities) const noexcept {
 		return {};
 	}
-	virtual size_t copy_to(psl::array_view<entity> entities, void* destination) const noexcept { return 0; };
-	virtual size_t copy_from(psl::array_view<entity> entities, void* source, bool repeat = false) noexcept {
+	virtual size_t copy_to(psl::array_view<entity_t> entities, void* destination) const noexcept { return 0; };
+	virtual size_t copy_from(psl::array_view<entity_t> entities, void* source, bool repeat = false) noexcept {
 		return 0;
 	};
 
@@ -77,25 +80,27 @@ class component_container_t {
 	}
 	size_t alignment() const noexcept { return m_Alignment; }
 
-	void set(entity entity, void* data) noexcept { set_impl(entity, data); }
+	void set(entity_t entity, void* data) noexcept { set_impl(entity, data); }
 	virtual bool should_serialize() const noexcept { return false; }
 	virtual bool should_serialize(bool value) noexcept { return false; }
 
-	virtual void remap(const psl::sparse_array<entity>& mapping, std::function<bool(entity)> pred) noexcept = 0;
-	virtual bool merge(const component_container_t& other) noexcept											= 0;
-	virtual void clear()																					= 0;
+	virtual void remap(const psl::sparse_array<entity_size_type>& mapping,
+					   std::function<bool(entity_t)> pred) noexcept = 0;
+	virtual bool merge(const component_container_t& other) noexcept = 0;
+	virtual void clear()											= 0;
 
   protected:
-	virtual void purge_impl() noexcept																	= 0;
-	virtual void add_impl(entity entity, void* data)													= 0;
-	virtual void add_impl(psl::array_view<entity> entities, void* data, bool repeat)					= 0;
-	virtual void add_impl(psl::array_view<std::pair<entity, entity>> entities, void* data, bool repeat) = 0;
-	virtual psl::array_view<entity> entities_impl(stage_range_t stage) const noexcept					= 0;
-	virtual void set_impl(entity entity, void* data) noexcept											= 0;
-	virtual void remove_impl(entity entity)																= 0;
-	virtual void remove_impl(psl::array_view<entity> entities)											= 0;
-	virtual void remove_impl(psl::array_view<std::pair<entity, entity>> entities)						= 0;
-	virtual bool has_impl(entity entity, stage_range_t stage) const noexcept							= 0;
+	virtual void purge_impl() noexcept												   = 0;
+	virtual void add_impl(entity_t entity, void* data)								   = 0;
+	virtual void add_impl(psl::array_view<entity_t> entities, void* data, bool repeat) = 0;
+	virtual void
+	add_impl(psl::array_view<std::pair<entity_size_type, entity_size_type>> entities, void* data, bool repeat) = 0;
+	virtual psl::array_view<entity_t> entities_impl(stage_range_t stage) const noexcept						   = 0;
+	virtual void set_impl(entity_t entity, void* data) noexcept												   = 0;
+	virtual void remove_impl(entity_t entity)																   = 0;
+	virtual void remove_impl(psl::array_view<entity_t> entities)											   = 0;
+	virtual void remove_impl(psl::array_view<std::pair<entity_size_type, entity_size_type>> entities)		   = 0;
+	virtual bool has_impl(entity_t entity, stage_range_t stage) const noexcept								   = 0;
 
   protected:
 	component_key_t m_ID;
@@ -121,45 +126,49 @@ class component_container_typed_t final : public component_container_t {
 	void* data() noexcept override { return m_Entities.data(); }
 	void* const data() const noexcept override { return m_Entities.data(); }
 
-	bool has_storage_for(entity entity) const noexcept override { return m_Entities.has(entity, stage_range_t::ALL); }
+	bool has_storage_for(entity_t entity) const noexcept override { return m_Entities.has(entity, stage_range_t::ALL); }
 
-	psl::array<entity> memory_location_offsets_for(psl::array_view<entity> entities) const noexcept override {
-		psl::array<entity> result {};
+	psl::array<entity_size_type>
+	memory_location_offsets_for(psl::array_view<entity_t> entities) const noexcept override {
+		psl::array<entity_size_type> result {};
 		result.reserve(entities.size());
 		for(auto e : entities) {
-			result.emplace_back(
-			  static_cast<entity>(m_Entities.addressof(e, stage_range_t::ALL) - (T*)m_Entities.data()));
+			result.emplace_back(static_cast<entity_size_type>(
+			  m_Entities.addressof(static_cast<entity_size_type>(e), stage_range_t::ALL) - (T*)m_Entities.data()));
 		}
 		return result;
 	}
 
-	size_t copy_to(psl::array_view<entity> entities, void* destination) const noexcept override {
+	size_t copy_to(psl::array_view<entity_t> entities, void* destination) const noexcept override {
 		psl_assert((std::uintptr_t)destination % alignment() == 0, "pointer has to be aligned");
 		T* dest = (T*)destination;
 		for(auto e : entities) {
-			std::memcpy(dest, m_Entities.addressof(e, stage_range_t::ALL), sizeof(T));
+			std::memcpy(dest, m_Entities.addressof(static_cast<entity_size_type>(e), stage_range_t::ALL), sizeof(T));
 			++dest;
 		}
 		return entities.size() * sizeof(T);
 	}
-	size_t copy_from(psl::array_view<entity> entities, void* source, bool repeat) noexcept override {
+	size_t copy_from(psl::array_view<entity_t> entities, void* source, bool repeat) noexcept override {
 		psl_assert((std::uintptr_t)source % alignment() == 0, "pointer has to be aligned");
 		T* src = (T*)source;
 		if(repeat) {
 			for(auto e : entities) {
-				std::memcpy((void*)&(m_Entities.at(e, stage_range_t::ALL)), src, sizeof(T));
+				std::memcpy(
+				  (void*)&(m_Entities.at(static_cast<entity_size_type>(e), stage_range_t::ALL)), src, sizeof(T));
 			}
 		} else {
 			for(auto e : entities) {
-				std::memcpy((void*)&(m_Entities.at(e, stage_range_t::ALL)), src, sizeof(T));
+				std::memcpy(
+				  (void*)&(m_Entities.at(static_cast<entity_size_type>(e), stage_range_t::ALL)), src, sizeof(T));
 				++src;
 			}
 		}
 		return sizeof(T) * entities.size();
 	};
 
-	void remap(const psl::sparse_array<entity>& mapping, std::function<bool(entity)> pred) noexcept override {
-		m_Entities.remap(mapping, pred);
+	void remap(const psl::sparse_array<entity_size_type>& mapping,
+			   std::function<bool(entity_t)> pred) noexcept override {
+		m_Entities.remap(mapping, [pred](entity_size_type e) -> bool { return pred(entity_t {e}); });
 	}
 	bool merge(const component_container_t& other) noexcept override {
 		if(other.id() != id())
@@ -170,44 +179,51 @@ class component_container_typed_t final : public component_container_t {
 		return true;
 	}
 
-	void set(entity e, const T& data) noexcept { m_Entities.at(e, stage_range_t::ALL) = data; }
+	void set(entity_t e, const T& data) noexcept {
+		m_Entities.at(static_cast<entity_size_type>(e), stage_range_t::ALL) = data;
+	}
 
   protected:
-	void set_impl(entity entity, void* data) noexcept override {
-		m_Entities.at(entity, stage_range_t::ALL) = *(T*)data;
+	void set_impl(entity_t entity, void* data) noexcept override {
+		m_Entities.at(static_cast<entity_size_type>(entity), stage_range_t::ALL) = *(T*)data;
 	}
-	psl::array_view<entity> entities_impl(stage_range_t stage) const noexcept override {
-		return m_Entities.indices(stage);
+	psl::array_view<entity_t> entities_impl(stage_range_t stage) const noexcept override {
+		auto indices = m_Entities.indices(stage);
+		return psl::array_view<entity_t>(reinterpret_cast<entity_t*>(indices.data()), indices.size());
 	}
-	void add_impl(psl::array_view<entity> entities, void* data, bool repeat) override {
+	void add_impl(psl::array_view<entity_t> entities, void* data, bool repeat) override {
 		m_Entities.reserve(m_Entities.size(stage_range_t::ALL) + entities.size());
 		T* source = (T*)data;
 		if(data == nullptr) {
 			for(size_t i = 0; i < entities.size(); ++i) {
-				m_Entities.insert(entities[i]);
+				m_Entities.insert(static_cast<entity_size_type>(entities[i]));
 			}
 		} else if(repeat) {
 			for(size_t i = 0; i < entities.size(); ++i) {
-				m_Entities.insert(entities[i], *source);
+				m_Entities.insert(static_cast<entity_size_type>(entities[i]), *source);
 			}
 		} else {
 			for(size_t i = 0; i < entities.size(); ++i) {
-				m_Entities.insert(entities[i], *source);
+				m_Entities.insert(static_cast<entity_size_type>(entities[i]), *source);
 				++source;
 			}
 		}
 	}
-	void add_impl(entity entity, void* data) override {
+	void add_impl(entity_t entity, void* data) override {
 		if(data == nullptr)
-			m_Entities.insert(entity);
+			m_Entities.insert(static_cast<entity_size_type>(entity));
 		else
-			m_Entities.insert(entity, *(T*)data);
+			m_Entities.insert(static_cast<entity_size_type>(entity), *(T*)data);
 	}
-	void add_impl(psl::array_view<std::pair<entity, entity>> entities, void* data, bool repeat) override {
-		auto count = std::accumulate(
-		  std::begin(entities), std::end(entities), size_t {0}, [](size_t sum, const std::pair<entity, entity>& r) {
-			  return sum + (r.second - r.first);
-		  });
+	void add_impl(psl::array_view<std::pair<entity_size_type, entity_size_type>> entities,
+				  void* data,
+				  bool repeat) override {
+		auto count = std::accumulate(std::begin(entities),
+									 std::end(entities),
+									 size_t {0},
+									 [](size_t sum, const std::pair<entity_size_type, entity_size_type>& r) {
+										 return sum + (r.second - r.first);
+									 });
 
 		m_Entities.reserve(m_Entities.size(stage_range_t::ALL) + count);
 		T* source = (T*)data;
@@ -230,21 +246,23 @@ class component_container_typed_t final : public component_container_t {
 	}
 	void purge_impl() noexcept override { m_Entities.promote(); }
 
-	void remove_impl(entity entity) override { m_Entities.erase(entity); }
-	void remove_impl(psl::array_view<entity> entities) override {
+	void remove_impl(entity_t entity) override { m_Entities.erase(static_cast<entity_size_type>(entity)); }
+	void remove_impl(psl::array_view<entity_t> entities) override {
 		for(size_t i = 0; i < entities.size(); ++i) m_Entities.erase(entities[i]);
 	}
-	void remove_impl(psl::array_view<std::pair<entity, entity>> entities) override {
+	void remove_impl(psl::array_view<std::pair<entity_size_type, entity_size_type>> entities) override {
 		for(auto range : entities) {
 			for(auto i = range.first; i < range.second; ++i) m_Entities.erase(i);
 		}
 	}
-	bool has_impl(entity entity, stage_range_t stage) const noexcept override { return m_Entities.has(entity, stage); }
+	bool has_impl(entity_t entity, stage_range_t stage) const noexcept override {
+		return m_Entities.has(static_cast<entity_size_type>(entity), stage);
+	}
 
 	void clear() override { m_Entities.clear(); }
 
   private:
-	details::staged_sparse_array<T, entity> m_Entities;
+	details::staged_sparse_array<T, entity_size_type> m_Entities;
 };
 
 class component_container_flag_t : public component_container_t {
@@ -256,10 +274,13 @@ class component_container_flag_t : public component_container_t {
 	void* data() noexcept override { return nullptr; }
 	void* const data() const noexcept override { return nullptr; }
 
-	bool has_storage_for(entity entity) const noexcept override { return m_Entities.has(entity, stage_range_t::ALL); }
+	bool has_storage_for(entity_t entity) const noexcept override {
+		return m_Entities.has(static_cast<entity_size_type>(entity), stage_range_t::ALL);
+	}
 
-	void remap(const psl::sparse_array<entity>& mapping, std::function<bool(entity)> pred) noexcept override {
-		m_Entities.remap(mapping, pred);
+	void remap(const psl::sparse_array<entity_size_type>& mapping,
+			   std::function<bool(entity_t)> pred) noexcept override {
+		m_Entities.remap(mapping, [pred](entity_size_type entity) { return pred(entity_t {entity}); });
 	}
 
 	bool merge(const component_container_t& other) noexcept override {
@@ -278,20 +299,25 @@ class component_container_flag_t : public component_container_t {
 	}
 
   protected:
-	void set_impl(entity entity, void* data) noexcept override {};
-	psl::array_view<entity> entities_impl(stage_range_t stage) const noexcept override {
-		return m_Entities.indices(stage);
+	void set_impl(entity_t entity, void* data) noexcept override {};
+	psl::array_view<entity_t> entities_impl(stage_range_t stage) const noexcept override {
+		auto indices = m_Entities.indices(stage);
+		return psl::array_view<entity_t>(reinterpret_cast<entity_t*>(indices.data()), indices.size());
 	}
-	void add_impl(psl::array_view<entity> entities, void* data, bool repeat) override {
+	void add_impl(psl::array_view<entity_t> entities, void* data, bool repeat) override {
 		m_Entities.reserve(m_Entities.size(stage_range_t::ALL) + entities.size());
-		for(auto e : entities) m_Entities.insert(e);
+		for(auto e : entities) m_Entities.insert(static_cast<entity_size_type>(e));
 	}
-	void add_impl(entity entity, void* data) override { m_Entities.insert(entity); }
-	void add_impl(psl::array_view<std::pair<entity, entity>> entities, void* data, bool repeat) override {
-		auto count = std::accumulate(
-		  std::begin(entities), std::end(entities), size_t {0}, [](size_t sum, const std::pair<entity, entity>& r) {
-			  return sum + (r.second - r.first);
-		  });
+	void add_impl(entity_t entity, void* data) override { m_Entities.insert(static_cast<entity_size_type>(entity)); }
+	void add_impl(psl::array_view<std::pair<entity_size_type, entity_size_type>> entities,
+				  void* data,
+				  bool repeat) override {
+		auto count = std::accumulate(std::begin(entities),
+									 std::end(entities),
+									 size_t {0},
+									 [](size_t sum, const std::pair<entity_size_type, entity_size_type>& r) {
+										 return sum + (r.second - r.first);
+									 });
 
 		m_Entities.reserve(m_Entities.size(stage_range_t::ALL) + count);
 		for(auto range : entities) {
@@ -300,16 +326,18 @@ class component_container_flag_t : public component_container_t {
 	}
 	void purge_impl() noexcept override { m_Entities.promote(); }
 
-	void remove_impl(entity entity) override { m_Entities.erase(entity); }
-	void remove_impl(psl::array_view<entity> entities) override {
-		for(size_t i = 0; i < entities.size(); ++i) m_Entities.erase(entities[i]);
+	void remove_impl(entity_t entity) override { m_Entities.erase(static_cast<entity_size_type>(entity)); }
+	void remove_impl(psl::array_view<entity_t> entities) override {
+		for(size_t i = 0; i < entities.size(); ++i) m_Entities.erase(static_cast<entity_size_type>(entities[i]));
 	}
-	void remove_impl(psl::array_view<std::pair<entity, entity>> entities) override {
+	void remove_impl(psl::array_view<std::pair<entity_size_type, entity_size_type>> entities) override {
 		for(auto range : entities) {
 			for(auto i = range.first; i < range.second; ++i) m_Entities.erase(i);
 		}
 	}
-	bool has_impl(entity entity, stage_range_t stage) const noexcept override { return m_Entities.has(entity, stage); }
+	bool has_impl(entity_t entity, stage_range_t stage) const noexcept override {
+		return m_Entities.has(static_cast<entity_size_type>(entity), stage);
+	}
 
 	void clear() override {
 		m_Entities.clear();
@@ -317,7 +345,7 @@ class component_container_flag_t : public component_container_t {
 	}
 
   private:
-	details::staged_sparse_array<void, entity> m_Entities;
+	details::staged_sparse_array<void, entity_size_type> m_Entities;
 	bool m_Serializable {false};
 };
 
@@ -337,46 +365,51 @@ class component_container_untyped_t : public component_container_t {
 	void* data() noexcept override { return m_Entities.data(); }
 	void* const data() const noexcept override { return m_Entities.data(); }
 
-	bool has_storage_for(entity entity) const noexcept override { return m_Entities.has(entity, stage_range_t::ALL); }
+	bool has_storage_for(entity_t entity) const noexcept override {
+		return m_Entities.has(static_cast<entity_size_type>(entity), stage_range_t::ALL);
+	}
 
-	psl::array<entity> memory_location_offsets_for(psl::array_view<entity> entities) const noexcept override {
-		psl::array<entity> result {};
+	psl::array<entity_size_type>
+	memory_location_offsets_for(psl::array_view<entity_t> entities) const noexcept override {
+		psl::array<entity_size_type> result {};
 		const auto base = reinterpret_cast<std::uintptr_t>(m_Entities.data());
 		result.reserve(entities.size());
 		for(auto e : entities) {
 			const auto address = reinterpret_cast<std::uintptr_t>(m_Entities.addressof(e, stage_range_t::ALL));
-			result.emplace_back(static_cast<entity>((address - base) / static_cast<entity>(m_Size)));
+			result.emplace_back(
+			  static_cast<entity_size_type>((address - base) / static_cast<entity_size_type>(m_Size)));
 		}
 		return result;
 	}
 
-	size_t copy_to(psl::array_view<entity> entities, void* destination) const noexcept override {
+	size_t copy_to(psl::array_view<entity_t> entities, void* destination) const noexcept override {
 		psl_assert((std::uintptr_t)destination % alignment() == 0, "pointer has to be aligned");
 		std::byte* dest = (std::byte*)destination;
 		for(auto e : entities) {
-			std::memcpy(dest, m_Entities.addressof(e, stage_range_t::ALL), m_Size);
+			std::memcpy(dest, m_Entities.addressof(static_cast<entity_size_type>(e), stage_range_t::ALL), m_Size);
 			dest += m_Size;
 		}
 		return entities.size() * m_Size;
 	}
-	size_t copy_from(psl::array_view<entity> entities, void* source, bool repeat) noexcept override {
+	size_t copy_from(psl::array_view<entity_t> entities, void* source, bool repeat) noexcept override {
 		psl_assert((std::uintptr_t)source % alignment() == 0, "pointer has to be aligned");
 		std::byte* src = (std::byte*)source;
 		if(repeat) {
 			for(auto e : entities) {
-				std::memcpy(m_Entities.addressof(e, stage_range_t::ALL), src, m_Size);
+				std::memcpy(m_Entities.addressof(static_cast<entity_size_type>(e), stage_range_t::ALL), src, m_Size);
 			}
 		} else {
 			for(auto e : entities) {
-				std::memcpy(m_Entities.addressof(e, stage_range_t::ALL), src, m_Size);
+				std::memcpy(m_Entities.addressof(static_cast<entity_size_type>(e), stage_range_t::ALL), src, m_Size);
 				src += m_Size;
 			}
 		}
 		return m_Size * entities.size();
 	};
 
-	void remap(const psl::sparse_array<entity>& mapping, std::function<bool(entity)> pred) noexcept override {
-		m_Entities.remap(mapping, pred);
+	void remap(const psl::sparse_array<entity_size_type>& mapping,
+			   std::function<bool(entity_t)> pred) noexcept override {
+		m_Entities.remap(mapping, [pred](entity_size_type entity) { return pred(entity_t {entity}); });
 	}
 
 	bool merge(const component_container_t& other) noexcept override {
@@ -388,8 +421,8 @@ class component_container_untyped_t : public component_container_t {
 	}
 
 	template <typename T>
-	void set(entity e, const T& data) noexcept {
-		m_Entities.template at<T>(e, stage_range_t::ALL) = data;
+	void set(entity_t e, const T& data) noexcept {
+		m_Entities.template at<T>(static_cast<entity_size_type>(e), stage_range_t::ALL) = data;
 	}
 
 	bool should_serialize() const noexcept override { return m_Serializable; }
@@ -404,45 +437,50 @@ class component_container_untyped_t : public component_container_t {
 	}
 
   protected:
-	void set_impl(entity entity, void* data) noexcept override {
-		auto* ptr = m_Entities.addressof(entity, stage_range_t::ALL);
+	void set_impl(entity_t entity, void* data) noexcept override {
+		auto* ptr = m_Entities.addressof(static_cast<entity_size_type>(entity), stage_range_t::ALL);
 		std::memcpy(ptr, data, m_Size);
 	}
-	psl::array_view<entity> entities_impl(stage_range_t stage) const noexcept override {
-		return m_Entities.indices(stage);
+	psl::array_view<entity_t> entities_impl(stage_range_t stage) const noexcept override {
+		auto indices = m_Entities.indices(stage);
+		return psl::array_view<entity_t>(reinterpret_cast<entity_t*>(indices.data()), indices.size());
 	}
 
-	void add_impl(psl::array_view<entity> entities, void* data, bool repeat) override {
+	void add_impl(psl::array_view<entity_t> entities, void* data, bool repeat) override {
 		std::byte* source = (std::byte*)data;
 		if(data == nullptr) {
 			for(size_t i = 0; i < entities.size(); ++i) {
-				m_Entities.insert(entities[i]);
+				m_Entities.insert(static_cast<entity_size_type>(entities[i]));
 			}
 		} else if(repeat) {
 			for(size_t i = 0; i < entities.size(); ++i) {
-				auto ptr = m_Entities.get_or_insert(entities[i]);
+				auto ptr = m_Entities.get_or_insert(static_cast<entity_size_type>(entities[i]));
 				memcpy(ptr, source, m_Size);
 			}
 		} else {
 			for(size_t i = 0; i < entities.size(); ++i) {
-				auto ptr = m_Entities.get_or_insert(entities[i]);
+				auto ptr = m_Entities.get_or_insert(static_cast<entity_size_type>(entities[i]));
 				memcpy(ptr, source, m_Size);
 				source += m_Size;
 			}
 		}
 	}
-	void add_impl(entity entity, void* data) override {
-		auto ptr = m_Entities.get_or_insert(entity);
+	void add_impl(entity_t entity, void* data) override {
+		auto ptr = m_Entities.get_or_insert(static_cast<entity_size_type>(entity));
 
 		if(data != nullptr)
 			memcpy(ptr, data, m_Size);
 	}
 
-	void add_impl(psl::array_view<std::pair<entity, entity>> entities, void* data, bool repeat) override {
-		auto count = std::accumulate(
-		  std::begin(entities), std::end(entities), size_t {0}, [](size_t sum, const std::pair<entity, entity>& r) {
-			  return sum + (r.second - r.first);
-		  });
+	void add_impl(psl::array_view<std::pair<entity_size_type, entity_size_type>> entities,
+				  void* data,
+				  bool repeat) override {
+		auto count = std::accumulate(std::begin(entities),
+									 std::end(entities),
+									 size_t {0},
+									 [](size_t sum, const std::pair<entity_size_type, entity_size_type>& r) {
+										 return sum + (r.second - r.first);
+									 });
 
 		std::byte* source = (std::byte*)data;
 		if(data == nullptr) {
@@ -468,16 +506,18 @@ class component_container_untyped_t : public component_container_t {
 	}
 	void purge_impl() noexcept override { m_Entities.promote(); }
 
-	void remove_impl(entity entity) override { m_Entities.erase(entity); }
-	void remove_impl(psl::array_view<entity> entities) override {
-		for(size_t i = 0; i < entities.size(); ++i) m_Entities.erase(entities[i]);
+	void remove_impl(entity_t entity) override { m_Entities.erase(static_cast<entity_size_type>(entity)); }
+	void remove_impl(psl::array_view<entity_t> entities) override {
+		for(size_t i = 0; i < entities.size(); ++i) m_Entities.erase(static_cast<entity_size_type>(entities[i]));
 	}
-	void remove_impl(psl::array_view<std::pair<entity, entity>> entities) override {
+	void remove_impl(psl::array_view<std::pair<entity_size_type, entity_size_type>> entities) override {
 		for(auto range : entities) {
 			for(auto i = range.first; i < range.second; ++i) m_Entities.erase(i);
 		}
 	}
-	bool has_impl(entity entity, stage_range_t stage) const noexcept override { return m_Entities.has(entity, stage); }
+	bool has_impl(entity_t entity, stage_range_t stage) const noexcept override {
+		return m_Entities.has(static_cast<entity_size_type>(entity), stage);
+	}
 
   private:
 	details::staged_sparse_memory_region_t m_Entities;

--- a/psl/inc/psl/ecs/details/staged_sparse_array.hpp
+++ b/psl/inc/psl/ecs/details/staged_sparse_array.hpp
@@ -21,7 +21,7 @@
 #include "psl/ecs/details/stage_range_t.hpp"
 
 namespace psl::ecs::details {
-template <typename T, typename Key = psl::ecs::entity, Key chunks_size = 4096>
+template <typename T, typename Key = psl::ecs::entity_size_type, Key chunks_size = 4096>
 class staged_sparse_array {
 	using value_t = T;
 	using index_t = Key;

--- a/psl/inc/psl/ecs/details/staged_sparse_array.hpp
+++ b/psl/inc/psl/ecs/details/staged_sparse_array.hpp
@@ -21,7 +21,7 @@
 #include "psl/ecs/details/stage_range_t.hpp"
 
 namespace psl::ecs::details {
-template <typename T, typename Key = psl::ecs::entity_size_type, Key chunks_size = 4096>
+template <typename T, typename Key = psl::ecs::entity_t::size_type, Key chunks_size = 4096>
 class staged_sparse_array {
 	using value_t = T;
 	using index_t = Key;

--- a/psl/inc/psl/ecs/details/staged_sparse_memory_region.hpp
+++ b/psl/inc/psl/ecs/details/staged_sparse_memory_region.hpp
@@ -500,8 +500,7 @@ class staged_sparse_memory_region_t {
 		m_StageSize[1] += 1;
 	}
 
-	FORCEINLINE auto has_impl(key_type chunk_index, key_type offset, stage_range_t stage) const noexcept
-	  -> bool {
+	FORCEINLINE auto has_impl(key_type chunk_index, key_type offset, stage_range_t stage) const noexcept -> bool {
 		if(m_Sparse.at(chunk_index)) {
 			const auto& chunk = get_chunk_from_index(chunk_index);
 			return chunk[offset] != std::numeric_limits<key_type>::max() &&
@@ -561,9 +560,7 @@ class staged_sparse_memory_region_t {
 		return m_Sparse.at(index).value();
 	}
 
-	FORCEINLINE auto get_chunk_from_index(key_type index) noexcept -> chunk_type& {
-		return m_Sparse.at(index).value();
-	}
+	FORCEINLINE auto get_chunk_from_index(key_type index) noexcept -> chunk_type& { return m_Sparse.at(index).value(); }
 
 	constexpr FORCEINLINE auto chunk_for(key_type& index) noexcept -> chunk_type& {
 		if(index >= capacity())

--- a/psl/inc/psl/ecs/details/staged_sparse_memory_region.hpp
+++ b/psl/inc/psl/ecs/details/staged_sparse_memory_region.hpp
@@ -500,9 +500,9 @@ class staged_sparse_memory_region_t {
 		m_StageSize[1] += 1;
 	}
 
-	constexpr FORCEINLINE auto has_impl(key_type chunk_index, key_type offset, stage_range_t stage) const noexcept
+	FORCEINLINE auto has_impl(key_type chunk_index, key_type offset, stage_range_t stage) const noexcept
 	  -> bool {
-		if(m_Sparse[chunk_index]) {
+		if(m_Sparse.at(chunk_index)) {
 			const auto& chunk = get_chunk_from_index(chunk_index);
 			return chunk[offset] != std::numeric_limits<key_type>::max() &&
 				   chunk[offset] >= m_StageStart[stage_begin(stage)] && chunk[offset] < m_StageStart[stage_end(stage)];
@@ -557,12 +557,12 @@ class staged_sparse_memory_region_t {
 		psl_assert(chunk[offset] == reverse_index, "expected {} == {}", chunk[offset], reverse_index);
 	}
 
-	constexpr FORCEINLINE auto get_chunk_from_index(key_type index) const noexcept -> const chunk_type& {
-		return m_Sparse[index].value();
+	FORCEINLINE auto get_chunk_from_index(key_type index) const noexcept -> const chunk_type& {
+		return m_Sparse.at(index).value();
 	}
 
-	constexpr FORCEINLINE auto get_chunk_from_index(key_type index) noexcept -> chunk_type& {
-		return m_Sparse[index].value();
+	FORCEINLINE auto get_chunk_from_index(key_type index) noexcept -> chunk_type& {
+		return m_Sparse.at(index).value();
 	}
 
 	constexpr FORCEINLINE auto chunk_for(key_type& index) noexcept -> chunk_type& {

--- a/psl/inc/psl/ecs/details/staged_sparse_memory_region.hpp
+++ b/psl/inc/psl/ecs/details/staged_sparse_memory_region.hpp
@@ -25,7 +25,7 @@ concept IsValidForStagedSparseMemoryRange = IsComponentTrivialType<T>;
 /// \note due to the dense data being stored on its own page, alignment shouldn't be a concern.
 /// \warning This container is unsuitable for types that have non-trivial constructors, copy/move operations, and destructors. Check your type against `IsValidForStagedSparseMemoryRange` to verify.
 class staged_sparse_memory_region_t {
-	using Key = psl::ecs::entity_size_type;
+	using Key = psl::ecs::entity_t::size_type;
 	static constexpr Key chunks_size {4096};
 	static constexpr bool is_power_of_two {chunks_size && ((chunks_size & (chunks_size - 1)) == 0)};
 	static constexpr Key mod_val {(is_power_of_two) ? chunks_size - 1 : chunks_size};

--- a/psl/inc/psl/ecs/details/staged_sparse_memory_region.hpp
+++ b/psl/inc/psl/ecs/details/staged_sparse_memory_region.hpp
@@ -25,7 +25,7 @@ concept IsValidForStagedSparseMemoryRange = IsComponentTrivialType<T>;
 /// \note due to the dense data being stored on its own page, alignment shouldn't be a concern.
 /// \warning This container is unsuitable for types that have non-trivial constructors, copy/move operations, and destructors. Check your type against `IsValidForStagedSparseMemoryRange` to verify.
 class staged_sparse_memory_region_t {
-	using Key = psl::ecs::entity;
+	using Key = psl::ecs::entity_size_type;
 	static constexpr Key chunks_size {4096};
 	static constexpr bool is_power_of_two {chunks_size && ((chunks_size & (chunks_size - 1)) == 0)};
 	static constexpr Key mod_val {(is_power_of_two) ? chunks_size - 1 : chunks_size};

--- a/psl/inc/psl/ecs/details/system_information.hpp
+++ b/psl/inc/psl/ecs/details/system_information.hpp
@@ -40,7 +40,7 @@ namespace psl::ecs::details {
 /// system would require several dependency_pack's.
 class dependency_pack {
 	struct indirect_storage_t {
-		psl::array<entity_size_type> indices {};
+		psl::array<entity_t::size_type> indices {};
 		void* data {nullptr};
 	};
 	friend class psl::ecs::state_t;
@@ -67,18 +67,18 @@ class dependency_pack {
 	auto _create_dependency_filters_impl(psl::array_view<entity_t const>) {}
 
 	template <typename T>
-	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<T, entity_size_type>) {
+	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<T, entity_t::size_type>) {
 		constexpr auto id = details::component_key_t::generate<T>();
 		m_IndirectReadWriteBindings.emplace(id, indirect_storage_t {});
 	}
 	template <typename T>
-	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<T const, entity_size_type>) {
+	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<T const, entity_t::size_type>) {
 		constexpr auto id = details::component_key_t::generate<T>();
 		m_IndirectReadBindings.emplace(id, indirect_storage_t {});
 	}
 
-	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<entity_t, entity_size_type>) {}
-	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<entity_t const, entity_size_type>) {}
+	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<entity_t, entity_t::size_type>) {}
+	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<entity_t const, entity_t::size_type>) {}
 
 	template <typename F>
 	void select_impl(std::vector<component_key_t>& target) {
@@ -128,26 +128,26 @@ class dependency_pack {
 	}
 
 	template <typename T>
-	auto fill_in(psl::type_pack_t<psl::ecs::details::indirect_array_t<T, psl::ecs::entity_size_type>>) {
+	auto fill_in(psl::type_pack_t<psl::ecs::details::indirect_array_t<T, psl::ecs::entity_t::size_type>>) {
 		if constexpr(std::is_same<T, psl::ecs::entity_t>::value) {
 			// todo: this is a temporary hack until mixed packs can be done. Ideally entities are an array_view not an
 			// indirect_array_t
-			std::vector<entity_size_type> indices {};
+			std::vector<entity_t::size_type> indices {};
 			indices.resize(m_Entities.size());
-			std::iota(std::begin(indices), std::end(indices), entity_size_type {0});
-			return psl::ecs::details::indirect_array_t<T, psl::ecs::entity_size_type>(indices, (T*)m_Entities.data());
+			std::iota(std::begin(indices), std::end(indices), entity_t::size_type {0});
+			return psl::ecs::details::indirect_array_t<T, psl::ecs::entity_t::size_type>(indices, (T*)m_Entities.data());
 		} else {
 			constexpr component_key_t id = details::component_key_t::generate<T>();
 			if constexpr(std::is_const<T>::value) {
 				auto it = m_IndirectReadBindings.find(id);
 				psl_assert(it != m_IndirectReadBindings.end(), "type wasn't present in `m_IndirectReadBindings`");
-				return psl::ecs::details::indirect_array_t<T, psl::ecs::entity_size_type>(it->second.indices,
+				return psl::ecs::details::indirect_array_t<T, psl::ecs::entity_t::size_type>(it->second.indices,
 																						  (T*)it->second.data);
 			} else {
 				auto it = m_IndirectReadWriteBindings.find(id);
 				psl_assert(it != m_IndirectReadWriteBindings.end(),
 						   "type wasn't present in `m_IndirectReadWriteBindings`");
-				return psl::ecs::details::indirect_array_t<T, psl::ecs::entity_size_type>(it->second.indices,
+				return psl::ecs::details::indirect_array_t<T, psl::ecs::entity_t::size_type>(it->second.indices,
 																						  (T*)it->second.data);
 			}
 		}
@@ -283,14 +283,14 @@ class dependency_pack {
 
 		for(const auto& binding : m_IndirectReadBindings) {
 			auto size										  = cpy.m_Sizes[binding.first];
-			cpy.m_IndirectReadBindings[binding.first].indices = psl::array<entity_size_type>(
+			cpy.m_IndirectReadBindings[binding.first].indices = psl::array<entity_t::size_type>(
 			  std::next(binding.second.indices.begin(), begin), std::next(binding.second.indices.begin(), end));
 			cpy.m_IndirectReadBindings[binding.first].data = binding.second.data;
 		}
 
 		for(const auto& binding : m_IndirectReadWriteBindings) {
 			auto size											   = cpy.m_Sizes[binding.first];
-			cpy.m_IndirectReadWriteBindings[binding.first].indices = psl::array<entity_size_type>(
+			cpy.m_IndirectReadWriteBindings[binding.first].indices = psl::array<entity_t::size_type>(
 			  std::next(binding.second.indices.begin(), begin), std::next(binding.second.indices.begin(), end));
 			cpy.m_IndirectReadWriteBindings[binding.first].data = binding.second.data;
 		}

--- a/psl/inc/psl/ecs/details/system_information.hpp
+++ b/psl/inc/psl/ecs/details/system_information.hpp
@@ -135,20 +135,21 @@ class dependency_pack {
 			std::vector<entity_t::size_type> indices {};
 			indices.resize(m_Entities.size());
 			std::iota(std::begin(indices), std::end(indices), entity_t::size_type {0});
-			return psl::ecs::details::indirect_array_t<T, psl::ecs::entity_t::size_type>(indices, (T*)m_Entities.data());
+			return psl::ecs::details::indirect_array_t<T, psl::ecs::entity_t::size_type>(indices,
+																						 (T*)m_Entities.data());
 		} else {
 			constexpr component_key_t id = details::component_key_t::generate<T>();
 			if constexpr(std::is_const<T>::value) {
 				auto it = m_IndirectReadBindings.find(id);
 				psl_assert(it != m_IndirectReadBindings.end(), "type wasn't present in `m_IndirectReadBindings`");
 				return psl::ecs::details::indirect_array_t<T, psl::ecs::entity_t::size_type>(it->second.indices,
-																						  (T*)it->second.data);
+																							 (T*)it->second.data);
 			} else {
 				auto it = m_IndirectReadWriteBindings.find(id);
 				psl_assert(it != m_IndirectReadWriteBindings.end(),
 						   "type wasn't present in `m_IndirectReadWriteBindings`");
 				return psl::ecs::details::indirect_array_t<T, psl::ecs::entity_t::size_type>(it->second.indices,
-																						  (T*)it->second.data);
+																							 (T*)it->second.data);
 			}
 		}
 	}

--- a/psl/inc/psl/ecs/details/system_information.hpp
+++ b/psl/inc/psl/ecs/details/system_information.hpp
@@ -33,14 +33,14 @@ namespace psl::ecs::details {
 ///
 /// systems can have various dependencies, for example a movement system could have
 /// dependencies on both a psl::ecs::components::transform component and a psl::ecs::components::renderable
-/// component. This dependency will output a set of psl::ecs::entity's that have all required
+/// component. This dependency will output a set of psl::ecs::entity_t's that have all required
 /// psl::ecs::components present. Certain systems could have sets of dependencies, for example the render
 /// system requires knowing about both all `psl::ecs::components::renderable` that have a
 /// `psl::ecs::components::transform`, but also needs to know all `psl::ecs::components::camera's`. So that
 /// system would require several dependency_pack's.
 class dependency_pack {
 	struct indirect_storage_t {
-		psl::array<entity> indices {};
+		psl::array<entity_size_type> indices {};
 		void* data {nullptr};
 	};
 	friend class psl::ecs::state_t;
@@ -63,26 +63,26 @@ class dependency_pack {
 		m_RBindings.emplace(id, psl::array_view<std::uintptr_t> {});
 	}
 
-	auto _create_dependency_filters_impl(psl::array_view<entity>) {}
-	auto _create_dependency_filters_impl(psl::array_view<entity const>) {}
+	auto _create_dependency_filters_impl(psl::array_view<entity_t>) {}
+	auto _create_dependency_filters_impl(psl::array_view<entity_t const>) {}
 
 	template <typename T>
-	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<T, entity>) {
+	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<T, entity_size_type>) {
 		constexpr auto id = details::component_key_t::generate<T>();
 		m_IndirectReadWriteBindings.emplace(id, indirect_storage_t {});
 	}
 	template <typename T>
-	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<T const, entity>) {
+	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<T const, entity_size_type>) {
 		constexpr auto id = details::component_key_t::generate<T>();
 		m_IndirectReadBindings.emplace(id, indirect_storage_t {});
 	}
 
-	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<entity, entity>) {}
-	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<entity const, entity>) {}
+	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<entity_t, entity_size_type>) {}
+	auto _create_dependency_filters_impl(psl::ecs::details::indirect_array_t<entity_t const, entity_size_type>) {}
 
 	template <typename F>
 	void select_impl(std::vector<component_key_t>& target) {
-		if constexpr(!std::is_same<typename std::decay<F>::type, psl::ecs::entity>::value) {
+		if constexpr(!std::is_same<typename std::decay<F>::type, psl::ecs::entity_t>::value) {
 			using component_t			  = F;
 			constexpr component_key_t key = details::component_key_t::generate<component_t>();
 			target.emplace_back(key);
@@ -115,7 +115,7 @@ class dependency_pack {
 
 	template <typename T>
 	auto fill_in(psl::type_pack_t<psl::array_view<T>>) -> psl::array_view<T> {
-		if constexpr(std::is_same<T, psl::ecs::entity>::value) {
+		if constexpr(std::is_same<T, psl::ecs::entity_t>::value) {
 			return m_Entities;
 		} else {
 			constexpr component_key_t id = details::component_key_t::generate<T>();
@@ -128,28 +128,27 @@ class dependency_pack {
 	}
 
 	template <typename T>
-	auto fill_in(psl::type_pack_t<psl::ecs::details::indirect_array_t<T, psl::ecs::entity>>) {
-		if constexpr(std::is_same<T, psl::ecs::entity>::value) {
+	auto fill_in(psl::type_pack_t<psl::ecs::details::indirect_array_t<T, psl::ecs::entity_size_type>>) {
+		if constexpr(std::is_same<T, psl::ecs::entity_t>::value) {
 			// todo: this is a temporary hack until mixed packs can be done. Ideally entities are an array_view not an
 			// indirect_array_t
-			std::vector<entity> indices {};
+			std::vector<entity_size_type> indices {};
 			indices.resize(m_Entities.size());
-			std::iota(std::begin(indices), std::end(indices), entity {0});
-			return psl::ecs::details::indirect_array_t<T, psl::ecs::entity>(indices,
-																			(psl::ecs::entity*)m_Entities.data());
+			std::iota(std::begin(indices), std::end(indices), entity_size_type {0});
+			return psl::ecs::details::indirect_array_t<T, psl::ecs::entity_size_type>(indices, (T*)m_Entities.data());
 		} else {
 			constexpr component_key_t id = details::component_key_t::generate<T>();
 			if constexpr(std::is_const<T>::value) {
 				auto it = m_IndirectReadBindings.find(id);
 				psl_assert(it != m_IndirectReadBindings.end(), "type wasn't present in `m_IndirectReadBindings`");
-				return psl::ecs::details::indirect_array_t<T, psl::ecs::entity>(it->second.indices,
-																				(T*)it->second.data);
+				return psl::ecs::details::indirect_array_t<T, psl::ecs::entity_size_type>(it->second.indices,
+																						  (T*)it->second.data);
 			} else {
 				auto it = m_IndirectReadWriteBindings.find(id);
 				psl_assert(it != m_IndirectReadWriteBindings.end(),
 						   "type wasn't present in `m_IndirectReadWriteBindings`");
-				return psl::ecs::details::indirect_array_t<T, psl::ecs::entity>(it->second.indices,
-																				(T*)it->second.data);
+				return psl::ecs::details::indirect_array_t<T, psl::ecs::entity_size_type>(it->second.indices,
+																						  (T*)it->second.data);
 			}
 		}
 	}
@@ -166,8 +165,9 @@ class dependency_pack {
 	template <typename T>
 	dependency_pack(psl::type_pack_t<T>, bool seedWithPrevious = false)
 		: m_IsPartial(IsPackPartial<typename T::policy_type>), m_IsIndirect(IsAccessIndirect<typename T::access_type>) {
-		orderby =
-		  [](psl::array<entity>::iterator begin, psl::array<entity>::iterator end, const psl::ecs::state_t& state) {};
+		orderby			= [](psl::array<entity_t>::iterator begin,
+					 psl::array<entity_t>::iterator end,
+					 const psl::ecs::state_t& state) {};
 		using pack_type = T;
 		create_dependency_filters(
 		  std::make_index_sequence<std::tuple_size_v<typename pack_type::pack_type::range_t>> {},
@@ -262,7 +262,7 @@ class dependency_pack {
 		auto cpy = make_partial_copy();
 
 		cpy.m_Entities =
-		  psl::array_view<entity>(std::next(m_Entities.begin(), begin), std::next(m_Entities.begin(), end));
+		  psl::array_view<entity_t>(std::next(m_Entities.begin(), begin), std::next(m_Entities.begin(), end));
 
 		for(const auto& binding : m_RBindings) {
 			auto size = cpy.m_Sizes[binding.first];
@@ -283,14 +283,14 @@ class dependency_pack {
 
 		for(const auto& binding : m_IndirectReadBindings) {
 			auto size										  = cpy.m_Sizes[binding.first];
-			cpy.m_IndirectReadBindings[binding.first].indices = psl::array<entity>(
+			cpy.m_IndirectReadBindings[binding.first].indices = psl::array<entity_size_type>(
 			  std::next(binding.second.indices.begin(), begin), std::next(binding.second.indices.begin(), end));
 			cpy.m_IndirectReadBindings[binding.first].data = binding.second.data;
 		}
 
 		for(const auto& binding : m_IndirectReadWriteBindings) {
 			auto size											   = cpy.m_Sizes[binding.first];
-			cpy.m_IndirectReadWriteBindings[binding.first].indices = psl::array<entity>(
+			cpy.m_IndirectReadWriteBindings[binding.first].indices = psl::array<entity_size_type>(
 			  std::next(binding.second.indices.begin(), begin), std::next(binding.second.indices.begin(), end));
 			cpy.m_IndirectReadWriteBindings[binding.first].data = binding.second.data;
 		}
@@ -315,7 +315,7 @@ class dependency_pack {
 		return cpy;
 	}
 
-	psl::array_view<psl::ecs::entity> m_Entities {};
+	psl::array_view<psl::ecs::entity_t> m_Entities {};
 	std::unordered_map<component_key_t, size_t> m_Sizes {};
 	std::unordered_map<component_key_t, psl::array_view<std::uintptr_t>> m_RBindings;
 	std::unordered_map<component_key_t, psl::array_view<std::uintptr_t>> m_RWBindings;
@@ -330,10 +330,10 @@ class dependency_pack {
 	std::vector<component_key_t> on_break {};
 
 	std::vector<std::function<psl::array<
-	  entity>::iterator(psl::array<entity>::iterator, psl::array<entity>::iterator, const psl::ecs::state_t&)>>
+	  entity_t>::iterator(psl::array<entity_t>::iterator, psl::array<entity_t>::iterator, const psl::ecs::state_t&)>>
 	  on_condition {};
 
-	std::function<void(psl::array<entity>::iterator, psl::array<entity>::iterator, const psl::ecs::state_t&)>
+	std::function<void(psl::array<entity_t>::iterator, psl::array<entity_t>::iterator, const psl::ecs::state_t&)>
 	  orderby {};
 	bool m_IsPartial  = false;
 	bool m_IsIndirect = false;

--- a/psl/inc/psl/ecs/entity.hpp
+++ b/psl/inc/psl/ecs/entity.hpp
@@ -40,20 +40,18 @@ namespace details {
 // struct entity;
 
 /// \brief entity points to a collection of components
-using entity_size_type = uint32_t;
-
-// enum class entity_t : entity_size_type {};
-
 struct entity_t {
+	// edit this value for smaller or larger entities.
+	using size_type = uint32_t;
 	constexpr entity_t() = default;
-	constexpr entity_t(entity_size_type value) noexcept : value(value) {}
+	constexpr entity_t(size_type value) noexcept : value(value) {}
 	constexpr entity_t(const entity_t& entity) noexcept			   = default;
 	constexpr entity_t& operator=(const entity_t& entity) noexcept = default;
 	constexpr entity_t(entity_t&& entity) noexcept				   = default;
 	constexpr entity_t& operator=(entity_t&& entity) noexcept	   = default;
 
-	explicit constexpr inline operator entity_size_type const&() const noexcept { return value; }
-	explicit constexpr inline operator entity_size_type&() noexcept { return value; }
+	explicit constexpr inline operator size_type const&() const noexcept { return value; }
+	explicit constexpr inline operator size_type&() noexcept { return value; }
 
 	constexpr inline friend bool operator==(entity_t const& lhs, entity_t const& rhs) noexcept {
 		return lhs.value == rhs.value;
@@ -62,16 +60,13 @@ struct entity_t {
 		return lhs.value != rhs.value;
 	}
 
-	entity_size_type value {};
+	constexpr inline operator bool() const noexcept { return value != 0; }
+
+	size_type value {};
 };
+
+static constexpr entity_t invalid_entity {0};
 
 template <typename T>
 concept IsEntity = std::is_same_v<std::remove_cvref_t<T>, entity_t>;
-
-/// \brief checks if an entity is valid or not
-/// \param[in] e the entity to check
-static constexpr bool valid(entity_t e) noexcept {
-	return static_cast<entity_size_type>(e) != entity_size_type {0};
-};
-
 }	 // namespace psl::ecs

--- a/psl/inc/psl/ecs/entity.hpp
+++ b/psl/inc/psl/ecs/entity.hpp
@@ -52,8 +52,15 @@ struct entity_t {
 	constexpr entity_t(entity_t&& entity) noexcept				   = default;
 	constexpr entity_t& operator=(entity_t&& entity) noexcept	   = default;
 
-	constexpr operator entity_size_type const&() const noexcept { return value; }
-	constexpr operator entity_size_type&() noexcept { return value; }
+	explicit constexpr inline operator entity_size_type const&() const noexcept { return value; }
+	explicit constexpr inline operator entity_size_type&() noexcept { return value; }
+
+	constexpr inline friend bool operator==(entity_t const& lhs, entity_t const& rhs) noexcept {
+		return lhs.value == rhs.value;
+	}
+	constexpr inline friend bool operator!=(entity_t const& lhs, entity_t const& rhs) noexcept {
+		return lhs.value != rhs.value;
+	}
 
 	entity_size_type value {};
 };

--- a/psl/inc/psl/ecs/entity.hpp
+++ b/psl/inc/psl/ecs/entity.hpp
@@ -42,7 +42,7 @@ namespace details {
 /// \brief entity points to a collection of components
 struct entity_t {
 	// edit this value for smaller or larger entities.
-	using size_type = uint32_t;
+	using size_type		 = uint32_t;
 	constexpr entity_t() = default;
 	constexpr entity_t(size_type value) noexcept : value(value) {}
 	constexpr entity_t(const entity_t& entity) noexcept			   = default;

--- a/psl/inc/psl/ecs/entity.hpp
+++ b/psl/inc/psl/ecs/entity.hpp
@@ -40,12 +40,31 @@ namespace details {
 // struct entity;
 
 /// \brief entity points to a collection of components
-using entity = uint32_t;
+using entity_size_type = uint32_t;
+
+// enum class entity_t : entity_size_type {};
+
+struct entity_t {
+	constexpr entity_t() = default;
+	constexpr entity_t(entity_size_type value) noexcept : value(value) {}
+	constexpr entity_t(const entity_t& entity) noexcept			   = default;
+	constexpr entity_t& operator=(const entity_t& entity) noexcept = default;
+	constexpr entity_t(entity_t&& entity) noexcept				   = default;
+	constexpr entity_t& operator=(entity_t&& entity) noexcept	   = default;
+
+	constexpr operator entity_size_type const&() const noexcept { return value; }
+	constexpr operator entity_size_type&() noexcept { return value; }
+
+	entity_size_type value {};
+};
+
+template <typename T>
+concept IsEntity = std::is_same_v<std::remove_cvref_t<T>, entity_t>;
 
 /// \brief checks if an entity is valid or not
 /// \param[in] e the entity to check
-static bool valid(entity e) noexcept {
-	return e != 0u;
+static constexpr bool valid(entity_t e) noexcept {
+	return static_cast<entity_size_type>(e) != entity_size_type {0};
 };
 
 }	 // namespace psl::ecs

--- a/psl/inc/psl/ecs/filtering.hpp
+++ b/psl/inc/psl/ecs/filtering.hpp
@@ -12,12 +12,12 @@ class state_t;
 namespace details {
 	// unlike filter_groups, transform groups are dynamic operations on every element of a filtered list
 	class transform_group {
-		using ordering_pred_t	 = void(psl::array<entity>::iterator,
-										psl::array<entity>::iterator,
+		using ordering_pred_t	 = void(psl::array<entity_t>::iterator,
+										psl::array<entity_t>::iterator,
 										const psl::ecs::state_t&);
-		using conditional_pred_t = psl::array<entity>::iterator(psl::array<entity>::iterator,
-																psl::array<entity>::iterator,
-																const psl::ecs::state_t&);
+		using conditional_pred_t = psl::array<entity_t>::iterator(psl::array<entity_t>::iterator,
+																  psl::array<entity_t>::iterator,
+																  const psl::ecs::state_t&);
 		template <typename T>
 		constexpr void selector(psl::type_pack_t<T>) noexcept {}
 
@@ -41,9 +41,9 @@ namespace details {
 		transform_group& operator=(const transform_group& other)	 = default;
 		transform_group& operator=(transform_group&& other) noexcept = default;
 
-		psl::array<entity>::iterator transform(psl::array<entity>::iterator begin,
-											   psl::array<entity>::iterator end,
-											   const state_t& state) const noexcept {
+		psl::array<entity_t>::iterator transform(psl::array<entity_t>::iterator begin,
+												 psl::array<entity_t>::iterator end,
+												 const state_t& state) const noexcept {
 			for(const auto& condition : on_condition) end = condition(begin, end, state);
 
 			if(order_by)
@@ -66,7 +66,7 @@ namespace details {
 	class filter_group {
 		template <typename T>
 		constexpr void selector(psl::type_pack_t<T>) noexcept {
-			if constexpr(!std::is_same_v<entity, T> && !IsPolicy<T> && !IsAccessType<T>)
+			if constexpr(!std::is_same_v<entity_t, T> && !IsPolicy<T> && !IsAccessType<T>)
 				filters.emplace_back(details::component_key_t::generate<T>());
 		}
 

--- a/psl/inc/psl/ecs/on_condition.hpp
+++ b/psl/inc/psl/ecs/on_condition.hpp
@@ -12,28 +12,28 @@
 
 namespace psl::ecs::details {
 template <typename Pred, typename T>
-static inline psl::array<entity>::iterator on_condition(const psl::ecs::state_t& state,
-														psl::array<entity>::iterator begin,
-														psl::array<entity>::iterator end) noexcept {
+static inline psl::array<entity_t>::iterator on_condition(const psl::ecs::state_t& state,
+														  psl::array<entity_t>::iterator begin,
+														  psl::array<entity_t>::iterator end) noexcept {
 	auto pred = Pred {};
 	if constexpr(std::is_same_v<psl::ecs::execution::parallel_unsequenced_policy, psl::ecs::execution::no_exec>) {
-		return std::remove_if(begin, end, [&state, &pred](entity lhs) -> bool { return !pred(state.get<T>(lhs)); });
+		return std::remove_if(begin, end, [&state, &pred](entity_t lhs) -> bool { return !pred(state.get<T>(lhs)); });
 	} else {
-		return std::remove_if(psl::ecs::execution::par_unseq, begin, end, [&state, &pred](entity lhs) -> bool {
+		return std::remove_if(psl::ecs::execution::par_unseq, begin, end, [&state, &pred](entity_t lhs) -> bool {
 			return !pred(state.get<T>(lhs));
 		});
 	}
 }
 
 template <typename T, typename Pred>
-psl::array<entity>::iterator static inline on_condition(const psl::ecs::state_t& state,
-														psl::array<entity>::iterator begin,
-														psl::array<entity>::iterator end,
-														Pred&& pred) noexcept {
+psl::array<entity_t>::iterator static inline on_condition(const psl::ecs::state_t& state,
+														  psl::array<entity_t>::iterator begin,
+														  psl::array<entity_t>::iterator end,
+														  Pred&& pred) noexcept {
 	if constexpr(std::is_same_v<psl::ecs::execution::parallel_unsequenced_policy, psl::ecs::execution::no_exec>) {
-		return std::remove_if(begin, end, [&state, &pred](entity lhs) -> bool { return !pred(state.get<T>(lhs)); });
+		return std::remove_if(begin, end, [&state, &pred](entity_t lhs) -> bool { return !pred(state.get<T>(lhs)); });
 	} else {
-		return std::remove_if(psl::ecs::execution::par_unseq, begin, end, [&state, &pred](entity lhs) -> bool {
+		return std::remove_if(psl::ecs::execution::par_unseq, begin, end, [&state, &pred](entity_t lhs) -> bool {
 			return !pred(state.get<T>(lhs));
 		});
 	}
@@ -41,18 +41,18 @@ psl::array<entity>::iterator static inline on_condition(const psl::ecs::state_t&
 
 template <typename Pred, typename... Ts>
 void dependency_pack::select_condition_impl(std::pair<Pred, std::tuple<Ts...>>) {
-	on_condition.push_back([](psl::array<entity>::iterator begin,
-							  psl::array<entity>::iterator end,
-							  const psl::ecs::state_t& state) -> psl::array<entity>::iterator {
+	on_condition.push_back([](psl::array<entity_t>::iterator begin,
+							  psl::array<entity_t>::iterator end,
+							  const psl::ecs::state_t& state) -> psl::array<entity_t>::iterator {
 		return psl::ecs::details::on_condition<Pred, Ts...>(state, begin, end);
 	});
 }
 
 template <typename Pred, typename T>
 void transform_group::selector(psl::type_pack_t<psl::ecs::on_condition<Pred, T>>) noexcept {
-	on_condition.emplace_back([](psl::array<entity>::iterator begin,
-								 psl::array<entity>::iterator end,
-								 const auto& state) -> psl::array<entity>::iterator {
+	on_condition.emplace_back([](psl::array<entity_t>::iterator begin,
+								 psl::array<entity_t>::iterator end,
+								 const auto& state) -> psl::array<entity_t>::iterator {
 		return psl::ecs::details::on_condition<Pred, T>(state, begin, end);
 	});
 }

--- a/psl/inc/psl/ecs/order_by.hpp
+++ b/psl/inc/psl/ecs/order_by.hpp
@@ -9,10 +9,10 @@ namespace psl::ecs::details {
 template <typename Pred, typename T>
 static inline void order_by(psl::ecs::execution::no_exec,
 							const psl::ecs::state_t& state,
-							psl::array<entity>::iterator begin,
-							psl::array<entity>::iterator end) noexcept {
+							psl::array<entity_t>::iterator begin,
+							psl::array<entity_t>::iterator end) noexcept {
 	const auto pred = Pred {};
-	std::sort(begin, end, [&state, &pred](entity lhs, entity rhs) -> bool {
+	std::sort(begin, end, [&state, &pred](entity_t lhs, entity_t rhs) -> bool {
 		return std::invoke(pred, state.get<T>(lhs), state.get<T>(rhs));
 	});
 }
@@ -20,18 +20,18 @@ static inline void order_by(psl::ecs::execution::no_exec,
 template <typename Pred, typename T>
 static inline void order_by(psl::ecs::execution::sequenced_policy,
 							const psl::ecs::state_t& state,
-							psl::array<entity>::iterator begin,
-							psl::array<entity>::iterator end) noexcept {
+							psl::array<entity_t>::iterator begin,
+							psl::array<entity_t>::iterator end) noexcept {
 	const auto pred = Pred {};
-	std::sort(psl::ecs::execution::seq, begin, end, [&state, &pred](entity lhs, entity rhs) -> bool {
+	std::sort(psl::ecs::execution::seq, begin, end, [&state, &pred](entity_t lhs, entity_t rhs) -> bool {
 		return std::invoke(pred, state.get<T>(lhs), state.get<T>(rhs));
 	});
 }
 template <typename Pred, typename T>
 static inline void order_by(psl::ecs::execution::parallel_policy,
 							const psl::ecs::state_t& state,
-							psl::array<entity>::iterator begin,
-							psl::array<entity>::iterator end,
+							psl::array<entity_t>::iterator begin,
+							psl::array<entity_t>::iterator end,
 							size_t max) noexcept {
 	auto size = std::distance(begin, end);
 	if(size <= static_cast<decltype(size)>(max)) {
@@ -52,12 +52,12 @@ static inline void order_by(psl::ecs::execution::parallel_policy,
 		const auto pred = Pred {};
 		future.wait();
 		if constexpr(std::is_same_v<psl::ecs::execution::parallel_unsequenced_policy, psl::ecs::execution::no_exec>) {
-			std::inplace_merge(begin, middle, end, [&state, &pred](entity lhs, entity rhs) -> bool {
+			std::inplace_merge(begin, middle, end, [&state, &pred](entity_t lhs, entity_t rhs) -> bool {
 				return std::invoke(pred, state.get<T>(lhs), state.get<T>(rhs));
 			});
 		} else {
 			std::inplace_merge(
-			  psl::ecs::execution::par_unseq, begin, middle, end, [&state, &pred](entity lhs, entity rhs) -> bool {
+			  psl::ecs::execution::par_unseq, begin, middle, end, [&state, &pred](entity_t lhs, entity_t rhs) -> bool {
 				  return std::invoke(pred, state.get<T>(lhs), state.get<T>(rhs));
 			  });
 		}
@@ -67,8 +67,8 @@ static inline void order_by(psl::ecs::execution::parallel_policy,
 template <typename Pred, typename T>
 static inline void order_by(psl::ecs::execution::parallel_policy,
 							const psl::ecs::state_t& state,
-							psl::array<entity>::iterator begin,
-							psl::array<entity>::iterator end) noexcept {
+							psl::array<entity_t>::iterator begin,
+							psl::array<entity_t>::iterator end) noexcept {
 	auto size		 = std::distance(begin, end);
 	auto thread_size = std::max<size_t>(1u, std::min<size_t>(std::thread::hardware_concurrency(), size % 1024u));
 	size /= thread_size;
@@ -79,22 +79,23 @@ static inline void order_by(psl::ecs::execution::parallel_policy,
 
 template <typename Pred, typename T>
 static inline void order_by(const psl::ecs::state_t& state,
-							psl::array<entity>::iterator begin,
-							psl::array<entity>::iterator end) noexcept {
+							psl::array<entity_t>::iterator begin,
+							psl::array<entity_t>::iterator end) noexcept {
 	psl::ecs::details::order_by<Pred, T>(psl::ecs::execution::seq, state, begin, end);
 }
 
 template <typename Pred, typename... Ts>
 void dependency_pack::select_ordering_impl(std::pair<Pred, std::tuple<Ts...>>) {
 	static_assert(sizeof...(Ts) == 1, "due to a bug in MSVC we cannot have deeper nested template packs");
-	orderby = [](psl::array<entity>::iterator begin, psl::array<entity>::iterator end, const psl::ecs::state_t& state) {
-		psl::ecs::details::order_by<Pred, Ts...>(psl::ecs::execution::par, state, begin, end);
-	};
+	orderby =
+	  [](psl::array<entity_t>::iterator begin, psl::array<entity_t>::iterator end, const psl::ecs::state_t& state) {
+		  psl::ecs::details::order_by<Pred, Ts...>(psl::ecs::execution::par, state, begin, end);
+	  };
 }
 
 template <typename Pred, typename T>
 void transform_group::selector(psl::type_pack_t<psl::ecs::order_by<Pred, T>>) noexcept {
-	order_by = [](psl::array<entity>::iterator begin, psl::array<entity>::iterator end, const auto& state) {
+	order_by = [](psl::array<entity_t>::iterator begin, psl::array<entity_t>::iterator end, const auto& state) {
 		psl::ecs::details::order_by<Pred, T>(psl::ecs::execution::par, state, begin, end);
 	};
 }

--- a/psl/inc/psl/ecs/pack.hpp
+++ b/psl/inc/psl/ecs/pack.hpp
@@ -202,7 +202,7 @@ namespace details {
 	template <typename... Ts>
 	class indirect_pack_view_iterator_t {
 	  public:
-		using size_type = psl::ecs::entity_size_type;
+		using size_type = psl::ecs::entity_t::size_type;
 		template <typename T>
 		using value_element_type   = indirect_array_iterator_t<T, size_type>;
 		using value_type		   = std::tuple<value_element_type<Ts>...>;
@@ -404,7 +404,7 @@ namespace details {
 
 	template <typename... Ts>
 	struct tuple_to_indirect_pack_view<std::tuple<Ts...>> {
-		using type = indirect_pack_view_t<psl::ecs::entity_size_type, Ts...>;
+		using type = indirect_pack_view_t<psl::ecs::entity_t::size_type, Ts...>;
 	};
 
 	template <typename T>
@@ -520,7 +520,7 @@ requires(!IsPolicy<Ts> && ...) class pack_t<Policy, indirect_t, Ts...> {
 };
 
 template <IsPolicy Policy, typename... Ts>
-pack_t(Policy, details::indirect_array_t<Ts, psl::ecs::entity_size_type>...) -> pack_t<Policy, indirect_t, Ts...>;
+pack_t(Policy, details::indirect_array_t<Ts, psl::ecs::entity_t::size_type>...) -> pack_t<Policy, indirect_t, Ts...>;
 
 template <IsPolicy Policy, typename... Ts>
 pack_t(Policy, psl::array_view<Ts>...) -> pack_t<Policy, direct_t, Ts...>;

--- a/psl/inc/psl/ecs/pack.hpp
+++ b/psl/inc/psl/ecs/pack.hpp
@@ -202,7 +202,7 @@ namespace details {
 	template <typename... Ts>
 	class indirect_pack_view_iterator_t {
 	  public:
-		using size_type = psl::ecs::entity;
+		using size_type = psl::ecs::entity_size_type;
 		template <typename T>
 		using value_element_type   = indirect_array_iterator_t<T, size_type>;
 		using value_type		   = std::tuple<value_element_type<Ts>...>;
@@ -404,7 +404,7 @@ namespace details {
 
 	template <typename... Ts>
 	struct tuple_to_indirect_pack_view<std::tuple<Ts...>> {
-		using type = indirect_pack_view_t<psl::ecs::entity, Ts...>;
+		using type = indirect_pack_view_t<psl::ecs::entity_size_type, Ts...>;
 	};
 
 	template <typename T>
@@ -425,7 +425,7 @@ requires(!IsPolicy<Ts> && ...) class pack_t {
 	using order_by_type	   = typename details::typelist_to_orderby_pack<Ts...>::type;
 	using policy_type	   = Policy;
 	using access_type	   = Access;
-	static constexpr bool has_entities {std::disjunction<std::is_same<psl::ecs::entity, Ts>...>::value};
+	static constexpr bool has_entities {std::disjunction<std::is_same<psl::ecs::entity_t, Ts>...>::value};
 
 	static_assert(std::tuple_size<order_by_type>::value <= 1, "multiple order_by statements make no sense");
 
@@ -472,7 +472,7 @@ requires(!IsPolicy<Ts> && ...) class pack_t<Policy, indirect_t, Ts...> {
 	using order_by_type	   = typename details::typelist_to_orderby_pack<Ts...>::type;
 	using policy_type	   = Policy;
 	using access_type	   = indirect_t;
-	static constexpr bool has_entities {std::disjunction<std::is_same<psl::ecs::entity, Ts>...>::value};
+	static constexpr bool has_entities {std::disjunction<std::is_same<psl::ecs::entity_t, Ts>...>::value};
 
 	static_assert(std::tuple_size<order_by_type>::value <= 1, "multiple order_by statements make no sense");
 
@@ -520,7 +520,7 @@ requires(!IsPolicy<Ts> && ...) class pack_t<Policy, indirect_t, Ts...> {
 };
 
 template <IsPolicy Policy, typename... Ts>
-pack_t(Policy, details::indirect_array_t<Ts, psl::ecs::entity>...) -> pack_t<Policy, indirect_t, Ts...>;
+pack_t(Policy, details::indirect_array_t<Ts, psl::ecs::entity_size_type>...) -> pack_t<Policy, indirect_t, Ts...>;
 
 template <IsPolicy Policy, typename... Ts>
 pack_t(Policy, psl::array_view<Ts>...) -> pack_t<Policy, direct_t, Ts...>;

--- a/psl/inc/psl/ecs/state.hpp
+++ b/psl/inc/psl/ecs/state.hpp
@@ -307,8 +307,11 @@ class state_t final {
 
 	psl::array<entity_t> all_entities() const noexcept {
 		auto orphans = m_Orphans;
-		psl::array_view<entity_t::size_type> orphans_view {(entity_t::size_type*)orphans.data(), orphans.size()};
-		std::sort(std::begin(orphans_view), std::end(orphans_view));
+		auto count	 = orphans.end() - orphans.begin();
+		if(count > 0) {
+			auto* data = (entity_t::size_type*)orphans.data();
+			std::sort(data, data + count);
+		}
 
 		auto orphan_it = std::begin(orphans);
 		psl::array<entity_t> result;

--- a/psl/inc/psl/ecs/state.hpp
+++ b/psl/inc/psl/ecs/state.hpp
@@ -155,7 +155,7 @@ class state_t final {
 	struct transform_result {
 		bool operator==(const transform_result& other) const noexcept { return group == other.group; }
 		psl::array<entity_t> entities;
-		psl::array<entity_t::size_type> indices;	 // used in case there is an order_by
+		psl::array<entity_t::size_type> indices;	// used in case there is an order_by
 		std::shared_ptr<details::transform_group> group;
 	};
 
@@ -221,14 +221,16 @@ class state_t final {
 	T& get(entity_t entity) {
 		// todo this should support filtering
 		auto cInfo = get_component_typed_info<T>();
-		return cInfo->entity_data().template at<T>(static_cast<entity_t::size_type>(entity), details::stage_range_t::ALL);
+		return cInfo->entity_data().template at<T>(static_cast<entity_t::size_type>(entity),
+												   details::stage_range_t::ALL);
 	}
 
 	template <typename T>
 	const T& get(entity_t entity) const noexcept {
 		// todo this should support filtering
 		auto cInfo = get_component_typed_info<T>();
-		return cInfo->entity_data().template at<T>(static_cast<entity_t::size_type>(entity), details::stage_range_t::ALL);
+		return cInfo->entity_data().template at<T>(static_cast<entity_t::size_type>(entity),
+												   details::stage_range_t::ALL);
 	}
 
 	template <typename T>

--- a/psl/src/ecs/command_buffer.cpp
+++ b/psl/src/ecs/command_buffer.cpp
@@ -5,7 +5,7 @@
 using namespace psl::ecs;
 
 command_buffer_t::command_buffer_t(const state_t& state)
-	: m_State(&state), m_First(static_cast<entity_size_type>(state.capacity())) {};
+	: m_State(&state), m_First(static_cast<entity_t::size_type>(state.capacity())) {};
 
 
 details::component_container_t*
@@ -19,7 +19,7 @@ command_buffer_t::get_component_container(const details::component_key_t& key) n
 
 // empty construction
 void command_buffer_t::add_component_impl(const details::component_key_t& key,
-										  psl::array_view<std::pair<entity_size_type, entity_size_type>> entities,
+										  psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities,
 										  size_t size) {
 	auto cInfo = get_component_container(key);
 
@@ -29,7 +29,7 @@ void command_buffer_t::add_component_impl(const details::component_key_t& key,
 
 // invocable based construction
 void command_buffer_t::add_component_impl(const details::component_key_t& key,
-										  psl::array_view<std::pair<entity_size_type, entity_size_type>> entities,
+										  psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities,
 										  size_t size,
 										  std::function<void(std::uintptr_t, size_t)> invocable) {
 	psl_assert(size != 0, "size of requested components shouldn't be 0");
@@ -45,7 +45,7 @@ void command_buffer_t::add_component_impl(const details::component_key_t& key,
 
 // prototype based construction
 void command_buffer_t::add_component_impl(const details::component_key_t& key,
-										  psl::array_view<std::pair<entity_size_type, entity_size_type>> entities,
+										  psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities,
 										  size_t size,
 										  void* prototype) {
 	psl_assert(size != 0, "size of requested components shouldn't be 0");
@@ -55,7 +55,7 @@ void command_buffer_t::add_component_impl(const details::component_key_t& key,
 	auto offset = cInfo->size();
 	cInfo->add(entities);
 	for(const auto& id_range : entities) {
-		for(auto i = static_cast<entity_size_type>(id_range.first); i < static_cast<entity_size_type>(id_range.second);
+		for(auto i = static_cast<entity_t::size_type>(id_range.first); i < static_cast<entity_t::size_type>(id_range.second);
 			++i) {
 			std::memcpy((void*)((std::uintptr_t)cInfo->data() + (offset++) * size), prototype, size);
 		}
@@ -117,7 +117,7 @@ void command_buffer_t::add_component_impl(const details::component_key_t& key,
 
 void command_buffer_t::remove_component(
   const details::component_key_t& key,
-  psl::array_view<std::pair<entity_size_type, entity_size_type>> entities) noexcept {
+  psl::array_view<std::pair<entity_t::size_type, entity_t::size_type>> entities) noexcept {
 	auto it = std::find_if(
 	  std::begin(m_Components), std::end(m_Components), [&key](const auto& cInfo) { return cInfo->id() == key; });
 	psl_assert(it != std::end(m_Components), "component info for key {} was not found", key);
@@ -147,25 +147,25 @@ void command_buffer_t::destroy(psl::array_view<entity_t> entities) noexcept {
 	// m_DestroyedEntities.insert(std::end(m_DestroyedEntities), std::begin(entities), std::end(entities));
 
 	for(auto e : entities) {
-		if(static_cast<entity_size_type>(e) < m_First) {
+		if(static_cast<entity_t::size_type>(e) < m_First) {
 			m_DestroyedEntities.emplace_back(e);
 			continue;
 		}
 		++m_Orphans;
-		m_Entities[static_cast<entity_size_type>(e)] = entity_t {m_Next};
-		m_Next										 = static_cast<entity_size_type>(e);
+		m_Entities[static_cast<entity_t::size_type>(e)] = entity_t {m_Next};
+		m_Next										 = static_cast<entity_t::size_type>(e);
 	}
 }
 
-void command_buffer_t::destroy(psl::ecs::details::indirect_array_t<entity_t, entity_size_type> entities) noexcept {
+void command_buffer_t::destroy(psl::ecs::details::indirect_array_t<entity_t, entity_t::size_type> entities) noexcept {
 	for(auto e : entities) {
-		if(static_cast<entity_size_type>(e) < m_First) {
+		if(static_cast<entity_t::size_type>(e) < m_First) {
 			m_DestroyedEntities.emplace_back(e);
 			continue;
 		}
 		++m_Orphans;
-		m_Entities[static_cast<entity_size_type>(e)] = entity_t {m_Next};
-		m_Next										 = static_cast<entity_size_type>(e);
+		m_Entities[static_cast<entity_t::size_type>(e)] = entity_t {m_Next};
+		m_Next										 = static_cast<entity_t::size_type>(e);
 	}
 }
 
@@ -176,11 +176,11 @@ void command_buffer_t::destroy(entity_t entity) noexcept {
 	}*/
 
 	m_DestroyedEntities.emplace_back(entity);
-	if(static_cast<entity_size_type>(entity) < m_First)
+	if(static_cast<entity_t::size_type>(entity) < m_First)
 		return;
 
-	m_Entities[static_cast<entity_size_type>(entity)] = entity_t {m_Next};
-	m_Next											  = static_cast<entity_size_type>(entity);
+	m_Entities[static_cast<entity_t::size_type>(entity)] = entity_t {m_Next};
+	m_Next											  = static_cast<entity_t::size_type>(entity);
 
 	++m_Orphans;
 }

--- a/psl/src/ecs/command_buffer.cpp
+++ b/psl/src/ecs/command_buffer.cpp
@@ -55,7 +55,8 @@ void command_buffer_t::add_component_impl(const details::component_key_t& key,
 	auto offset = cInfo->size();
 	cInfo->add(entities);
 	for(const auto& id_range : entities) {
-		for(auto i = static_cast<entity_t::size_type>(id_range.first); i < static_cast<entity_t::size_type>(id_range.second);
+		for(auto i = static_cast<entity_t::size_type>(id_range.first);
+			i < static_cast<entity_t::size_type>(id_range.second);
 			++i) {
 			std::memcpy((void*)((std::uintptr_t)cInfo->data() + (offset++) * size), prototype, size);
 		}
@@ -153,7 +154,7 @@ void command_buffer_t::destroy(psl::array_view<entity_t> entities) noexcept {
 		}
 		++m_Orphans;
 		m_Entities[static_cast<entity_t::size_type>(e)] = entity_t {m_Next};
-		m_Next										 = static_cast<entity_t::size_type>(e);
+		m_Next											= static_cast<entity_t::size_type>(e);
 	}
 }
 
@@ -165,7 +166,7 @@ void command_buffer_t::destroy(psl::ecs::details::indirect_array_t<entity_t, ent
 		}
 		++m_Orphans;
 		m_Entities[static_cast<entity_t::size_type>(e)] = entity_t {m_Next};
-		m_Next										 = static_cast<entity_t::size_type>(e);
+		m_Next											= static_cast<entity_t::size_type>(e);
 	}
 }
 
@@ -180,7 +181,7 @@ void command_buffer_t::destroy(entity_t entity) noexcept {
 		return;
 
 	m_Entities[static_cast<entity_t::size_type>(entity)] = entity_t {m_Next};
-	m_Next											  = static_cast<entity_t::size_type>(entity);
+	m_Next												 = static_cast<entity_t::size_type>(entity);
 
 	++m_Orphans;
 }

--- a/psl/src/ecs/state.cpp
+++ b/psl/src/ecs/state.cpp
@@ -659,7 +659,7 @@ void state_t::filter(filter_result& data, psl::array_view<entity_t> source) cons
 				psl::array_view new_source {begin, end};
 				psl::array<entity_t> diff_set {};
 				psl::array_view<entity_t::size_type> ent_view {(entity_t::size_type*)(data.entities.data()),
-															data.entities.size()};
+															   data.entities.size()};
 				psl::array_view<entity_t::size_type> source_view {(entity_t::size_type*)(source.data()), source.size()};
 				std::set_difference(std::begin(ent_view),
 									std::end(ent_view),
@@ -670,8 +670,8 @@ void state_t::filter(filter_result& data, psl::array_view<entity_t> source) cons
 
 				auto size = std::size(data.entities);
 				data.entities.insert(std::end(data.entities), begin, end);
-				ent_view =
-				  psl::array_view<entity_t::size_type> {(entity_t::size_type*)(data.entities.data()), data.entities.size()};
+				ent_view = psl::array_view<entity_t::size_type> {(entity_t::size_type*)(data.entities.data()),
+																 data.entities.size()};
 				std::inplace_merge(std::begin(ent_view), std::next(std::begin(ent_view), size), std::end(ent_view));
 			}
 		}
@@ -763,9 +763,9 @@ void state_t::execute_command_buffer(info_t& info) {
 	if(buffer.m_Entities.size() > 0) {
 		psl::array<entity_t> added_entities;
 		psl::array_view<entity_t::size_type> buf_view {(entity_t::size_type*)buffer.m_Entities.data(),
-													buffer.m_Entities.size()};
-		psl::array_view<entity_t::size_type> buf_destroyed_view {(entity_t::size_type*)buffer.m_DestroyedEntities.data(),
-															  buffer.m_DestroyedEntities.size()};
+													   buffer.m_Entities.size()};
+		psl::array_view<entity_t::size_type> buf_destroyed_view {
+		  (entity_t::size_type*)buffer.m_DestroyedEntities.data(), buffer.m_DestroyedEntities.size()};
 		std::set_difference(std::begin(buf_view),
 							std::end(buf_view),
 							std::begin(buf_destroyed_view),
@@ -793,13 +793,15 @@ void state_t::execute_command_buffer(info_t& info) {
 			m_Components[component_src->id()] = std::move(component_src);
 		} else {
 			component_dst->merge(*component_src);
-			for(auto e : component_src->entities(true)) m_ModifiedEntities.try_insert(static_cast<entity_t::size_type>(e));
+			for(auto e : component_src->entities(true))
+				m_ModifiedEntities.try_insert(static_cast<entity_t::size_type>(e));
 		}
 	}
 	auto destroyed_entities = buffer.m_DestroyedEntities;
-	auto mid				= std::partition(std::begin(destroyed_entities),
-								 std::end(destroyed_entities),
-								 [first = buffer.m_First](auto e) { return static_cast<entity_t::size_type>(e) >= first; });
+	auto mid =
+	  std::partition(std::begin(destroyed_entities), std::end(destroyed_entities), [first = buffer.m_First](auto e) {
+		  return static_cast<entity_t::size_type>(e) >= first;
+	  });
 	if(mid != std::end(destroyed_entities))
 		destroy(
 		  psl::array_view<entity_t> {&*mid, static_cast<size_t>(std::distance(mid, std::end(destroyed_entities)))});

--- a/psl/src/ecs/state.cpp
+++ b/psl/src/ecs/state.cpp
@@ -697,8 +697,8 @@ size_t state_t::prepare_data(psl::array_view<entity_t> entities, void* cache, co
 	psl_assert(
 	  std::all_of(std::begin(entities), std::end(entities), [&cInfo](auto e) { return cInfo->has_storage_for(e); }),
 	  "some components failed to have storage for the entities");
-	psl_assert(static_cast<std::uintptr_t>(cache) + (cInfo->component_size() * entities.size()) <=
-				 static_cast<std::uintptr_t>(m_Cache.data()) + m_Cache.size(),
+	psl_assert((std::uintptr_t)(cache) + (cInfo->component_size() * entities.size()) <=
+				 (std::uintptr_t)(m_Cache.data()) + m_Cache.size(),
 			   "Cache ran out of memory");
 	return cInfo->copy_to(entities, cache);
 }
@@ -707,8 +707,8 @@ size_t state_t::prepare_bindings(psl::array_view<entity_t> entities,
 								 void* cache,
 								 details::dependency_pack& dep_pack) const noexcept {
 	size_t offset_start = (std::uintptr_t)cache;
-	psl_assert(static_cast<std::uintptr_t>(cache) + (sizeof(entity_t) * entities.size()) <=
-				 static_cast<std::uintptr_t>(m_Cache.data()) + m_Cache.size(),
+	psl_assert((std::uintptr_t)(cache) + (sizeof(entity_t) * entities.size()) <=
+				 (std::uintptr_t)(m_Cache.data()) + m_Cache.size(),
 			   "Cache ran out of memory");
 	std::memcpy(cache, entities.data(), sizeof(entity_t) * entities.size());
 	dep_pack.m_Entities = psl::array_view<entity_t>(

--- a/psl/src/ecs/state.cpp
+++ b/psl/src/ecs/state.cpp
@@ -97,7 +97,7 @@ void state_t::prepare_system(std::chrono::duration<float> dTime,
 
 	if(has_partial && information.threading() == threading::par) {
 		for(auto& dep_pack : pack) {
-			psl::array_view<entity> entities;
+			psl::array_view<entity_t> entities;
 			auto group_it = std::find_if(
 			  begin(m_Filters), end(m_Filters), [filter_it](const auto& data) { return data == **filter_it; });
 			if(*transform_it) {
@@ -147,7 +147,7 @@ void state_t::prepare_system(std::chrono::duration<float> dTime,
 	} else {
 		bool has_entities = false;
 		for(auto& dep_pack : pack) {
-			psl::array_view<entity> entities;
+			psl::array_view<entity_t> entities;
 			auto group_it = std::find_if(
 			  begin(m_Filters), end(m_Filters), [filter_it](const auto& data) { return data == **filter_it; });
 			if(*transform_it) {
@@ -187,7 +187,9 @@ void state_t::tick(std::chrono::duration<float> dTime) {
 								   [](const filter_result& res) { return res.group.use_count() <= 1; }),
 					end(m_Filters));
 
-	auto modified_entities = psl::array<entity> {m_ModifiedEntities.indices()};
+	auto modified_entities =
+	  psl::array<entity_t> {(entity_t*)m_ModifiedEntities.indices().data(),
+							(entity_t*)m_ModifiedEntities.indices().data() + m_ModifiedEntities.indices().size()};
 	std::sort(std::begin(modified_entities), std::end(modified_entities));
 
 	// apply filterings
@@ -261,17 +263,18 @@ state_t::get_component_container(psl::array_view<details::component_key_t> keys)
 }
 
 // empty construction
-void state_t::add_component_impl(const details::component_key_t& key, psl::array_view<entity> entities) {
+void state_t::add_component_impl(const details::component_key_t& key, psl::array_view<entity_t> entities) {
 	auto cInfo = get_component_container(key);
 	psl_assert(cInfo != nullptr, "component info for key {} was not found", key);
 
 	cInfo->add(entities);
-	for(size_t i = 0; i < entities.size(); ++i) m_ModifiedEntities.try_insert(entities[i]);
+	for(size_t i = 0; i < entities.size(); ++i)
+		m_ModifiedEntities.try_insert(static_cast<entity_size_type>(entities[i]));
 }
 
 // prototype based construction
 void state_t::add_component_impl(const details::component_key_t& key,
-								 psl::array_view<entity> entities,
+								 psl::array_view<entity_t> entities,
 								 void* prototype,
 								 bool repeat) {
 	auto cInfo = get_component_container(key);
@@ -282,18 +285,20 @@ void state_t::add_component_impl(const details::component_key_t& key,
 	auto offset = cInfo->entities().size();
 
 	cInfo->add(entities, prototype, repeat);
-	for(size_t i = 0; i < entities.size(); ++i) m_ModifiedEntities.try_insert(entities[i]);
+	for(size_t i = 0; i < entities.size(); ++i)
+		m_ModifiedEntities.try_insert(static_cast<entity_size_type>(entities[i]));
 }
 
 
-void state_t::remove_component(const details::component_key_t& key, psl::array_view<entity> entities) noexcept {
+void state_t::remove_component(const details::component_key_t& key, psl::array_view<entity_t> entities) noexcept {
 	m_Components[key]->destroy(entities);
-	for(size_t i = 0; i < entities.size(); ++i) m_ModifiedEntities.try_insert(entities[i]);
+	for(size_t i = 0; i < entities.size(); ++i)
+		m_ModifiedEntities.try_insert(static_cast<entity_size_type>(entities[i]));
 }
 
 // consider an alias feature
 // ie: alias transform = position, rotation, scale components
-void state_t::destroy(psl::array_view<entity> entities) noexcept {
+void state_t::destroy(psl::array_view<entity_t> entities) noexcept {
 	if(entities.size() == 0)
 		return;
 
@@ -302,58 +307,60 @@ void state_t::destroy(psl::array_view<entity> entities) noexcept {
 	}
 
 	m_ToBeOrphans.insert(std::end(m_ToBeOrphans), std::begin(entities), std::end(entities));
-	for(size_t i = 0; i < entities.size(); ++i) m_ModifiedEntities.try_insert(entities[i]);
+	for(size_t i = 0; i < entities.size(); ++i)
+		m_ModifiedEntities.try_insert(static_cast<entity_size_type>(entities[i]));
 }
 
-void state_t::destroy(entity entity) noexcept {
+void state_t::destroy(entity_t entity) noexcept {
 	for(auto& [key, cInfo] : m_Components) {
 		cInfo->destroy(entity);
 	}
 	m_ToBeOrphans.emplace_back(entity);
-	m_ModifiedEntities.try_insert(entity);
+	m_ModifiedEntities.try_insert(static_cast<entity_size_type>(entity));
 }
 
-void state_t::reset(psl::array_view<entity> entities) noexcept {
+void state_t::reset(psl::array_view<entity_t> entities) noexcept {
 	for(auto& [key, cInfo] : m_Components) {
 		cInfo->destroy(entities);
 	}
 }
 
-psl::array<entity>::iterator state_t::filter_op(details::component_key_t key,
-												psl::array<entity>::iterator& begin,
-												psl::array<entity>::iterator& end) const noexcept {
+psl::array<entity_t>::iterator state_t::filter_op(details::component_key_t key,
+												  psl::array<entity_t>::iterator& begin,
+												  psl::array<entity_t>::iterator& end) const noexcept {
 	const auto cInfo = get_component_container(key);
 	return (cInfo == nullptr) ? begin
-							  : std::partition(begin, end, [cInfo](entity e) { return cInfo->has_component(e); });
+							  : std::partition(begin, end, [cInfo](entity_t e) { return cInfo->has_component(e); });
 }
 
-psl::array<entity>::iterator state_t::on_add_op(details::component_key_t key,
-												psl::array<entity>::iterator& begin,
-												psl::array<entity>::iterator& end) const noexcept {
+psl::array<entity_t>::iterator state_t::on_add_op(details::component_key_t key,
+												  psl::array<entity_t>::iterator& begin,
+												  psl::array<entity_t>::iterator& end) const noexcept {
 	const auto cInfo = get_component_container(key);
-	return (cInfo == nullptr) ? begin : std::partition(begin, end, [cInfo](entity e) { return cInfo->has_added(e); });
+	return (cInfo == nullptr) ? begin : std::partition(begin, end, [cInfo](entity_t e) { return cInfo->has_added(e); });
 }
-psl::array<entity>::iterator state_t::on_remove_op(details::component_key_t key,
-												   psl::array<entity>::iterator& begin,
-												   psl::array<entity>::iterator& end) const noexcept {
+psl::array<entity_t>::iterator state_t::on_remove_op(details::component_key_t key,
+													 psl::array<entity_t>::iterator& begin,
+													 psl::array<entity_t>::iterator& end) const noexcept {
 	const auto cInfo = get_component_container(key);
-	return (cInfo == nullptr) ? begin : std::partition(begin, end, [cInfo](entity e) { return cInfo->has_removed(e); });
+	return (cInfo == nullptr) ? begin
+							  : std::partition(begin, end, [cInfo](entity_t e) { return cInfo->has_removed(e); });
 }
-psl::array<entity>::iterator state_t::on_except_op(details::component_key_t key,
-												   psl::array<entity>::iterator& begin,
-												   psl::array<entity>::iterator& end) const noexcept {
+psl::array<entity_t>::iterator state_t::on_except_op(details::component_key_t key,
+													 psl::array<entity_t>::iterator& begin,
+													 psl::array<entity_t>::iterator& end) const noexcept {
 	auto cInfo = get_component_container(key);
 	return (cInfo == nullptr) ? end
-							  : std::partition(begin, end, [cInfo](entity e) { return !cInfo->has_component(e); });
+							  : std::partition(begin, end, [cInfo](entity_t e) { return !cInfo->has_component(e); });
 }
-psl::array<entity>::iterator state_t::on_break_op(psl::array<details::component_key_t> keys,
-												  psl::array<entity>::iterator& begin,
-												  psl::array<entity>::iterator& end) const noexcept {
+psl::array<entity_t>::iterator state_t::on_break_op(psl::array<details::component_key_t> keys,
+													psl::array<entity_t>::iterator& begin,
+													psl::array<entity_t>::iterator& end) const noexcept {
 	auto cInfos = get_component_container(psl::array_view<details::component_key_t> {keys});
 
 	return (cInfos.size() != keys.size()) ? begin :
 										  // for every entity, remove if...
-			 std::partition(begin, end, [&cInfos](entity e) {
+			 std::partition(begin, end, [&cInfos](entity_t e) {
 				 return
 				   // any of them have not had an entity removed
 				   !(!std::any_of(std::begin(cInfos),
@@ -367,12 +374,12 @@ psl::array<entity>::iterator state_t::on_break_op(psl::array<details::component_
 			 });
 }
 
-psl::array<entity>::iterator state_t::on_combine_op(psl::array<details::component_key_t> keys,
-													psl::array<entity>::iterator& begin,
-													psl::array<entity>::iterator& end) const noexcept {
+psl::array<entity_t>::iterator state_t::on_combine_op(psl::array<details::component_key_t> keys,
+													  psl::array<entity_t>::iterator& begin,
+													  psl::array<entity_t>::iterator& end) const noexcept {
 	auto cInfos = get_component_container(psl::array_view<details::component_key_t> {keys});
 
-	return (cInfos.size() != keys.size()) ? begin : std::remove_if(begin, end, [cInfos](entity e) {
+	return (cInfos.size() != keys.size()) ? begin : std::remove_if(begin, end, [cInfos](entity_t e) {
 		return !std::any_of(std::begin(cInfos), std::end(cInfos), [e](const details::component_container_t* cInfo) {
 			return cInfo->has_added(e);
 		}) || !std::all_of(std::begin(cInfos), std::end(cInfos), [e](const details::component_container_t* cInfo) {
@@ -381,7 +388,7 @@ psl::array<entity>::iterator state_t::on_combine_op(psl::array<details::componen
 	});
 }
 
-psl::array<entity> state_t::filter(const details::dependency_pack& pack, bool seed_with_previous) const noexcept {
+psl::array<entity_t> state_t::filter(const details::dependency_pack& pack, bool seed_with_previous) const noexcept {
 	auto pack_filters = pack.filters;
 	for(const auto& [key, arr] : pack.m_RBindings) pack_filters.emplace_back(key);
 	for(const auto& [key, arr] : pack.m_RWBindings) pack_filters.emplace_back(key);
@@ -418,16 +425,16 @@ psl::array<entity> state_t::filter(const details::dependency_pack& pack, bool se
 						   std::end(pack.filters),
 						   [this, &entities](auto filter) {
 							   auto cInfo = get_component_container(filter);
-							   return std::all_of(std::begin(entities), std::end(entities), [filter, &cInfo](entity e) {
-								   return cInfo->has_storage_for(e);
-							   });
+							   return std::all_of(std::begin(entities),
+												  std::end(entities),
+												  [filter, &cInfo](entity_t e) { return cInfo->has_storage_for(e); });
 						   }),
 			   "not all components had storage for all entities");
 	return entities;
 }
 
 void state_t::filter(filter_result& data, bool seed_with_previous) const noexcept {
-	std::optional<psl::array_view<entity>> source;
+	std::optional<psl::array_view<entity_t>> source;
 
 	for(auto filter : data.group->on_remove) {
 		auto cInfo = get_component_container(filter);
@@ -494,7 +501,7 @@ void state_t::filter(filter_result& data, bool seed_with_previous) const noexcep
 	}
 
 	if(source) {
-		psl::array<entity> result {source.value()};
+		psl::array<entity_t> result {source.value()};
 		auto begin = std::begin(result);
 		auto end   = std::end(result);
 
@@ -533,13 +540,13 @@ void state_t::filter(filter_result& data, bool seed_with_previous) const noexcep
 	}
 }
 
-void state_t::filter(filter_result& data, psl::array_view<entity> source) const noexcept {
+void state_t::filter(filter_result& data, psl::array_view<entity_t> source) const noexcept {
 	if(source.size() == 0) {
 		if(data.group->clear_every_frame()) {
 			data.entities.clear();
 		}
 	} else {
-		psl::array<entity> result {source};
+		psl::array<entity_t> result {source};
 		auto begin = std::begin(result);
 		auto end   = std::end(result);
 
@@ -586,7 +593,7 @@ void state_t::filter(filter_result& data, psl::array_view<entity> source) const 
 			//	for (auto& transformation : data.transformations)
 			//	{
 			//		continue;
-			//		psl::array<entity> ordered_indices(transformation.entities.size());
+			//		psl::array<entity_t> ordered_indices(transformation.entities.size());
 			//		std::iota(std::begin(ordered_indices), std::end(ordered_indices), 0);
 
 			//		auto zip = psl::zip(transformation.entities, transformation.indices, ordered_indices);
@@ -598,14 +605,14 @@ void state_t::filter(filter_result& data, psl::array_view<entity> source) const 
 			//				return lhs.get<1>() < rhs.get<1>();
 			//			});
 
-			//		std::tuple<psl::array<entity>, psl::array<entity>, psl::array<entity>> diff_set{};
+			//		std::tuple<psl::array<entity_t>, psl::array<entity_t>, psl::array<entity_t>> diff_set{};
 
 			//		// apply the normal merging operations, keeping track of index changes
 			//		std::set_difference(std::begin(zip), std::end(zip), end, std::end(result),
 			// special_inserter(diff_set),
 			//			[](const auto& lhs, const auto& rhs)
 			//			{
-			//				if constexpr (std::is_same_v<decltype(lhs), const entity&>)
+			//				if constexpr (std::is_same_v<decltype(lhs), const entity_t&>)
 			//					return rhs.get<0>() < lhs;
 			//				else
 			//					return lhs.get<0>() < rhs; });
@@ -620,7 +627,7 @@ void state_t::filter(filter_result& data, psl::array_view<entity> source) const 
 			//		auto size = ordered_indices.size();
 			//		ordered_indices.resize(ordered_indices.size() + std::distance(begin, end));
 			//		std::fill(std::next(std::begin(ordered_indices), size), std::next(std::begin(ordered_indices),
-			// std::distance(begin, end)), std::numeric_limits<entity>::max());
+			// std::distance(begin, end)), std::numeric_limits<entity_size_type>::max());
 
 			//		zip = psl::zip(transformation.entities, transformation.indices, ordered_indices);
 			//		// unwind existing entities
@@ -637,7 +644,7 @@ void state_t::filter(filter_result& data, psl::array_view<entity> source) const 
 			// else
 			{
 				psl::array_view new_source {begin, end};
-				psl::array<entity> diff_set {};
+				psl::array<entity_t> diff_set {};
 				std::set_difference(std::begin(data.entities),
 									std::end(data.entities),
 									std::begin(source),
@@ -660,12 +667,12 @@ void state_t::filter(filter_result& data, psl::array_view<entity> source) const 
 							   auto cInfo = get_component_container(filter);
 							   return std::all_of(std::begin(data.entities),
 												  std::end(data.entities),
-												  [filter, &cInfo](entity e) { return cInfo->has_storage_for(e); });
+												  [filter, &cInfo](entity_t e) { return cInfo->has_storage_for(e); });
 						   }),
 			   "some components failed to have storage for the entities");
 }
 
-size_t state_t::prepare_data(psl::array_view<entity> entities, void* cache, component_key_t id) const noexcept {
+size_t state_t::prepare_data(psl::array_view<entity_t> entities, void* cache, component_key_t id) const noexcept {
 	if(entities.size() == 0)
 		return 0;
 	const auto& cInfo = get_component_container(id);
@@ -679,18 +686,18 @@ size_t state_t::prepare_data(psl::array_view<entity> entities, void* cache, comp
 	return cInfo->copy_to(entities, cache);
 }
 
-size_t state_t::prepare_bindings(psl::array_view<entity> entities,
+size_t state_t::prepare_bindings(psl::array_view<entity_t> entities,
 								 void* cache,
 								 details::dependency_pack& dep_pack) const noexcept {
 	size_t offset_start = (std::uintptr_t)cache;
-	psl_assert(static_cast<std::uintptr_t>(cache) + (sizeof(entity) * entities.size()) <=
+	psl_assert(static_cast<std::uintptr_t>(cache) + (sizeof(entity_t) * entities.size()) <=
 				 static_cast<std::uintptr_t>(m_Cache.data()) + m_Cache.size(),
 			   "Cache ran out of memory");
-	std::memcpy(cache, entities.data(), sizeof(entity) * entities.size());
-	dep_pack.m_Entities =
-	  psl::array_view<entity>((entity*)cache, (entity*)((std::uintptr_t)cache + (sizeof(entity) * entities.size())));
+	std::memcpy(cache, entities.data(), sizeof(entity_t) * entities.size());
+	dep_pack.m_Entities = psl::array_view<entity_t>(
+	  (entity_t*)cache, (entity_t*)((std::uintptr_t)cache + (sizeof(entity_t) * entities.size())));
 
-	cache = (void*)((std::uintptr_t)cache + (sizeof(entity) * entities.size()));
+	cache = (void*)((std::uintptr_t)cache + (sizeof(entity_t) * entities.size()));
 
 	if(dep_pack.is_direct_access()) {
 		// this functional handles filling in the cache with the data for the given component
@@ -723,7 +730,7 @@ size_t state_t::prepare_bindings(psl::array_view<entity> entities,
 	return (std::uintptr_t)cache - offset_start;
 }
 
-size_t state_t::set(psl::array_view<entity> entities, const details::component_key_t& key, void* data) noexcept {
+size_t state_t::set(psl::array_view<entity_t> entities, const details::component_key_t& key, void* data) noexcept {
 	if(entities.size() == 0)
 		return 0;
 	const auto& cInfo = get_component_container(key);
@@ -735,9 +742,9 @@ size_t state_t::set(psl::array_view<entity> entities, const details::component_k
 void state_t::execute_command_buffer(info_t& info) {
 	auto& buffer = info.command_buffer;
 
-	psl::sparse_array<entity> remapped_entities;
+	psl::sparse_array<entity_size_type> remapped_entities;
 	if(buffer.m_Entities.size() > 0) {
-		psl::array<entity> added_entities;
+		psl::array<entity_t> added_entities;
 		std::set_difference(std::begin(buffer.m_Entities),
 							std::end(buffer.m_Entities),
 							std::begin(buffer.m_DestroyedEntities),
@@ -746,7 +753,7 @@ void state_t::execute_command_buffer(info_t& info) {
 
 
 		for(auto e : added_entities) {
-			remapped_entities[e] = create();
+			remapped_entities[e] = static_cast<entity_size_type>(create());
 		}
 	}
 	for(auto& component_src : buffer.m_Components) {
@@ -754,16 +761,16 @@ void state_t::execute_command_buffer(info_t& info) {
 			continue;
 		auto component_dst = get_component_container(component_src->id());
 
-		component_src->remap(remapped_entities, [first = buffer.m_First](entity e) -> bool { return e >= first; });
+		component_src->remap(remapped_entities, [first = buffer.m_First](entity_t e) -> bool { return e >= first; });
 		if(component_dst == nullptr) {
 			auto entities = component_src->entities(true);
 			for(auto e : entities) {
-				m_ModifiedEntities.try_insert(e);
+				m_ModifiedEntities.try_insert(static_cast<entity_size_type>(e));
 			}
 			m_Components[component_src->id()] = std::move(component_src);
 		} else {
 			component_dst->merge(*component_src);
-			for(auto e : component_src->entities(true)) m_ModifiedEntities.try_insert(e);
+			for(auto e : component_src->entities(true)) m_ModifiedEntities.try_insert(static_cast<entity_size_type>(e));
 		}
 	}
 	auto destroyed_entities = buffer.m_DestroyedEntities;
@@ -771,7 +778,8 @@ void state_t::execute_command_buffer(info_t& info) {
 								 std::end(destroyed_entities),
 								 [first = buffer.m_First](auto e) { return e >= first; });
 	if(mid != std::end(destroyed_entities))
-		destroy(psl::array_view<entity> {&*mid, static_cast<size_t>(std::distance(mid, std::end(destroyed_entities)))});
+		destroy(
+		  psl::array_view<entity_t> {&*mid, static_cast<size_t>(std::distance(mid, std::end(destroyed_entities)))});
 }
 
 

--- a/psl/src/ecs/state.cpp
+++ b/psl/src/ecs/state.cpp
@@ -658,21 +658,19 @@ void state_t::filter(filter_result& data, psl::array_view<entity_t> source) cons
 			{
 				psl::array_view new_source {begin, end};
 				psl::array<entity_t> diff_set {};
-				psl::array_view<entity_t::size_type> ent_view {(entity_t::size_type*)(data.entities.data()),
-															   data.entities.size()};
-				psl::array_view<entity_t::size_type> source_view {(entity_t::size_type*)(source.data()), source.size()};
-				std::set_difference(std::begin(ent_view),
-									std::end(ent_view),
-									std::begin(source_view),
-									std::end(source_view),
+				std::set_difference((entity_t::size_type*)(data.entities.data()),
+									(entity_t::size_type*)(data.entities.data()) + data.entities.size(),
+									(entity_t::size_type*)(source.data()),
+									(entity_t::size_type*)(source.data()) + source.size(),
 									std::back_inserter(diff_set));
 				data.entities = std::move(diff_set);
 
 				auto size = std::size(data.entities);
 				data.entities.insert(std::end(data.entities), begin, end);
-				ent_view = psl::array_view<entity_t::size_type> {(entity_t::size_type*)(data.entities.data()),
-																 data.entities.size()};
-				std::inplace_merge(std::begin(ent_view), std::next(std::begin(ent_view), size), std::end(ent_view));
+
+				std::inplace_merge((entity_t::size_type*)(data.entities.data()),
+								   (entity_t::size_type*)(data.entities.data()) + size,
+								   (entity_t::size_type*)(data.entities.data()) + data.entities.size());
 			}
 		}
 	}
@@ -762,14 +760,11 @@ void state_t::execute_command_buffer(info_t& info) {
 	psl::sparse_array<entity_t::size_type> remapped_entities;
 	if(buffer.m_Entities.size() > 0) {
 		psl::array<entity_t> added_entities;
-		psl::array_view<entity_t::size_type> buf_view {(entity_t::size_type*)buffer.m_Entities.data(),
-													   buffer.m_Entities.size()};
-		psl::array_view<entity_t::size_type> buf_destroyed_view {
-		  (entity_t::size_type*)buffer.m_DestroyedEntities.data(), buffer.m_DestroyedEntities.size()};
-		std::set_difference(std::begin(buf_view),
-							std::end(buf_view),
-							std::begin(buf_destroyed_view),
-							std::end(buf_destroyed_view),
+		std::set_difference((entity_t::size_type*)(buffer.m_Entities.data()),
+							(entity_t::size_type*)(buffer.m_Entities.data()) + buffer.m_Entities.size(),
+							(entity_t::size_type*)(buffer.m_DestroyedEntities.data()),
+							(entity_t::size_type*)(buffer.m_DestroyedEntities.data()) +
+							  buffer.m_DestroyedEntities.size(),
 							std::back_inserter(added_entities));
 
 

--- a/tests/src/ecs.cpp
+++ b/tests/src/ecs.cpp
@@ -101,14 +101,14 @@ auto t0 = suite<"component_info", "ecs", "psl">().templates<float_tpack>() = []<
 		auto& cInfo = *details::cast_component_container<type>(cInfoPtr.get());
 
 		section<"additions">() = [&]() {
-			psl::array<entity> entities;
+			psl::array<entity_t> entities;
 			entities.resize(100);
-			std::iota(std::begin(entities), std::end(entities), entity {0});
+			std::iota(std::begin(entities), std::end(entities), entity_size_type {0});
 			cInfo.add(entities);
 			require(cInfo.size()) == entities.size();
 			require(cInfo.added_entities().size()) == entities.size();
-			std::for_each(std::begin(entities), std::end(entities), [&cInfo](entity e) { cInfo.set(e, type(e)); });
-			std::for_each(std::begin(entities), std::end(entities), [&cInfo](entity e) {
+			std::for_each(std::begin(entities), std::end(entities), [&cInfo](entity_t e) { cInfo.set(e, type(e)); });
+			std::for_each(std::begin(entities), std::end(entities), [&cInfo](entity_t e) {
 				require(cInfo.has_component(e));
 				require(cInfo.has_added(e));
 				require(cInfo.entity_data().template at<type>(e)) == type(e);
@@ -120,13 +120,13 @@ auto t0 = suite<"component_info", "ecs", "psl">().templates<float_tpack>() = []<
 				std::shuffle(std::begin(entities), std::end(entities), g);
 
 				auto count = entities.size() / 10;
-				for(entity c = 0; c < 10; ++c) {
+				for(entity_size_type c = 0; c < 10; ++c) {
 					for(auto i = 0; i < count; ++i) {
 						auto index = c * 10 + i;
 						cInfo.destroy(entities[index]);
 					}
 
-					for(entity i = 0; i < static_cast<entity>(entities.size()); ++i) {
+					for(entity_size_type i = 0; i < static_cast<entity_size_type>(entities.size()); ++i) {
 						if(i < (c + 1) * 10) {
 							auto index = entities[i];
 							require(!cInfo.has_component(index));
@@ -148,36 +148,46 @@ auto t0 = suite<"component_info", "ecs", "psl">().templates<float_tpack>() = []<
 		section<"remap">() = [&]() {
 			auto cInfo2Ptr {details::instantiate_component_container<type>()};
 			auto& cInfo2 = *details::cast_component_container<type>(cInfo2Ptr.get());
-			psl::array<entity> entities;
+			psl::array<entity_t> entities;
 			entities.resize(100);
-			std::iota(std::begin(entities), std::end(entities), entity {0});
+			std::iota(std::begin(entities), std::end(entities), entity_size_type {0});
 			cInfo.add(entities);
 			cInfo2.add(entities);
 
-			std::for_each(std::begin(entities), std::end(entities), [&cInfo](entity e) { cInfo.set(e, type(e)); });
+			std::for_each(std::begin(entities), std::end(entities), [&cInfo](entity_t e) {
+				cInfo.set(e, type(static_cast<entity_size_type>(e)));
+			});
 
-			std::for_each(
-			  std::begin(entities),
-			  std::end(entities),
-			  [&cInfo2, offset = static_cast<entity>(cInfo.size())](entity e) { cInfo2.set(e, type(e + offset)); });
-
-			psl::sparse_array<entity> remap;
 			std::for_each(std::begin(entities),
 						  std::end(entities),
-						  [&remap, offset = static_cast<entity>(cInfo.size())](entity e) { remap[e] = e + offset; });
-			cInfo2.remap(remap, [offset = static_cast<entity>(cInfo.size())](entity e) { return e < offset; });
+						  [&cInfo2, offset = static_cast<entity_size_type>(cInfo.size())](entity_t e) {
+							  cInfo2.set(e, type(e + offset));
+						  });
+
+			psl::sparse_array<entity_size_type> remap;
+			std::for_each(std::begin(entities),
+						  std::end(entities),
+						  [&remap, offset = static_cast<entity_size_type>(cInfo.size())](entity_t e) {
+							  remap[e] = entity_t {static_cast<entity_size_type>(e) + offset};
+						  });
+			cInfo2.remap(remap, [offset = static_cast<entity_size_type>(cInfo.size())](entity_t e) {
+				return static_cast<entity_size_type>(e) < offset;
+			});
 			std::for_each(std::begin(cInfo2.entities()),
 						  std::end(cInfo2.entities()),
-						  [offset = static_cast<entity>(cInfo.size())](entity e) { require(e) >= offset; });
+						  [offset = static_cast<entity_size_type>(cInfo.size())](entity_t e) {
+							  require(static_cast<entity_size_type>(e)) >= offset;
+						  });
 			section<"merge">() = [&]() {
 				auto orig_size = cInfo.size();
 				cInfo.merge(cInfo2);
 				require(cInfo.size()) == orig_size + cInfo2.size();
 				std::for_each(std::begin(cInfo.entities()),
 							  std::end(cInfo.entities()),
-							  [&cInfo, offset = static_cast<entity>(cInfo.size())](entity e) {
-								  require(e) <= offset;
-								  require(cInfo.entity_data().template operator[]<type>(e)) == type(e);
+							  [&cInfo, offset = static_cast<entity_size_type>(cInfo.size())](entity_t e) {
+								  require(static_cast<entity_size_type>(e)) <= offset;
+								  require(cInfo.entity_data().template operator[]<type>(e)) ==
+									type(static_cast<entity_size_type>(e));
 							  });
 			};
 		};
@@ -208,9 +218,9 @@ auto t2 = suite<"filtering", "ecs", "psl">()
 			.templates<tpack<float, complex_wrapper_float, flag_type>, policy_tpack, access_tpack>() =
   []<typename type, typename policy, typename access>() {
 	  state_t state;
-	  auto e_list1 {state.create(100)};
-	  auto e_list2 {state.create(400)};
-	  auto e_list3 {state.create(500)};
+	  auto e_list1 {state.create(static_cast<entity_size_type>(100))};
+	  auto e_list2 {state.create(static_cast<entity_size_type>(400))};
+	  auto e_list3 {state.create(static_cast<entity_size_type>(500))};
 
 
 	  section<"only the first 100 are given all components">() = [&]() {
@@ -244,8 +254,8 @@ auto t2 = suite<"filtering", "ecs", "psl">()
 		  require(f.size()) == e_list1.size();
 		  require(std::equal(std::begin(f), std::end(f), std::begin(e_list1)));
 
-		  f								  = state.filter<size_t, char>();
-		  std::vector<entity> combination = e_list1;
+		  f									= state.filter<size_t, char>();
+		  std::vector<entity_t> combination = e_list1;
 		  combination.reserve(e_list1.size() + e_list3.size());
 		  combination.insert(std::end(combination), std::begin(e_list3), std::end(e_list3));
 		  require(std::equal(std::begin(f), std::end(f), std::begin(combination)));
@@ -256,9 +266,9 @@ auto t2 = suite<"filtering", "ecs", "psl">()
 	  };
 
 	  section<"filtering components that are non-contiguous">() = [&]() {
-		  state.create<type, size_t>(500);
+		  state.create<type, size_t>(static_cast<entity_size_type>(500));
 		  state.destroy(1200);
-		  auto entities = state.create<type, size_t>(3);
+		  auto entities = state.create<type, size_t>(static_cast<entity_size_type>(3));
 
 		  require(entities.size()) == 3;
 		  require(entities[0]) == 1500;
@@ -334,7 +344,7 @@ auto t3 = suite<"initializing components", "ecs", "psl">().templates<float_tpack
 
 	size_t count {0};
 	state.create(
-	  50,
+	  static_cast<entity_size_type>(50),
 	  [&count](position& i) {
 		  i = {++count, 0};
 	  },
@@ -362,17 +372,17 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 	  state_t state;
 
 	  section<"lifetime test">() = [&]() {
-		  auto e_list1 {state.create(10)};
-		  auto e_list2 {state.create(40)};
-		  auto e_list3 {state.create(50)};
+		  auto e_list1 {state.create(static_cast<entity_size_type>(10))};
+		  auto e_list2 {state.create(static_cast<entity_size_type>(40))};
+		  auto e_list3 {state.create(static_cast<entity_size_type>(50))};
 		  // pre-tick #1
 		  // we add int components to all elements in e_list1, by giving them an incrementing value
 		  // thanks to these being the first entities, they overlap with their ID
 		  size_t incrementer = 0;
 		  state.add_components(e_list1, [&incrementer](type& target) { target = type(incrementer++); });
 
-		  state.declare([](psl::ecs::info_t& info, pack_t<policy, access, entity, filter<type>> pack) {
-			  info.command_buffer.destroy(pack.template get<entity>());
+		  state.declare([](psl::ecs::info_t& info, pack_t<policy, access, entity_t, filter<type>> pack) {
+			  info.command_buffer.destroy(pack.template get<entity_t>());
 		  });
 
 		  size_t total_pack1 {0};
@@ -381,9 +391,9 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 		  std::mutex lock {};
 
 		  auto token = state.declare(
-			[&lock, &total_pack1](psl::ecs::info_t& info, pack_t<policy, access, entity, const type> pack1) {
+			[&lock, &total_pack1](psl::ecs::info_t& info, pack_t<policy, access, entity_t, const type> pack1) {
 				for(auto [e, i] : pack1) {
-					require(e) == i;
+					require(static_cast<entity_size_type>(e)) == i;
 				}
 
 				std::lock_guard<std::mutex> guard(lock);
@@ -421,14 +431,14 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 
 		  token = state.declare(
 			[&lock, &total_pack1, &total_pack2](psl::ecs::info_t& info,
-												pack_t<policy, access, entity, const type, on_remove<type>> pack1,
-												pack_t<policy, access, entity, const type, filter<type>> pack2) {
+												pack_t<policy, access, entity_t, const type, on_remove<type>> pack1,
+												pack_t<policy, access, entity_t, const type, filter<type>> pack2) {
 				for(auto [e, i] : pack1) {
 					require(e) == i;
 				}
-				require(pack1.template get<entity>()[0]) == 0;
+				require(static_cast<entity_size_type>(pack1.template get<entity_t>()[0])) == 0;
 				// if this shows 0, then the previous deleted components of tick #1 are still present
-				require(pack2.template get<entity>()[0]) == 10;
+				require(static_cast<entity_size_type>(pack2.template get<entity_t>()[0])) == 10;
 				for(auto [e, i] : pack2) {
 					require(e) == i;
 				}
@@ -453,8 +463,8 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 		  require(e_list2.size()) == state.filter<on_remove<type>>().size();
 		  require(0) == state.filter<type>().size();
 		  token = state.declare([&lock, &total_pack2](psl::ecs::info_t& info,
-													  pack_t<policy, access, entity, on_remove<type>> pack1,
-													  pack_t<policy, access, entity, filter<type>> pack2) {
+													  pack_t<policy, access, entity_t, on_remove<type>> pack1,
+													  pack_t<policy, access, entity_t, filter<type>> pack2) {
 			  std::lock_guard<std::mutex> guard(lock);
 			  total_pack2 += pack1.size();
 
@@ -483,7 +493,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 	  };
 
 	  section<"continuous removal from within systems">() = [&]() {
-		  auto e_list2 {state.create(40)};
+		  auto e_list2 {state.create(static_cast<entity_size_type>(40))};
 		  psl::array<type> values;
 		  values.resize(e_list2.size());
 		  std::iota(std::begin(values), std::end(values), 0);
@@ -493,9 +503,9 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 
 		  std::mutex lock {};
 
-		  state.declare([&expected, &lock](psl::ecs::info_t& info, pack_t<policy, access, entity, type> pack) {
+		  state.declare([&expected, &lock](psl::ecs::info_t& info, pack_t<policy, access, entity_t, type> pack) {
 			  size_t removed {0};
-			  psl::array<entity> entities;
+			  psl::array<entity_t> entities;
 			  for(auto [e, i] : pack) {
 				  require(type(e)) == i;
 				  if(std::rand() % 2 == 0) {
@@ -514,7 +524,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 
 
 	  section<"continuous removal from external">() = [&]() {
-		  auto e_list2 {state.create(40)};
+		  auto e_list2 {state.create(static_cast<entity_size_type>(40))};
 		  psl::array<type> values;
 		  values.resize(e_list2.size());
 		  std::iota(std::begin(values), std::end(values), 0);
@@ -524,9 +534,9 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 		  size_t total = 0;
 		  std::mutex lock {};
 
-		  state.declare([&total, &lock](psl::ecs::info_t& info, pack_t<policy, access, entity, type> pack) {
+		  state.declare([&total, &lock](psl::ecs::info_t& info, pack_t<policy, access, entity_t, type> pack) {
 			  for(auto [e, i] : pack) {
-				  require(type(e)) == i;
+				  require(type(static_cast<entity_size_type>(e))) == i;
 			  }
 			  std::lock_guard<std::mutex> guard(lock);
 			  total += pack.size();
@@ -539,28 +549,28 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 			  total	   = 0;
 			  auto mid = std::partition(std::begin(e_list2), std::end(e_list2), [](auto e) { return std::rand() % 2; });
 			  state.remove_components<type>(
-				psl::array_view<entity> {mid, static_cast<size_t>(std::distance(mid, std::end(e_list2)))});
+				psl::array_view<entity_t> {mid, static_cast<size_t>(std::distance(mid, std::end(e_list2)))});
 			  expected -= std::distance(mid, std::end(e_list2));
 			  e_list2.erase(mid, std::end(e_list2));
 		  }
 	  };
 
 	  section<"continuous addition from within systems">() = [&]() {
-		  auto e_list2 {state.create(40)};
+		  auto e_list2 {state.create(static_cast<entity_size_type>(40))};
 		  psl::array<type> values;
 		  values.resize(e_list2.size());
 		  std::iota(std::begin(values), std::end(values), 0);
 		  state.add_components<type>(e_list2, values);
 		  auto expected = e_list2.size();
 
-		  state.declare([&expected](psl::ecs::info_t& info, pack_t<psl::ecs::full_t, access, entity, type> pack) {
+		  state.declare([&expected](psl::ecs::info_t& info, pack_t<psl::ecs::full_t, access, entity_t, type> pack) {
 			  require(pack.size()) == expected;
 
 			  for(auto [e, i] : pack) {
-				  require(type(e)) == i;
+				  require(type(static_cast<entity_size_type>(e))) == i;
 			  }
-			  auto new_count			  = std::rand() % 20;
-			  psl::array<entity> entities = info.command_buffer.create(new_count);
+			  auto new_count				= static_cast<entity_size_type>(std::rand() % 20);
+			  psl::array<entity_t> entities = info.command_buffer.create(new_count);
 			  psl::array<type> values;
 			  values.resize(entities.size());
 			  std::iota(std::begin(values), std::end(values), type(expected));
@@ -574,7 +584,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 	  };
 
 	  section<"continuous addition from external">() = [&]() {
-		  auto e_list2 {state.create(40)};
+		  auto e_list2 {state.create(static_cast<entity_size_type>(40))};
 		  {
 			  psl::array<type> values;
 			  values.resize(e_list2.size());
@@ -586,9 +596,9 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 		  size_t total = 0;
 		  std::mutex lock {};
 
-		  state.declare([&total, &lock](psl::ecs::info_t& info, pack_t<policy, access, entity, type> pack) {
+		  state.declare([&total, &lock](psl::ecs::info_t& info, pack_t<policy, access, entity_t, type> pack) {
 			  for(auto [e, i] : pack) {
-				  require(type(e)) == i;
+				  require(type(static_cast<entity_size_type>(e))) == i;
 			  }
 			  std::lock_guard<std::mutex> guard(lock);
 			  total += pack.size();
@@ -599,8 +609,8 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 			  require(total) == expected;
 			  total = 0;
 
-			  auto new_count			  = std::rand() % 20;
-			  psl::array<entity> entities = state.create(new_count);
+			  auto new_count				= static_cast<entity_size_type>(std::rand() % 20);
+			  psl::array<entity_t> entities = state.create(new_count);
 			  psl::array<type> values;
 			  values.resize(entities.size());
 			  std::iota(std::begin(values), std::end(values), type(expected));
@@ -610,9 +620,9 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 	  };
 
 	  section<"simple iterations test">() = [&]() {
-		  auto e_list1 {state.create(10)};
-		  auto e_list2 {state.create(40)};
-		  auto e_list3 {state.create(50)};
+		  auto e_list1 {state.create(static_cast<entity_size_type>(10))};
+		  auto e_list2 {state.create(static_cast<entity_size_type>(40))};
+		  auto e_list3 {state.create(static_cast<entity_size_type>(50))};
 		  state.add_components<float>(e_list1);
 		  state.add_components<type>(e_list1);
 		  auto system_id = state.declare(float_iteration_test<policy, access>);
@@ -654,7 +664,7 @@ auto t7 =
 
 		  size_t count = 0;
 		  std::mutex lock {};
-		  state.declare([&](info_t& info, pack_t<policy, access, entity, type> pack) {
+		  state.declare([&](info_t& info, pack_t<policy, access, entity_t, type> pack) {
 			  if(pack.empty())
 				  return;
 			  info.command_buffer.add_components<int>(pack, {0});
@@ -663,7 +673,7 @@ auto t7 =
 			  count += pack.size();
 		  });
 
-		  auto entities = state.create<type>(1);
+		  auto entities = state.create<type>(static_cast<entity_size_type>(1));
 		  expect(state.filter<on_add<type>>().size()) == 1;
 		  state.tick(std::chrono::duration<float>(1.0f));
 		  expect(state.filter<type>().size()) == 1;
@@ -684,8 +694,8 @@ auto t7 =
 		  // reason: filtering operation that was based on existing filters did not correctly
 		  //         use the already filtered entity list
 
-		  auto entities0 = state.create<type>(1);
-		  auto entities1 = state.create(1);
+		  auto entities0 = state.create<type>(static_cast<entity_size_type>(1));
+		  auto entities1 = state.create(static_cast<entity_size_type>(1));
 		  state.remove_components<type>(entities0);
 		  expect(state.filter<type>().size()) == 0;
 		  expect(state.filter<on_remove<type>>().size()) == 1;
@@ -693,9 +703,9 @@ auto t7 =
 		  expect(state.filter<type>().size()) == 1;
 		  expect(state.filter<on_add<type>>().size()) == 1;
 		  expect(state.filter<on_remove<type>>().size()) == 1;
-		  state.declare([&](info_t& info, pack_t<psl::ecs::full_t, access, entity, type> pack) {
+		  state.declare([&](info_t& info, pack_t<psl::ecs::full_t, access, entity_t, type> pack) {
 			  expect(pack.size()) == 1;
-			  expect(pack.template get<entity>()[0]) == 1;
+			  expect(static_cast<entity_size_type>(pack.template get<entity_t>()[0])) == 1;
 		  });
 		  state.tick(std::chrono::duration<float>(1.0f));
 		  expect(state.filter<type>().size()) == 1;
@@ -730,7 +740,7 @@ auto t8 = suite<"component_key name matches expected", "ecs", "psl">() = []() {
 auto t9 = suite<"ecs state serialization", "ecs", "psl">() = []() {
 	psl::ecs::state_t state_a {}, state_b {};
 	int counter {0};
-	state_a.create(200, [&counter](int& value) { value = counter++; });
+	state_a.create(static_cast<entity_size_type>(200), [&counter](int& value) { value = counter++; });
 	state_a.override_serialization<int>(true);
 
 	psl::serialization::serializer serializer {};
@@ -764,7 +774,7 @@ struct foo {
 
 auto t10 = suite<"ecs prototype support", "ecs", "psl">() = []() {
 	psl::ecs::state_t state {};
-	auto entity = state.create<foo>(1);
+	auto entity = state.create<foo>(static_cast<entity_size_type>(1));
 	require(state.get<foo>(entity[0]).value) == 10;
 };
 }	 // namespace

--- a/tests/src/ecs.cpp
+++ b/tests/src/ecs.cpp
@@ -103,18 +103,18 @@ auto t0 = suite<"component_info", "ecs", "psl">().templates<float_tpack>() = []<
 		section<"additions">() = [&]() {
 			psl::array<entity_t> entities;
 			entities.resize(100);
-			std::iota(std::begin(entities), std::end(entities), entity_size_type {0});
+			std::iota(std::begin(entities), std::end(entities), entity_t::size_type {0});
 			cInfo.add(entities);
 			require(cInfo.size()) == entities.size();
 			require(cInfo.added_entities().size()) == entities.size();
 			std::for_each(std::begin(entities), std::end(entities), [&cInfo](entity_t e) {
-				cInfo.set(e, type(static_cast<entity_size_type>(e)));
+				cInfo.set(e, type(static_cast<entity_t::size_type>(e)));
 			});
 			std::for_each(std::begin(entities), std::end(entities), [&cInfo](entity_t e) {
 				require(cInfo.has_component(e));
 				require(cInfo.has_added(e));
-				require(cInfo.entity_data().template at<type>(static_cast<entity_size_type>(e))) ==
-				  type(static_cast<entity_size_type>(e));
+				require(cInfo.entity_data().template at<type>(static_cast<entity_t::size_type>(e))) ==
+				  type(static_cast<entity_t::size_type>(e));
 			});
 
 			section<"removals">() = [&]() {
@@ -123,25 +123,25 @@ auto t0 = suite<"component_info", "ecs", "psl">().templates<float_tpack>() = []<
 				std::shuffle(std::begin(entities), std::end(entities), g);
 
 				auto count = entities.size() / 10;
-				for(entity_size_type c = 0; c < 10; ++c) {
+				for(entity_t::size_type c = 0; c < 10; ++c) {
 					for(auto i = 0; i < count; ++i) {
 						auto index = c * 10 + i;
 						cInfo.destroy(entities[index]);
 					}
 
-					for(entity_size_type i = 0; i < static_cast<entity_size_type>(entities.size()); ++i) {
+					for(entity_t::size_type i = 0; i < static_cast<entity_t::size_type>(entities.size()); ++i) {
 						if(i < (c + 1) * 10) {
 							auto index = entities[i];
 							require(!cInfo.has_component(index));
 							require(cInfo.has_removed(index));
-							require(cInfo.entity_data().template at<type>(static_cast<entity_size_type>(index),
+							require(cInfo.entity_data().template at<type>(static_cast<entity_t::size_type>(index),
 																		  details::stage_range_t::REMOVED)) ==
-							  type(static_cast<entity_size_type>(index));
+							  type(static_cast<entity_t::size_type>(index));
 						} else {
 							auto index = entities[i];
 							require(cInfo.has_component(index));
-							require(cInfo.entity_data().template at<type>(static_cast<entity_size_type>(index))) ==
-							  type(static_cast<entity_size_type>(index));
+							require(cInfo.entity_data().template at<type>(static_cast<entity_t::size_type>(index))) ==
+							  type(static_cast<entity_t::size_type>(index));
 						}
 					}
 				}
@@ -155,33 +155,33 @@ auto t0 = suite<"component_info", "ecs", "psl">().templates<float_tpack>() = []<
 			auto& cInfo2 = *details::cast_component_container<type>(cInfo2Ptr.get());
 			psl::array<entity_t> entities;
 			entities.resize(100);
-			std::iota(std::begin(entities), std::end(entities), entity_size_type {0});
+			std::iota(std::begin(entities), std::end(entities), entity_t::size_type {0});
 			cInfo.add(entities);
 			cInfo2.add(entities);
 
 			std::for_each(std::begin(entities), std::end(entities), [&cInfo](entity_t e) {
-				cInfo.set(e, type(static_cast<entity_size_type>(e)));
+				cInfo.set(e, type(static_cast<entity_t::size_type>(e)));
 			});
 
 			std::for_each(std::begin(entities),
 						  std::end(entities),
-						  [&cInfo2, offset = static_cast<entity_size_type>(cInfo.size())](entity_t e) {
-							  cInfo2.set(e, type(static_cast<entity_size_type>(e) + offset));
+						  [&cInfo2, offset = static_cast<entity_t::size_type>(cInfo.size())](entity_t e) {
+							  cInfo2.set(e, type(static_cast<entity_t::size_type>(e) + offset));
 						  });
 
-			psl::sparse_array<entity_size_type> remap;
+			psl::sparse_array<entity_t::size_type> remap;
 			std::for_each(std::begin(entities),
 						  std::end(entities),
-						  [&remap, offset = static_cast<entity_size_type>(cInfo.size())](entity_t e) {
-							  remap[static_cast<entity_size_type>(e)] = static_cast<entity_size_type>(e) + offset;
+						  [&remap, offset = static_cast<entity_t::size_type>(cInfo.size())](entity_t e) {
+							  remap[static_cast<entity_t::size_type>(e)] = static_cast<entity_t::size_type>(e) + offset;
 						  });
-			cInfo2.remap(remap, [offset = static_cast<entity_size_type>(cInfo.size())](entity_t e) {
-				return static_cast<entity_size_type>(e) < offset;
+			cInfo2.remap(remap, [offset = static_cast<entity_t::size_type>(cInfo.size())](entity_t e) {
+				return static_cast<entity_t::size_type>(e) < offset;
 			});
 			std::for_each(std::begin(cInfo2.entities()),
 						  std::end(cInfo2.entities()),
-						  [offset = static_cast<entity_size_type>(cInfo.size())](entity_t e) {
-							  require(static_cast<entity_size_type>(e)) >= offset;
+						  [offset = static_cast<entity_t::size_type>(cInfo.size())](entity_t e) {
+							  require(static_cast<entity_t::size_type>(e)) >= offset;
 						  });
 			section<"merge">() = [&]() {
 				auto orig_size = cInfo.size();
@@ -189,10 +189,10 @@ auto t0 = suite<"component_info", "ecs", "psl">().templates<float_tpack>() = []<
 				require(cInfo.size()) == orig_size + cInfo2.size();
 				std::for_each(std::begin(cInfo.entities()),
 							  std::end(cInfo.entities()),
-							  [&cInfo, offset = static_cast<entity_size_type>(cInfo.size())](entity_t e) {
-								  require(static_cast<entity_size_type>(e)) <= offset;
+							  [&cInfo, offset = static_cast<entity_t::size_type>(cInfo.size())](entity_t e) {
+								  require(static_cast<entity_t::size_type>(e)) <= offset;
 								  require(cInfo.entity_data().template operator[]<type>(
-									static_cast<entity_size_type>(e))) == type(static_cast<entity_size_type>(e));
+									static_cast<entity_t::size_type>(e))) == type(static_cast<entity_t::size_type>(e));
 							  });
 			};
 		};
@@ -223,9 +223,9 @@ auto t2 = suite<"filtering", "ecs", "psl">()
 			.templates<tpack<float, complex_wrapper_float, flag_type>, policy_tpack, access_tpack>() =
   []<typename type, typename policy, typename access>() {
 	  state_t state;
-	  auto e_list1 {state.create(static_cast<entity_size_type>(100))};
-	  auto e_list2 {state.create(static_cast<entity_size_type>(400))};
-	  auto e_list3 {state.create(static_cast<entity_size_type>(500))};
+	  auto e_list1 {state.create(static_cast<entity_t::size_type>(100))};
+	  auto e_list2 {state.create(static_cast<entity_t::size_type>(400))};
+	  auto e_list3 {state.create(static_cast<entity_t::size_type>(500))};
 
 
 	  section<"only the first 100 are given all components">() = [&]() {
@@ -271,14 +271,14 @@ auto t2 = suite<"filtering", "ecs", "psl">()
 	  };
 
 	  section<"filtering components that are non-contiguous">() = [&]() {
-		  state.create<type, size_t>(static_cast<entity_size_type>(500));
+		  state.create<type, size_t>(static_cast<entity_t::size_type>(500));
 		  state.destroy(1200);
-		  auto entities = state.create<type, size_t>(static_cast<entity_size_type>(3));
+		  auto entities = state.create<type, size_t>(static_cast<entity_t::size_type>(3));
 
 		  require(entities.size()) == 3;
-		  require(static_cast<entity_size_type>(entities[0])) == 1500;
-		  require(static_cast<entity_size_type>(entities[1])) == 1501;
-		  require(static_cast<entity_size_type>(entities[2])) == 1502;
+		  require(static_cast<entity_t::size_type>(entities[0])) == 1500;
+		  require(static_cast<entity_t::size_type>(entities[1])) == 1501;
+		  require(static_cast<entity_t::size_type>(entities[2])) == 1502;
 		  require(state.filter<type>().size()) == 502;	  // 500 + 3 - 1
 		  require(state.filter<type>().size()) == state.filter<on_add<type>>().size();
 		  require(state.filter<type>().size()) == state.filter<on_combine<type, size_t>>().size();
@@ -349,7 +349,7 @@ auto t3 = suite<"initializing components", "ecs", "psl">().templates<float_tpack
 
 	size_t count {0};
 	state.create(
-	  static_cast<entity_size_type>(50),
+	  static_cast<entity_t::size_type>(50),
 	  [&count](position& i) {
 		  i = {++count, 0};
 	  },
@@ -377,9 +377,9 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 	  state_t state;
 
 	  section<"lifetime test">() = [&]() {
-		  auto e_list1 {state.create(static_cast<entity_size_type>(10))};
-		  auto e_list2 {state.create(static_cast<entity_size_type>(40))};
-		  auto e_list3 {state.create(static_cast<entity_size_type>(50))};
+		  auto e_list1 {state.create(static_cast<entity_t::size_type>(10))};
+		  auto e_list2 {state.create(static_cast<entity_t::size_type>(40))};
+		  auto e_list3 {state.create(static_cast<entity_t::size_type>(50))};
 		  // pre-tick #1
 		  // we add int components to all elements in e_list1, by giving them an incrementing value
 		  // thanks to these being the first entities, they overlap with their ID
@@ -398,7 +398,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 		  auto token = state.declare(
 			[&lock, &total_pack1](psl::ecs::info_t& info, pack_t<policy, access, entity_t, const type> pack1) {
 				for(auto [e, i] : pack1) {
-					require(static_cast<entity_size_type>(e)) == i;
+					require(static_cast<entity_t::size_type>(e)) == i;
 				}
 
 				std::lock_guard<std::mutex> guard(lock);
@@ -418,7 +418,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 		  {
 			  for(auto e : e_list1) {
 				  auto val = state.template get<type>(e);
-				  require(static_cast<entity_size_type>(e)) == val;
+				  require(static_cast<entity_t::size_type>(e)) == val;
 			  }
 		  }
 		  state.revoke(token);
@@ -439,13 +439,13 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 												pack_t<policy, access, entity_t, const type, on_remove<type>> pack1,
 												pack_t<policy, access, entity_t, const type, filter<type>> pack2) {
 				for(auto [e, i] : pack1) {
-					require(static_cast<entity_size_type>(e)) == i;
+					require(static_cast<entity_t::size_type>(e)) == i;
 				}
-				require(static_cast<entity_size_type>(pack1.template get<entity_t>()[0])) == 0;
+				require(static_cast<entity_t::size_type>(pack1.template get<entity_t>()[0])) == 0;
 				// if this shows 0, then the previous deleted components of tick #1 are still present
-				require(static_cast<entity_size_type>(pack2.template get<entity_t>()[0])) == 10;
+				require(static_cast<entity_t::size_type>(pack2.template get<entity_t>()[0])) == 10;
 				for(auto [e, i] : pack2) {
-					require(static_cast<entity_size_type>(e)) == i;
+					require(static_cast<entity_t::size_type>(e)) == i;
 				}
 				std::lock_guard<std::mutex> guard(lock);
 				total_pack1 += pack1.size();
@@ -498,7 +498,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 	  };
 
 	  section<"continuous removal from within systems">() = [&]() {
-		  auto e_list2 {state.create(static_cast<entity_size_type>(40))};
+		  auto e_list2 {state.create(static_cast<entity_t::size_type>(40))};
 		  psl::array<type> values;
 		  values.resize(e_list2.size());
 		  std::iota(std::begin(values), std::end(values), 0);
@@ -512,7 +512,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 			  size_t removed {0};
 			  psl::array<entity_t> entities;
 			  for(auto [e, i] : pack) {
-				  require(type(static_cast<entity_size_type>(e))) == i;
+				  require(type(static_cast<entity_t::size_type>(e))) == i;
 				  if(std::rand() % 2 == 0) {
 					  entities.emplace_back(e);
 					  removed++;
@@ -529,7 +529,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 
 
 	  section<"continuous removal from external">() = [&]() {
-		  auto e_list2 {state.create(static_cast<entity_size_type>(40))};
+		  auto e_list2 {state.create(static_cast<entity_t::size_type>(40))};
 		  psl::array<type> values;
 		  values.resize(e_list2.size());
 		  std::iota(std::begin(values), std::end(values), 0);
@@ -541,7 +541,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 
 		  state.declare([&total, &lock](psl::ecs::info_t& info, pack_t<policy, access, entity_t, type> pack) {
 			  for(auto [e, i] : pack) {
-				  require(type(static_cast<entity_size_type>(e))) == i;
+				  require(type(static_cast<entity_t::size_type>(e))) == i;
 			  }
 			  std::lock_guard<std::mutex> guard(lock);
 			  total += pack.size();
@@ -561,7 +561,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 	  };
 
 	  section<"continuous addition from within systems">() = [&]() {
-		  auto e_list2 {state.create(static_cast<entity_size_type>(40))};
+		  auto e_list2 {state.create(static_cast<entity_t::size_type>(40))};
 		  psl::array<type> values;
 		  values.resize(e_list2.size());
 		  std::iota(std::begin(values), std::end(values), 0);
@@ -572,9 +572,9 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 			  require(pack.size()) == expected;
 
 			  for(auto [e, i] : pack) {
-				  require(type(static_cast<entity_size_type>(e))) == i;
+				  require(type(static_cast<entity_t::size_type>(e))) == i;
 			  }
-			  auto new_count				= static_cast<entity_size_type>(std::rand() % 20);
+			  auto new_count				= static_cast<entity_t::size_type>(std::rand() % 20);
 			  psl::array<entity_t> entities = info.command_buffer.create(new_count);
 			  psl::array<type> values;
 			  values.resize(entities.size());
@@ -589,7 +589,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 	  };
 
 	  section<"continuous addition from external">() = [&]() {
-		  auto e_list2 {state.create(static_cast<entity_size_type>(40))};
+		  auto e_list2 {state.create(static_cast<entity_t::size_type>(40))};
 		  {
 			  psl::array<type> values;
 			  values.resize(e_list2.size());
@@ -603,7 +603,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 
 		  state.declare([&total, &lock](psl::ecs::info_t& info, pack_t<policy, access, entity_t, type> pack) {
 			  for(auto [e, i] : pack) {
-				  require(type(static_cast<entity_size_type>(e))) == i;
+				  require(type(static_cast<entity_t::size_type>(e))) == i;
 			  }
 			  std::lock_guard<std::mutex> guard(lock);
 			  total += pack.size();
@@ -614,7 +614,7 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 			  require(total) == expected;
 			  total = 0;
 
-			  auto new_count				= static_cast<entity_size_type>(std::rand() % 20);
+			  auto new_count				= static_cast<entity_t::size_type>(std::rand() % 20);
 			  psl::array<entity_t> entities = state.create(new_count);
 			  psl::array<type> values;
 			  values.resize(entities.size());
@@ -625,9 +625,9 @@ auto t4 = suite<"systems", "ecs", "psl">().templates<int_tpack, policy_tpack, ac
 	  };
 
 	  section<"simple iterations test">() = [&]() {
-		  auto e_list1 {state.create(static_cast<entity_size_type>(10))};
-		  auto e_list2 {state.create(static_cast<entity_size_type>(40))};
-		  auto e_list3 {state.create(static_cast<entity_size_type>(50))};
+		  auto e_list1 {state.create(static_cast<entity_t::size_type>(10))};
+		  auto e_list2 {state.create(static_cast<entity_t::size_type>(40))};
+		  auto e_list3 {state.create(static_cast<entity_t::size_type>(50))};
 		  state.add_components<float>(e_list1);
 		  state.add_components<type>(e_list1);
 		  auto system_id = state.declare(float_iteration_test<policy, access>);
@@ -678,7 +678,7 @@ auto t7 =
 			  count += pack.size();
 		  });
 
-		  auto entities = state.create<type>(static_cast<entity_size_type>(1));
+		  auto entities = state.create<type>(static_cast<entity_t::size_type>(1));
 		  expect(state.filter<on_add<type>>().size()) == 1;
 		  state.tick(std::chrono::duration<float>(1.0f));
 		  expect(state.filter<type>().size()) == 1;
@@ -699,8 +699,8 @@ auto t7 =
 		  // reason: filtering operation that was based on existing filters did not correctly
 		  //         use the already filtered entity list
 
-		  auto entities0 = state.create<type>(static_cast<entity_size_type>(1));
-		  auto entities1 = state.create(static_cast<entity_size_type>(1));
+		  auto entities0 = state.create<type>(static_cast<entity_t::size_type>(1));
+		  auto entities1 = state.create(static_cast<entity_t::size_type>(1));
 		  state.remove_components<type>(entities0);
 		  expect(state.filter<type>().size()) == 0;
 		  expect(state.filter<on_remove<type>>().size()) == 1;
@@ -710,7 +710,7 @@ auto t7 =
 		  expect(state.filter<on_remove<type>>().size()) == 1;
 		  state.declare([&](info_t& info, pack_t<psl::ecs::full_t, access, entity_t, type> pack) {
 			  expect(pack.size()) == 1;
-			  expect(static_cast<entity_size_type>(pack.template get<entity_t>()[0])) == 1;
+			  expect(static_cast<entity_t::size_type>(pack.template get<entity_t>()[0])) == 1;
 		  });
 		  state.tick(std::chrono::duration<float>(1.0f));
 		  expect(state.filter<type>().size()) == 1;
@@ -745,7 +745,7 @@ auto t8 = suite<"component_key name matches expected", "ecs", "psl">() = []() {
 auto t9 = suite<"ecs state serialization", "ecs", "psl">() = []() {
 	psl::ecs::state_t state_a {}, state_b {};
 	int counter {0};
-	state_a.create(static_cast<entity_size_type>(200), [&counter](int& value) { value = counter++; });
+	state_a.create(static_cast<entity_t::size_type>(200), [&counter](int& value) { value = counter++; });
 	state_a.override_serialization<int>(true);
 
 	psl::serialization::serializer serializer {};
@@ -763,7 +763,7 @@ auto t9 = suite<"ecs state serialization", "ecs", "psl">() = []() {
 
 	for(size_t i = 0; i < components_a.size(); ++i) {
 		require(components_a[i]) == components_b[i];
-		require(static_cast<entity_size_type>(entities[i])) == components_a[i];
+		require(static_cast<entity_t::size_type>(entities[i])) == components_a[i];
 	}
 
 	psl::format::container container_b {};
@@ -779,7 +779,7 @@ struct foo {
 
 auto t10 = suite<"ecs prototype support", "ecs", "psl">() = []() {
 	psl::ecs::state_t state {};
-	auto entity = state.create<foo>(static_cast<entity_size_type>(1));
+	auto entity = state.create<foo>(static_cast<entity_t::size_type>(1));
 	require(state.get<foo>(entity[0]).value) == 10;
 };
 }	 // namespace

--- a/tests/src/ecs/staged_sparse_memory_region.cpp
+++ b/tests/src/ecs/staged_sparse_memory_region.cpp
@@ -13,7 +13,7 @@ using namespace litmus;
 template <typename T, auto... Values>
 using array_typed = litmus::generator::array_typed<T, Values...>;
 
-using entity = psl::ecs::entity_size_type;
+using entity = psl::ecs::entity_t::size_type;
 
 template <typename Fn>
 auto any_of_n(auto first, auto last, Fn&& fn) {

--- a/tests/src/ecs/staged_sparse_memory_region.cpp
+++ b/tests/src/ecs/staged_sparse_memory_region.cpp
@@ -13,7 +13,7 @@ using namespace litmus;
 template <typename T, auto... Values>
 using array_typed = litmus::generator::array_typed<T, Values...>;
 
-using entity = psl::ecs::entity;
+using entity = psl::ecs::entity_size_type;
 
 template <typename Fn>
 auto any_of_n(auto first, auto last, Fn&& fn) {


### PR DESCRIPTION
This PR changes `psl::ecs::entity` which is a `using declaration` to an integer type (default `uint32_t`) into `psl::ecs::entity_t` which is a `struct` containing a value that is an integer type (same default).

This makes it so storing a component of the same underlying type as the entity is not going to create problems.