### PR TITLE
Added cached lookups for component containers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,8 @@ set(ANDROID_BUNDLETOOL "" CACHE PATH "override android bundletool location")
 set(ANDROID_GRADLE "" CACHE PATH "override gradle location")
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+OPTION(PE_ECS_DISABLE_LOOKUP_CACHE_BEHAVIOUR "Disable the usage of the lookup cache for psl::ecs::state_t" OFF)
+
 if(${PE_CCACHE})
 	find_program(CCACHE "ccache")
 	if(CCACHE)
@@ -162,6 +164,10 @@ endif()
 
 if(${PE_PLATFORM} STREQUAL ANDROID AND (NOT DEFINED ANDROID_NDK OR ANDROID_NDK STREQUAL ""))
 		message(FATAL_ERROR "Trying to build 'android' target outside of the gradle context is not supported.")
+endif()
+
+if(PE_ECS_DISABLE_LOOKUP_CACHE_BEHAVIOUR)
+	list(APPEND PE_DEFINES -DPE_ECS_DISABLE_LOOKUP_CACHE)
 endif()
 
 ###############################################################################

--- a/psl/inc/psl/collections/indirect_array.hpp
+++ b/psl/inc/psl/collections/indirect_array.hpp
@@ -1,0 +1,191 @@
+#pragma once
+#include "psl/array.hpp"
+#include <cstdint>
+
+namespace psl {
+template <typename T, typename SizeType = size_t>
+class indirect_array_iterator_t;
+
+template <typename T>
+struct is_indirect_array_iterator : std::false_type {};
+
+template <typename T, typename SizeType>
+struct is_indirect_array_iterator<indirect_array_iterator_t<T, SizeType>> : std::true_type {};
+
+template <typename T, typename Y>
+struct is_compatible_indirect_array_iterator : std::false_type {};
+
+template <typename T, typename Y, typename SizeType>
+requires(std::is_same_v<std::remove_const_t<T>, std::remove_const_t<Y>>) struct is_compatible_indirect_array_iterator<
+  indirect_array_iterator_t<T, SizeType>,
+  indirect_array_iterator_t<Y, SizeType>> : std::true_type {};
+
+template <typename T, typename SizeType>
+class indirect_array_iterator_t {
+  private:
+	static constexpr bool _is_const = std::is_const_v<T>;
+
+	// give access to the const/non-const version of itself so we can have the logical operators access internals.
+	friend class indirect_array_iterator_t<
+	  std::conditional_t<_is_const, std::remove_cvref_t<T>, std::remove_cvref_t<T> const>,
+	  SizeType>;
+
+  public:
+	using size_type			   = SizeType;
+	using value_type		   = std::remove_cvref_t<T>;
+	using const_value_type	   = value_type const;
+	using reference_type	   = value_type&;
+	using const_reference_type = value_type const&;
+	using pointer_type		   = value_type*;
+	using const_pointer_type   = value_type const*;
+
+	using difference_type		   = std::ptrdiff_t;
+	using unpack_iterator_category = std::random_access_iterator_tag;
+
+
+	indirect_array_iterator_t(size_type* it, pointer_type data) : m_It(it), m_Data(data) {}
+	indirect_array_iterator_t(size_type* it, const_pointer_type data) requires(_is_const)
+		: m_It(it), m_Data(const_cast<pointer_type>(data)) {}
+	indirect_array_iterator_t(size_type const* it, pointer_type data)
+		: m_It(const_cast<size_type*>(it)), m_Data(data) {}
+
+	indirect_array_iterator_t(size_type const* it, const_pointer_type data) requires(_is_const)
+		: m_It(const_cast<size_type*>(it)), m_Data(const_cast<pointer_type>(data)) {}
+
+	reference_type operator*() noexcept requires(!_is_const) { return m_Data[*m_It]; }
+	const_reference_type operator*() const noexcept { return m_Data[*m_It]; }
+	pointer_type operator->() noexcept requires(!_is_const) { return &(m_Data[*m_It]); }
+	const_pointer_type operator->() const noexcept { return &m_Data[*m_It]; }
+
+	template <typename Y>
+	requires(is_compatible_indirect_array_iterator<indirect_array_iterator_t, Y>::value) constexpr friend bool
+	operator==(indirect_array_iterator_t const& lhs, Y const& rhs) noexcept {
+		return lhs.m_It == rhs.m_It && lhs.m_Data == rhs.m_Data;
+	}
+
+	template <typename Y>
+	requires(is_compatible_indirect_array_iterator<indirect_array_iterator_t, Y>::value) constexpr friend bool
+	operator!=(indirect_array_iterator_t const& lhs, Y const& rhs) noexcept {
+		return lhs.m_It != rhs.m_It || lhs.m_Data != rhs.m_Data;
+	}
+
+	template <typename Y>
+	requires(is_compatible_indirect_array_iterator<indirect_array_iterator_t, Y>::value) constexpr friend bool
+	operator<(indirect_array_iterator_t const& lhs, Y const& rhs) noexcept {
+		return *lhs.m_It < *rhs.m_It;
+	}
+
+	template <typename Y>
+	requires(is_compatible_indirect_array_iterator<indirect_array_iterator_t, Y>::value) constexpr friend bool
+	operator>(indirect_array_iterator_t const& lhs, Y const& rhs) noexcept {
+		return *lhs.m_It > *rhs.m_It;
+	}
+
+	template <typename Y>
+	requires(is_compatible_indirect_array_iterator<indirect_array_iterator_t, Y>::value) constexpr friend bool
+	operator<=(indirect_array_iterator_t const& lhs, Y const& rhs) noexcept {
+		return *lhs.m_It <= *rhs.m_It;
+	}
+
+	template <typename Y>
+	requires(is_compatible_indirect_array_iterator<indirect_array_iterator_t, Y>::value) constexpr friend bool
+	operator>=(indirect_array_iterator_t const& lhs, Y const& rhs) noexcept {
+		return *lhs.m_It >= *rhs.m_It;
+	}
+
+	constexpr indirect_array_iterator_t& operator++() noexcept {
+		++m_It;
+		return *this;
+	}
+
+	constexpr indirect_array_iterator_t& operator--() noexcept {
+		--m_It;
+		return *this;
+	}
+
+	constexpr indirect_array_iterator_t operator++(int) noexcept {
+		auto tmp = *this;
+		++(*this);
+		return tmp;
+	}
+
+	constexpr indirect_array_iterator_t operator--(int) noexcept {
+		auto tmp = *this;
+		--(*this);
+		return tmp;
+	}
+
+	constexpr indirect_array_iterator_t& operator+=(difference_type offset) noexcept {
+		m_It = std::next(m_It, offset);
+		return *this;
+	}
+	constexpr indirect_array_iterator_t operator+(difference_type offset) const noexcept {
+		auto tmp = *this;
+		tmp += offset;
+		return tmp;
+	}
+	constexpr indirect_array_iterator_t operator-(difference_type offset) {
+		auto tmp = *this;
+		tmp -= offset;
+		return tmp;
+	}
+
+  private:
+	size_type* m_It {};
+	pointer_type m_Data {nullptr};
+};
+
+template <typename T, typename SizeType = size_t>
+class indirect_array_t {
+  private:
+	static constexpr bool _is_const = std::is_const_v<T>;
+
+  public:
+	using size_type			 = SizeType;
+	using value_type		 = std::remove_cvref_t<T>;
+	using const_value_type	 = value_type const;
+	using pointer_type		 = value_type*;
+	using const_pointer_type = value_type const*;
+
+	using iterator_type		  = indirect_array_iterator_t<value_type, size_type>;
+	using const_iterator_type = indirect_array_iterator_t<const_value_type, size_type>;
+
+	template <typename Y>
+	indirect_array_t(Y&& indices, pointer_type data) : m_Indices(std::forward<Y>(indices)), m_Data(data) {}
+	template <typename Y>
+	indirect_array_t(Y&& indices, const_pointer_type data) requires(_is_const)
+		: m_Indices(std::forward<Y>(indices)), m_Data(const_cast<pointer_type>(data)) {}
+	indirect_array_t() = default;
+
+	constexpr inline auto& operator[](size_t index) noexcept requires(!_is_const) {
+		return *(m_Data + m_Indices[index]);
+	}
+	constexpr inline auto const& operator[](size_t index) const noexcept { return *(m_Data + m_Indices[index]); }
+	constexpr inline auto& at(size_t index) noexcept requires(!_is_const) { return *(m_Data + m_Indices[index]); }
+	constexpr inline auto const& at(size_t index) const noexcept { return *(m_Data + m_Indices[index]); }
+
+	constexpr inline auto size() const noexcept { return m_Indices.size(); }
+	constexpr inline auto begin() noexcept requires(!_is_const) { return iterator_type(m_Indices.data(), m_Data); }
+	constexpr inline auto end() noexcept requires(!_is_const) {
+		return iterator_type(m_Indices.data() + m_Indices.size(), m_Data);
+	}
+	constexpr inline auto begin() const noexcept { return const_iterator_type(m_Indices.data(), m_Data); }
+	constexpr inline auto end() const noexcept {
+		return const_iterator_type(m_Indices.data() + m_Indices.size(), m_Data);
+	}
+	constexpr inline auto cbegin() const noexcept { return begin(); }
+	constexpr inline auto cend() const noexcept { return end(); }
+	constexpr inline auto empty() const noexcept -> bool { return size() == 0; }
+
+	constexpr inline auto data() noexcept -> pointer_type requires(!_is_const) { return m_Data; }
+	constexpr inline auto data() const noexcept -> const_pointer_type { return m_Data; }
+	constexpr inline auto cdata() const noexcept -> const_pointer_type { return m_Data; }
+
+  private:
+	psl::array<size_type> m_Indices {};
+	pointer_type m_Data {};
+};
+
+template <typename T, typename IndiceType, template <typename, typename...> typename Container, typename... Rest>
+indirect_array_t(Container<IndiceType, Rest...>, T*) -> indirect_array_t<T, IndiceType>;
+}	 // namespace psl

--- a/psl/inc/psl/ecs/details/component_container.hpp
+++ b/psl/inc/psl/ecs/details/component_container.hpp
@@ -53,19 +53,24 @@ class component_container_t {
 	void destroy(entity_t entity) noexcept { remove_impl(entity); }
 	virtual void* data() noexcept			  = 0;
 	virtual void* const data() const noexcept = 0;
-	bool has_component(entity_t entity) const noexcept { return has_impl(entity, stage_range_t::ALIVE); }
-	bool has_added(entity_t entity) const noexcept { return has_impl(entity, stage_range_t::ADDED); }
-	bool has_removed(entity_t entity) const noexcept { return has_impl(entity, stage_range_t::REMOVED); }
+	inline bool has(entity_t entity, stage_range_t stage = stage_range_t::ALL) { return has_impl(entity, stage); }
+	inline bool has_component(entity_t entity) const noexcept { return has_impl(entity, stage_range_t::ALIVE); }
+	inline bool has_added(entity_t entity) const noexcept { return has_impl(entity, stage_range_t::ADDED); }
+	inline bool has_removed(entity_t entity) const noexcept { return has_impl(entity, stage_range_t::REMOVED); }
 	virtual bool has_storage_for(entity_t entity) const noexcept = 0;
-	psl::array_view<entity_t> entities(bool include_removed = false) const noexcept {
+	inline psl::array_view<entity_t> entities(bool include_removed = false) const noexcept {
 		return entities_impl((include_removed) ? stage_range_t::ALL : stage_range_t::ALIVE);
 	}
 
-	void purge() noexcept { purge_impl(); }
+	virtual void* get_if(entity_t entity, stage_range_t stage = stage_range_t::ALL) { return nullptr; }
+
+	inline void purge() noexcept { purge_impl(); }
 	const component_key_t& id() const noexcept;
 
-	psl::array_view<entity_t> added_entities() const noexcept { return entities_impl(stage_range_t::ADDED); };
-	psl::array_view<entity_t> removed_entities() const noexcept { return entities_impl(stage_range_t::REMOVED); };
+	inline psl::array_view<entity_t> added_entities() const noexcept { return entities_impl(stage_range_t::ADDED); };
+	inline psl::array_view<entity_t> removed_entities() const noexcept {
+		return entities_impl(stage_range_t::REMOVED);
+	};
 
 	virtual entity_t::size_type* write_memory_location_offsets_for(psl::array_view<entity_t> entities,
 																   entity_t::size_type* target) const noexcept {
@@ -131,6 +136,10 @@ class component_container_typed_t final : public component_container_t {
 
 	bool has_storage_for(entity_t entity) const noexcept override {
 		return m_Entities.has(static_cast<entity_t::size_type>(entity), stage_range_t::ALL);
+	}
+
+	void* get_if(entity_t entity, stage_range_t stage = stage_range_t::ALL) override {
+		return m_Entities.addressof_if(static_cast<entity_t::size_type>(entity), stage);
 	}
 
 	entity_t::size_type* write_memory_location_offsets_for(psl::array_view<entity_t> entities,
@@ -370,6 +379,10 @@ class component_container_untyped_t : public component_container_t {
 
 	bool has_storage_for(entity_t entity) const noexcept override {
 		return m_Entities.has(static_cast<entity_t::size_type>(entity), stage_range_t::ALL);
+	}
+
+	void* get_if(entity_t entity, stage_range_t stage = stage_range_t::ALL) override {
+		return m_Entities.addressof_if(static_cast<entity_t::size_type>(entity), stage);
 	}
 
 	entity_t::size_type* write_memory_location_offsets_for(psl::array_view<entity_t> entities,

--- a/psl/inc/psl/ecs/details/staged_sparse_array.hpp
+++ b/psl/inc/psl/ecs/details/staged_sparse_array.hpp
@@ -108,6 +108,24 @@ class staged_sparse_array {
 		return ((T*)m_DenseData.data() + get_chunk_from_index(chunk_index)[sparse_index]);
 	}
 
+	pointer addressof_if(index_t index, stage_range_t stage = stage_range_t::ALIVE) noexcept {
+		index_t sparse_index, chunk_index;
+		chunk_info_for(index, sparse_index, chunk_index);
+		if(has(index, stage)) {
+			return ((T*)m_DenseData.data() + get_chunk_from_index(chunk_index)[sparse_index]);
+		}
+		return nullptr;
+	}
+
+	const_pointer addressof_if(index_t index, stage_range_t stage = stage_range_t::ALIVE) const noexcept {
+		index_t sparse_index, chunk_index;
+		chunk_info_for(index, sparse_index, chunk_index);
+		if(has(index, stage)) {
+			return ((T*)m_DenseData.data() + get_chunk_from_index(chunk_index)[sparse_index]);
+		}
+		return nullptr;
+	}
+
 	inline auto dense_index_for(index_t index, stage_range_t stage = stage_range_t::ALIVE) const noexcept -> index_t {
 		index_t sparse_index, chunk_index;
 		chunk_info_for(index, sparse_index, chunk_index);

--- a/psl/inc/psl/ecs/details/staged_sparse_memory_region.hpp
+++ b/psl/inc/psl/ecs/details/staged_sparse_memory_region.hpp
@@ -227,6 +227,37 @@ class staged_sparse_memory_region_t {
 		return (static_cast<pointer>(m_DenseData.data()) + (get_chunk_from_index(chunk_index)[sparse_index] * m_Size));
 	}
 
+	/// \brief Get a pointer of the data at the index
+	/// \param index Where to look
+	/// \param stage Used to limit the stages we wish to look in
+	/// \return memory address
+	/// \note When assertions are enabled, this function can assert
+	FORCEINLINE auto addressof_if(key_type index, stage_range_t stage = stage_range_t::ALIVE) const noexcept
+	  -> const_pointer {
+		key_type sparse_index, chunk_index;
+		chunk_info_for(index, sparse_index, chunk_index);
+		if(has(index, stage)) {
+			return (static_cast<const_pointer>(m_DenseData.data()) +
+					(get_chunk_from_index(chunk_index)[sparse_index] * m_Size));
+		}
+		return nullptr;
+	}
+
+	/// \brief Get a pointer of the data at the index
+	/// \param index Where to look
+	/// \param stage Used to limit the stages we wish to look in
+	/// \return memory address
+	/// \note When assertions are enabled, this function can assert
+	FORCEINLINE auto addressof_if(key_type index, stage_range_t stage = stage_range_t::ALIVE) noexcept -> pointer {
+		key_type sparse_index, chunk_index;
+		chunk_info_for(index, sparse_index, chunk_index);
+		if(has(index, stage)) {
+			return (static_cast<pointer>(m_DenseData.data()) +
+					(get_chunk_from_index(chunk_index)[sparse_index] * m_Size));
+		}
+		return nullptr;
+	}
+
 	/// \brief Retrieves the internal index for the dense data for the given index
 	/// \param index Where to look
 	/// \param stage Used to limit the stages we wish to look in

--- a/psl/inc/psl/ecs/details/staged_sparse_memory_region.hpp
+++ b/psl/inc/psl/ecs/details/staged_sparse_memory_region.hpp
@@ -227,11 +227,10 @@ class staged_sparse_memory_region_t {
 		return (static_cast<pointer>(m_DenseData.data()) + (get_chunk_from_index(chunk_index)[sparse_index] * m_Size));
 	}
 
-	/// \brief Get a pointer of the data at the index
+	/// \brief Get a pointer of the data at the index, or nullptr when not found
 	/// \param index Where to look
 	/// \param stage Used to limit the stages we wish to look in
-	/// \return memory address
-	/// \note When assertions are enabled, this function can assert
+	/// \return memory address or nullptr
 	FORCEINLINE auto addressof_if(key_type index, stage_range_t stage = stage_range_t::ALIVE) const noexcept
 	  -> const_pointer {
 		key_type sparse_index, chunk_index;
@@ -243,11 +242,10 @@ class staged_sparse_memory_region_t {
 		return nullptr;
 	}
 
-	/// \brief Get a pointer of the data at the index
+	/// \brief Get a pointer of the data at the index, or nullptr when not found
 	/// \param index Where to look
 	/// \param stage Used to limit the stages we wish to look in
-	/// \return memory address
-	/// \note When assertions are enabled, this function can assert
+	/// \return memory address or nullptr
 	FORCEINLINE auto addressof_if(key_type index, stage_range_t stage = stage_range_t::ALIVE) noexcept -> pointer {
 		key_type sparse_index, chunk_index;
 		chunk_info_for(index, sparse_index, chunk_index);

--- a/psl/inc/psl/ecs/state.hpp
+++ b/psl/inc/psl/ecs/state.hpp
@@ -799,7 +799,7 @@ class state_t final {
 											 psl::array<entity_t>::iterator& begin,
 											 psl::array<entity_t>::iterator& end) const noexcept {
 		return on_break_op(
-		  psl::array<details::component_container_t*> {get_component_untyped_info<Ts...>()...}, begin, end);
+		  psl::array<details::component_container_t*> {get_component_untyped_info<Ts>()...}, begin, end);
 	}
 
 	template <typename... Ts>
@@ -807,7 +807,7 @@ class state_t final {
 											 psl::array<entity_t>::iterator& begin,
 											 psl::array<entity_t>::iterator& end) const noexcept {
 		return on_combine_op(
-		  psl::array<details::component_container_t*> {get_component_untyped_info<Ts...>()...}, begin, end);
+		  psl::array<details::component_container_t*> {get_component_untyped_info<Ts>()...}, begin, end);
 	}
 
 	psl::array<entity_t>::iterator filter_op(details::component_key_t key,

--- a/psl/src/ecs/state.cpp
+++ b/psl/src/ecs/state.cpp
@@ -27,6 +27,10 @@ state_t::state_t(size_t workers, size_t cache_size, entity_t::size_type min_enti
 	: m_Cache(cache_size),
 	  m_Scheduler(new psl::async::scheduler((workers == 0) ? std::nullopt : std::optional {workers})),
 	  m_MinEntitiesPerWorker(min_entities_per_worker) {
+	static std::mutex mut {};
+	static std::atomic<size_t> generation {1};
+	std::lock_guard l {mut};
+	m_StateUniqueKey = ++generation;
 	m_ModifiedEntities.reserve(65536);
 }
 

--- a/psl/src/ecs/state.cpp
+++ b/psl/src/ecs/state.cpp
@@ -27,10 +27,12 @@ state_t::state_t(size_t workers, size_t cache_size, entity_t::size_type min_enti
 	: m_Cache(cache_size),
 	  m_Scheduler(new psl::async::scheduler((workers == 0) ? std::nullopt : std::optional {workers})),
 	  m_MinEntitiesPerWorker(min_entities_per_worker) {
+#if !defined(PE_ECS_DISABLE_LOOKUP_CACHE)
 	static std::mutex mut {};
 	static std::atomic<size_t> generation {1};
 	std::lock_guard l {mut};
 	m_StateUniqueKey = ++generation;
+#endif
 	m_ModifiedEntities.reserve(65536);
 }
 


### PR DESCRIPTION
This PR adds a set of new query functions to the ecs state (`try_get_component`) as well as optimizes lookups for the state's container types (see `get_component_untyped_info<T>` and `create_storage<T>`).