### PR TITLE
Changed MacOS Github CI's llvm target

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,7 +23,7 @@ jobs:
     - name: setup dependencies
       run: python3 tools/generate_project_info.py
     - name: initialize
-      run: cmake --preset=${{ matrix.target }}-release -DPE_BENCHMARKS=${{ matrix.benchmarks }} -DPE_TESTS=${{ matrix.tests }} -DCMAKE_C_COMPILER=$(brew --prefix llvm@14)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@14)/bin/clang++
+      run: cmake --preset=${{ matrix.target }}-release -DPE_BENCHMARKS=${{ matrix.benchmarks }} -DPE_TESTS=${{ matrix.tests }} -DCMAKE_C_COMPILER=$(brew --prefix llvm)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++
     - name: compile
       run: cmake --build --preset=${{ matrix.target }}-release -j ${{ steps.cpu-cores.outputs.count }}
     - name: test


### PR DESCRIPTION
Github's CI runner silently removed LLVM-14 in favour of LLVM-15. Our runner was hard-linked to 14. This PR changes the script to just let brew return us whatever version is present, rather than a specific version.