### PR TITLE
fixed ecs state using incorrect heuristics

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -85,7 +85,7 @@ jobs:
       run: cmake --build --preset=${{ matrix.target }}-release-${{ matrix.graphics }} -j ${{ steps.cpu-cores.outputs.count }}
     - name: test
       if: ${{ matrix.tests == 'ON' }}
-      run: ./builds/default/bin/tests --formatter compact --no-source
+      run: ./builds/default/bin/tests --formatter compact --no-source --single-threaded
     - name: finalize
       if: ${{ matrix.benchmarks == 'ON' }}
       uses: actions/upload-artifact@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,7 +34,7 @@ jobs:
     - name: test
       run: |
             cd builds\x64\release\bin
-            .\tests.exe --formatter compact --no-source
+            .\tests.exe --formatter compact --no-source --single-threaded
     - name: finalize    
       if: ${{ matrix.benchmarks == 'ON' }}
       uses: actions/upload-artifact@v3

--- a/psl/inc/psl/ecs/state.hpp
+++ b/psl/inc/psl/ecs/state.hpp
@@ -171,7 +171,9 @@ class state_t final {
 
 
   public:
-	state_t(size_t workers = 0, size_t cache_size = 1024 * 1024 * 256, entity_t::size_type min_entities_per_worker = 1024);
+	state_t(size_t workers								= 0,
+			size_t cache_size							= 1024 * 1024 * 256,
+			entity_t::size_type min_entities_per_worker = 1024);
 	~state_t();
 	state_t(const state_t&)			   = delete;
 	state_t(state_t&&)				   = default;

--- a/psl/inc/psl/ecs/state.hpp
+++ b/psl/inc/psl/ecs/state.hpp
@@ -171,7 +171,7 @@ class state_t final {
 
 
   public:
-	state_t(size_t workers = 0, size_t cache_size = 1024 * 1024 * 256);
+	state_t(size_t workers = 0, size_t cache_size = 1024 * 1024 * 256, entity_t::size_type min_entities_per_worker = 1024);
 	~state_t();
 	state_t(const state_t&)			   = delete;
 	state_t(state_t&&)				   = default;
@@ -867,5 +867,6 @@ class state_t final {
 	size_t m_Tick {0};
 	size_t m_SystemCounter {0};
 	entity_t::size_type m_Entities {0};
+	entity_t::size_type m_MinEntitiesPerWorker {1024};
 };
 }	 // namespace psl::ecs

--- a/psl/src/async/scheduler.cpp
+++ b/psl/src/async/scheduler.cpp
@@ -44,12 +44,10 @@ struct worker {
 			m_Paused = false;
 		}
 		cv.notify_one();
-		// resume t2
 	}
 
   private:
 	void loop() {
-		int max_spin = 1000;
 		while(m_Run.load(std::memory_order_relaxed)) {
 			while(m_Paused) {
 				std::unique_lock<std::mutex> lk(m);
@@ -60,12 +58,6 @@ struct worker {
 			if(auto item = m_Consumer.pop(); item) {
 				auto task = item.value();
 				task->operator()();
-			} else
-				--max_spin;
-
-			if(max_spin == 0) {
-				max_spin = 1000;
-				std::this_thread::sleep_for(std::chrono::microseconds(5));
 			}
 		}
 		m_Done.store(true, std::memory_order_relaxed);
@@ -111,8 +103,9 @@ void scheduler::execute() {
 	};
 
 	// make sure no proxy objects exist
-	// assert(std::none_of(std::begin(m_Invocables), std::end(m_Invocables), [](const auto& ptr) { return ptr ==
-	// nullptr; }) == true);
+	psl_assert(std::none_of(std::begin(m_Invocables), std::end(m_Invocables), [](const auto& ptr) {
+				   return ptr == nullptr;
+			   }) == true);
 
 	psl::array<barrier> barriers {};
 	psl::array<size_t> done {};
@@ -145,7 +138,10 @@ void scheduler::execute() {
 							std::end(inflight),
 							std::back_inserter(invocables));
 	}
-	for(auto& thread : m_Workerthreads) thread->resume();
+
+	for(auto& thread : m_Workerthreads) {
+		thread->resume();
+	}
 
 	while(inflight.size() > 0) {
 		psl_assert(std::unique(std::begin(inflight),
@@ -161,7 +157,8 @@ void scheduler::execute() {
 										   std::end(inflight),
 										   [](psl::view_ptr<details::packet> packet) { return !packet->is_ready(); });
 		   it != std::end(inflight)) {
-			// Add all ready inflight tasks to the done list, and sort the result. Then remove them from the infight.
+			// Add all ready inflight tasks to the done list, and sort the result. Then remove them from the inflight
+			// container.
 			auto done_mid = done.size();
 			std::transform(it, std::end(inflight), std::back_inserter(done), [](const auto& task) -> size_t {
 				return task->operator size_t();
@@ -217,7 +214,9 @@ void scheduler::execute() {
 							   [](const auto& lhs, const auto& rhs) { return *lhs < *rhs; });
 		}
 	}
-	for(auto& thread : m_Workerthreads) thread->pause();
+	for(auto& thread : m_Workerthreads) {
+		thread->pause();
+	}
 
 	psl_assert(
 	  m_Invocables.size() == done.size(), "there were still {} tasks in flight", m_Invocables.size() - done.size());

--- a/psl/src/async/scheduler.cpp
+++ b/psl/src/async/scheduler.cpp
@@ -102,11 +102,6 @@ void scheduler::execute() {
 		});
 	};
 
-	// make sure no proxy objects exist
-	psl_assert(std::none_of(std::begin(m_Invocables), std::end(m_Invocables), [](const auto& ptr) {
-				   return ptr == nullptr;
-			   }) == true);
-
 	psl::array<barrier> barriers {};
 	psl::array<size_t> done {};
 


### PR DESCRIPTION
ECS state used incorrect heuristics to estimate the lowest number of workers to use, now it should scale (and can be set per state instance).
Additionally the workers of the scheduler were sleeping between tasks, this has been resolved.

Future work should look into making a heuristic controlled by the system, and component sizes.