### PR TITLE
[psl] Paradigm Format V2

### DIFF
--- a/psl/inc.txt
+++ b/psl/inc.txt
@@ -104,6 +104,7 @@ noise/perlin
 
 serialization/decoder
 serialization/encoder
+serialization/format
 serialization/parser
 serialization/polymorphic
 serialization/property

--- a/psl/inc.txt
+++ b/psl/inc.txt
@@ -56,6 +56,7 @@ memory/raw_region
 memory/segment
 memory/sparse_array
 
+collections/compile_time_string
 collections/indirect_array
 collections/static_ring_array
 collections/ring_array

--- a/psl/inc.txt
+++ b/psl/inc.txt
@@ -104,6 +104,7 @@ noise/perlin
 
 serialization/decoder
 serialization/encoder
+serialization/parser
 serialization/polymorphic
 serialization/property
 serialization/serializer

--- a/psl/inc/psl/collections/compile_time_string.hpp
+++ b/psl/inc/psl/collections/compile_time_string.hpp
@@ -1,0 +1,70 @@
+#pragma once
+#include <compare>
+#include <cstdint>
+#include <string_view>
+
+namespace psl {
+template <std::size_t N>
+struct ct_string;
+
+inline namespace _details {
+	template <typename T>
+	struct is_ct_string : std::false_type {};
+	template <std::size_t N>
+	struct is_ct_string<ct_string<N>> : std::true_type {};
+}	 // namespace details
+template <typename T>
+concept IsCTString = is_ct_string<std::remove_cvref_t<T>>::value;
+
+template <ct_string Str>
+struct ct_string_wrapper;
+
+template <std::size_t N>
+struct ct_string {
+	char buf[N + 1] {};
+	constexpr ct_string(char const* s) {
+		for(std::size_t i = 0; i != N; ++i) buf[i] = s[i];
+	}
+
+	template <auto Str>
+	constexpr ct_string(ct_string_wrapper<Str>) {
+		for(std::size_t i = 0; i != N; ++i) buf[i] = Str[i];
+	}
+	auto operator<=>(const ct_string&) const = default;
+
+	constexpr char operator[](std::size_t index) const noexcept { return buf[index]; }
+
+	constexpr operator std::string_view() const noexcept { return std::string_view {buf, N}; }
+	constexpr std::string_view view() const noexcept { return std::string_view {buf, N}; }
+	constexpr operator char const*() const { return buf; }
+
+	constexpr std::size_t size() const noexcept { return N; }
+
+	template <std::size_t start, std::size_t end>
+	consteval ct_string<end - start> substr() const noexcept {
+		static_assert(start <= end);
+		static_assert(end <= N + 1);
+		return ct_string<end - start> {&buf[start]};
+	}
+
+	constexpr auto begin() const noexcept { return &buf[0]; }
+	constexpr auto cbegin() const noexcept { return &buf[0]; }
+	constexpr auto end() const noexcept { return &buf[N]; }
+	constexpr auto cend() const noexcept { return &buf[N]; }
+};
+template <unsigned N>
+ct_string(char const (&)[N]) -> ct_string<N - 1>;
+
+template <ct_string Str>
+struct ct_string_wrapper {
+	static constexpr auto value {Str};
+};
+
+template <auto Str>
+ct_string(ct_string_wrapper<Str>) -> ct_string<Str.size()>;
+
+template <ct_string Str>
+constexpr ct_string_wrapper<Str> operator""_ctstr() {
+	return {};
+}
+}	 // namespace psl

--- a/psl/inc/psl/collections/compile_time_string.hpp
+++ b/psl/inc/psl/collections/compile_time_string.hpp
@@ -12,7 +12,7 @@ inline namespace _details {
 	struct is_ct_string : std::false_type {};
 	template <std::size_t N>
 	struct is_ct_string<ct_string<N>> : std::true_type {};
-}	 // namespace details
+}	 // namespace _details
 template <typename T>
 concept IsCTString = is_ct_string<std::remove_cvref_t<T>>::value;
 

--- a/psl/inc/psl/serialization/format.hpp
+++ b/psl/inc/psl/serialization/format.hpp
@@ -1,0 +1,180 @@
+#pragma once
+
+#include "psl/serialization/parser.hpp"
+#include <algorithm>
+#include <stdexcept>
+
+namespace psl::serialization::format {
+constexpr auto parse_identifier(psl::string8::view view)
+  -> psl::serialization::parser::parse_result_t<psl::string8::view> {
+	using namespace psl::serialization::parser;
+	constexpr auto parser = skip_whitespace_parser()<accumulate(
+	  text_parser<std::not_equal_to>("#"sv),
+	  accumulate_many(none_of(" \n\r\t:"), 1),
+	  [](auto sv1, auto sv2) {
+		  // todo this isn't exactly safe, find better way
+		  return psl::string8::view {sv2.data() - sv1.size(), sv1.size() + sv2.size()};
+	  })>
+	skip_whitespace_parser();
+	return parser(view);
+}
+
+constexpr auto parse_identifier_type_seperator(psl::string8::view view)
+  -> psl::serialization::parser::parse_result_t<psl::string8::view> {
+	using namespace psl::serialization::parser;
+	constexpr auto parser = skip_whitespace_parser()<text_parser(":"sv)> skip_whitespace_parser();
+	return parser(view);
+}
+
+constexpr auto parse_type(psl::string8::view view) -> psl::serialization::parser::parse_result_t<psl::string8::view> {
+	using namespace psl::serialization::parser;
+
+	// accumulate all except anything template related, attribute related, or assigment (in case of no space)
+	constexpr auto parser = skip_whitespace_parser()<accumulate_many(none_of(" \n\r\t<[="sv))> skip_whitespace_parser();
+	const auto result	  = parser(view);
+
+	// we do a look ahead to figure out if the next statement would be either a template, or an attribute
+	constexpr auto next_symbol_parser = any_of("<["sv);
+	if(const auto next = next_symbol_parser(result.view()); next) {
+		throw std::runtime_error("not implemented");
+	}
+	return result;
+}
+constexpr auto parse_type_assignment_seperator(psl::string8::view view)
+  -> psl::serialization::parser::parse_result_t<psl::string8::view> {
+	using namespace psl::serialization::parser;
+	constexpr auto parser = skip_whitespace_parser()<text_parser("="sv)> skip_whitespace_parser();
+	return parser(view);
+}
+
+constexpr auto parse_assignment_begin(psl::string8::view view)
+  -> psl::serialization::parser::parse_result_t<psl::string8::view> {
+	using namespace psl::serialization::parser;
+
+	constexpr auto parser = skip_whitespace_parser()<text_parser("{"sv)> skip_whitespace_parser();
+	return parser(view);
+}
+
+constexpr auto parse_assigment_value(psl::string8::view view)
+  -> psl::serialization::parser::parse_result_t<psl::string8::view> {
+	using namespace psl::serialization::parser;
+	parse_result_t<psl::string8::view> result {invalid_result};
+	// skip all space, then check if we are in a literal (either ' or " ), then check if it's a strong literal
+	// we parse the value based on that.
+	view = skip_whitespace_parser()(view).view();
+
+
+	if(const auto is_literal = any_of("\"'"sv)(view); is_literal) {
+		if(const auto is_strong_literal =
+			 exactly(2, char_parser(is_literal.value()), std::monostate {}, [](auto lhs, auto) { return lhs; })(
+			   is_literal.view());
+		   is_strong_literal) {
+			const auto get_value =
+			  accumulate_many([c = view.at(0)](parse_view_t view) -> parse_result_t<char> {
+				  if(view.size() >= 3 &&
+					 std::all_of(view.begin(), std::next(view.begin(), 3), [c](char val) { return c == val; })) {
+					  return invalid_result;
+				  }
+				  return {view.substr(1), view.at(0)};
+			  }) > text_parser(view.substr(0, 3));
+			result = get_value(is_strong_literal.view());
+		} else {
+			const auto get_value = accumulate_many([c = view.at(0)](parse_view_t view) -> parse_result_t<char> {
+									   if(view.size() >= 1 && view.at(0) == c) {
+										   return invalid_result;
+									   }
+									   return {view.substr(1), view.at(0)};
+								   }) > text_parser(view.substr(0, 1));
+			result				 = get_value(is_literal.view());
+		}
+	} else {
+		constexpr auto get_value = accumulate_many(none_of(" \n\r\t,}"));
+		result					 = get_value(view);
+	}
+	if(!result) {
+		return invalid_result;
+	}
+
+	view = result.view();
+
+	// next we check if we have a comma seperator, in case of array.
+	if(const auto seperator = (skip_whitespace_parser() < text_parser(","sv))(view); seperator) {
+		throw std::runtime_error("not implemented");
+	}
+
+	return result;
+}
+
+constexpr auto parse_assignment_end(psl::string8::view view)
+  -> psl::serialization::parser::parse_result_t<psl::string8::view> {
+	using namespace psl::serialization::parser;
+	constexpr auto parser = skip_whitespace_parser()<text_parser("}"sv) < skip_whitespace_parser() < text_parser(";"sv)>
+	skip_whitespace_parser();
+	return parser(view);
+}
+
+struct type_t {
+	psl::string8::view name;
+};
+struct value_t {
+	psl::string8::view value;
+};
+
+struct identifier_t {
+	psl::string8::view name;
+	type_t type;
+	value_t value;
+};
+
+constexpr auto parse_field(psl::string8::view view) -> psl::serialization::parser::parse_result_t<identifier_t> {
+	using namespace psl::serialization::parser;
+	identifier_t result {};
+
+	if(const auto identifier = parse_identifier(view); !identifier) {
+		return invalid_result;
+	} else {
+		result.name = identifier.value();
+		view		= identifier.view();
+	}
+
+	if(const auto seperator = parse_identifier_type_seperator(view); !seperator) {
+		return invalid_result;
+	} else {
+		view = seperator.view();
+	}
+
+	if(const auto type = parse_type(view); !type) {
+		return invalid_result;
+	} else {
+		view			 = type.view();
+		result.type.name = type.value();
+	}
+
+	if(const auto seperator = parse_type_assignment_seperator(view); !seperator) {
+		return invalid_result;
+	} else {
+		view = seperator.view();
+	}
+
+	if(const auto seperator = parse_assignment_begin(view); !seperator) {
+		return invalid_result;
+	} else {
+		view = seperator.view();
+	}
+
+	if(const auto value = parse_assigment_value(view); !value) {
+		return invalid_result;
+	} else {
+		view			   = value.view();
+		result.value.value = value.value();
+	}
+
+	if(const auto seperator = parse_assignment_end(view); !seperator) {
+		return invalid_result;
+	} else {
+		view = seperator.view();
+	}
+
+	return {view, result};
+}
+}	 // namespace psl::serialization::format

--- a/psl/inc/psl/serialization/parser.hpp
+++ b/psl/inc/psl/serialization/parser.hpp
@@ -66,7 +66,7 @@ parse_result_t(parse_view_t, T&&) -> parse_result_t<T>;
 template <typename FMapFn, IsParser ParserFn>
 constexpr auto fmap(FMapFn&& fmapFn, ParserFn&& parserFn) noexcept {
 	return [fmapFn = std::forward<FMapFn>(fmapFn), parserFn = std::forward<ParserFn>(parserFn)](
-			 parse_view_t view) -> parse_result_t<std::invoke_result_t<FMapFn, parser_result_type_t<ParserFn>>> {
+			 parse_view_t view) -> parse_result_t<std::invoke_result_t<FMapFn, typename parser_result_type_t<ParserFn>::value_type>> {
 		if(parse_result_t const res = parserFn(view); res) {
 			return {res.view(), fmapFn(res.value())};
 		}

--- a/psl/inc/psl/serialization/parser.hpp
+++ b/psl/inc/psl/serialization/parser.hpp
@@ -177,8 +177,10 @@ inline namespace operators {
 	}
 }	 // namespace operators
 
-template <IsParser Parser, typename T, typename Accumulator>
-constexpr auto many(Parser&& parser, T&& default_val, Accumulator&& accumulator, size_t atleast = 0) {
+template <IsParser Parser,
+		  typename T		   = typename parser_result_type_t<Parser>::value_type,
+		  typename Accumulator = std::plus<T>>
+constexpr auto many(Parser&& parser, T&& default_val = {}, Accumulator&& accumulator = {}, size_t atleast = 0) {
 	using return_type =
 	  parse_result_t<std::invoke_result_t<Accumulator, T, typename parser_result_type_t<Parser>::value_type>>;
 

--- a/psl/inc/psl/serialization/parser.hpp
+++ b/psl/inc/psl/serialization/parser.hpp
@@ -61,7 +61,7 @@ requires(std::is_default_constructible_v<T>) class parse_result_t {
 };
 
 template <typename T>
-parse_result_t(parse_view_t, T&&) -> parse_result_t<T>;
+parse_result_t(auto, T) -> parse_result_t<T>;
 
 template <typename FMapFn, IsParser ParserFn>
 constexpr auto fmap(FMapFn&& fmapFn, ParserFn&& parserFn) noexcept {

--- a/psl/inc/psl/serialization/parser.hpp
+++ b/psl/inc/psl/serialization/parser.hpp
@@ -1,0 +1,174 @@
+#pragma once
+#include "psl/ustring.hpp"
+#include <tuple>
+#include <type_traits>
+
+namespace psl::serialization::parser {
+using parse_view_t = psl::string8::view;
+
+inline namespace details {
+	struct invalid_result_t {
+		explicit constexpr invalid_result_t(int) noexcept {}
+	};
+
+	inline constexpr invalid_result_t invalid_result {int(0)};
+
+	template <typename T>
+	concept IsParser = std::is_invocable_v<T, parse_view_t>;
+
+	template <IsParser T>
+	struct parser_result_type {
+		using type = std::invoke_result_t<T, parse_view_t>;
+	};
+
+	template <IsParser... Parsers>
+	requires(sizeof...(Parsers) < 2)	// when 1 or 0 they are compatible by default
+	  struct is_compatible_parsers : std::true_type {};
+
+	template <IsParser Parser1, IsParser... Rest>
+	struct is_compatible_parsers<Parser1, Rest...>
+		: std::conditional_t<std::conjunction_v<std::is_same<typename parser_result_type<Parser1>::type,
+															 typename parser_result_type<Rest>::type>...>,
+							 std::true_type,
+							 std::false_type> {};
+
+	template <typename... Parsers>
+	concept IsCompatibleParsers = is_compatible_parsers<Parsers...>::value;
+
+
+	template <IsParser T, IsParser... Rest>
+	requires(sizeof...(Rest) == 0 ||
+			 IsCompatibleParsers<T, Rest...>) using parser_result_type_t = typename parser_result_type<T>::type;
+
+	template <typename T, typename Y>
+	struct make_tuple_with_element_count_impl {};
+
+	template <typename T, size_t... Indices>
+	struct make_tuple_with_element_count_impl<T, std::index_sequence<Indices...>> {
+		template <size_t>
+		using _type_repeater = T;
+
+		using type = std::tuple<_type_repeater<Indices>...>;
+	};
+
+	template <typename T, size_t Count>
+	struct make_tuple_with_element_count {
+		using type = typename make_tuple_with_element_count_impl<T, decltype(std::make_index_sequence<Count>())>::type;
+	};
+
+	template <typename T, size_t Count>
+	using make_tuple_with_element_count_t = typename make_tuple_with_element_count<T, Count>::type;
+}	 // namespace details
+
+template <typename T>
+requires(std::is_default_constructible_v<T>) class parse_result_t {
+  public:
+	using value_type = T;
+
+	constexpr parse_result_t() noexcept(std::is_nothrow_default_constructible_v<T>) = default;
+	constexpr parse_result_t(invalid_result_t) noexcept(std::is_nothrow_default_constructible_v<T>) {}
+	template <typename... Args>
+	constexpr parse_result_t(parse_view_t view, Args&&... args) noexcept(std::is_nothrow_constructible_v<T, Args...>)
+		: m_Value(std::forward<Args>(args)...), m_View(view) {}
+
+	constexpr operator bool() const noexcept { return m_View.data() != nullptr; }
+
+	constexpr T& value() noexcept { return m_Value; }
+	constexpr T const& value() const noexcept { return m_Value; }
+	constexpr parse_view_t& view() noexcept { return m_View; }
+	constexpr parse_view_t const& view() const noexcept { return m_View; }
+
+  private:
+	T m_Value {};
+	parse_view_t m_View {};
+};
+
+template <typename T>
+parse_result_t(parse_view_t, T&&) -> parse_result_t<T>;
+
+template <typename FMapFn, IsParser ParserFn>
+constexpr auto fmap(FMapFn&& fmapFn, ParserFn&& parserFn) noexcept {
+	return [fmapFn = std::forward<FMapFn>(fmapFn), parserFn = std::forward<ParserFn>(parserFn)](
+			 parse_view_t view) -> parse_result_t<std::invoke_result_t<FMapFn, parser_result_type_t<ParserFn>>> {
+		if(parse_result_t const res = parserFn(view); res) {
+			return {fmapFn(res.value()), res.view()};
+		}
+		return invalid_result;
+	};
+}
+
+template <typename T>
+constexpr auto fail(T&&) {
+	return [](parse_view_t) -> parse_result_t<T> { return invalid_result; };
+}
+
+template <typename T, typename ErrorFn>
+constexpr auto fail(T&&, ErrorFn&& errorFn) {
+	return [errorFn = std::forward<ErrorFn>(errorFn)](parse_view_t) -> parse_result_t<T> {
+		errorFn();
+		return invalid_result;
+	};
+}
+
+template <IsParser Parser1, IsParser Parser2>
+requires(IsCompatibleParsers<Parser1, Parser2>) constexpr auto if_else(Parser1&& parser1, Parser2&& parser2) noexcept {
+	return [parser1 = std::forward<Parser1>(parser1),
+			parser2 = std::forward<Parser2>(parser2)](parse_view_t view) -> parser_result_type_t<Parser1> {
+		if(const parse_result_t res1 = parser1(view); res1) {
+			return res1;
+		}
+		return parser2(view);
+	};
+}
+
+template <IsParser... Parsers, typename AccumulatorFn>
+requires(IsCompatibleParsers<Parsers...> &&
+		 sizeof...(Parsers) > 1) constexpr auto accumulate(Parsers&&... parsers, AccumulatorFn&& accumulatorFn) {
+	using parser_return_type	  = parser_result_type_t<Parsers...>;
+	using accumulated_result_type = make_tuple_with_element_count_t<parser_return_type, sizeof...(Parsers)>;
+	using return_type = parse_result_t<std::invoke_result_t<AccumulatorFn, parser_return_type, parser_return_type>>;
+
+	return [parsers = std::forward<Parsers>(parsers)](parse_view_t view) -> return_type {
+		return_type result {invalid_result};
+		auto cpy_view = view;
+		bool stop {false};
+		accumulated_result_type accumulated {[&stop, &view]() mutable -> parser_return_type {
+			if(!stop) {
+				const auto result = Parsers(view);
+				if(!result) {
+					stop = true;
+					return invalid_result;
+				} else {
+					view = result.view();
+					return result;
+				}
+			}
+		}()...};
+
+		if(stop) {
+			return invalid_result;
+		}
+		return {std::apply(AccumulatorFn, accumulated), view};
+	};
+}
+
+template <IsParser ParserLhs, IsParser ParserRhs>
+requires(IsCompatibleParsers<ParserLhs, ParserRhs>) constexpr auto drop_left(ParserLhs&& lhs, ParserRhs&& rhs) {
+	return accumulate(std::forward<ParserLhs>(lhs), std::forward<ParserRhs>(rhs), []<typename T>(T&&, T&& rhs) {
+		return std::forward<T>(rhs);
+	});
+}
+
+template <IsParser ParserLhs, IsParser ParserRhs>
+requires(IsCompatibleParsers<ParserLhs, ParserRhs>) constexpr auto drop_right(ParserLhs&& lhs, ParserRhs&& rhs) {
+	return accumulate(std::forward<ParserLhs>(lhs), std::forward<ParserRhs>(rhs), []<typename T>(T&& lhs, T&&) {
+		return std::forward<T>(lhs);
+	});
+}
+
+template <IsParser Parser1, IsParser Parser2>
+requires(IsCompatibleParsers<Parser1, Parser2>) constexpr auto operator|(Parser1&& parser1,
+																		 Parser2&& parser2) noexcept {
+	return if_else(std::forward<Parser1>(parser1), std::forward<Parser2>(parser2));
+}
+}	 // namespace psl::serialization::parser

--- a/psl/main/main.cpp
+++ b/psl/main/main.cpp
@@ -10,7 +10,7 @@
 int main(int argc, char* argv[]) {
 	using namespace psl::serialization::parser;
 
-	constexpr psl::string8::view text {"identifier : t<float> { 'some_value', '5', '''3  3 ''' };"};
+	constexpr psl::string8::view text {"identifier : t<float> [inline]{ 'some_value', '5', '''3  3 ''' };"};
 
 	constexpr auto size = psl::serialization::format::size::parse_field(text);
 	// constexpr std::array<char, size.value()> storage {};

--- a/psl/main/main.cpp
+++ b/psl/main/main.cpp
@@ -10,7 +10,7 @@
 int main(int argc, char* argv[]) {
 	using namespace psl::serialization::parser;
 
-	constexpr psl::string8::view text {"identifier : t = { 'some_value', '5', '''3  3 ''' };"};
+	constexpr psl::string8::view text {"identifier : t<float> { 'some_value', '5', '''3  3 ''' };"};
 
 	constexpr auto size = psl::serialization::format::size::parse_field(text);
 	// constexpr std::array<char, size.value()> storage {};

--- a/psl/main/main.cpp
+++ b/psl/main/main.cpp
@@ -9,16 +9,33 @@
 
 int main(int argc, char* argv[]) {
 	using namespace psl::serialization::parser;
+	using namespace psl;
 
 	constexpr psl::string8::view text {"identifier : t<float> [inline] { 'some_value', '5', '''3  3 ''' };"};
-	constexpr psl::string8::view text2 {"i : object { a : object { b := {}; };  }; "};
+	constexpr psl::string8::view text1 {"i : object { a : f {};  }; "};
+	constexpr psl::string8::view text2 {"i : object { a : object { b : {f}; };  }; "};
+	constexpr psl::string8::view text3 {"b : {f};"};
+	constexpr psl::string8::view text4 {
+	  "identifi : object<float> [inline{something}] { a : object { b : {''' ''', unguarded}; };  }; "};
 
-	constexpr auto size = psl::serialization::format::size::parse(text2);
-	// constexpr std::array<char, size.value()> storage {};
-	constexpr auto field = psl::serialization::format::parse_field(text);
-	// static_assert(field.value().name == "identifier"sv);
-	// static_assert(field.value().type.name == "t"sv);
-	// static_assert(field.value().value.value == "some_value   "sv);
+	constexpr psl::string8::view text5 {"b : {''' ''', unguarded}; "};
+	constexpr auto size = psl::serialization::format::size(text2);
+	// constexpr auto size = psl::serialization::format::size::parse(text4);
+	//// constexpr std::array<char, size.value()> storage {};
+	// constexpr auto field = psl::serialization::format::parse_field(text);
+
+	//// constexpr auto f = psl::serialization::format::parse<
+	////   "identifi : object<float> [inline{something}] { a : object { b : {''' ''', unguarded}; };  };
+	////   "_fixed_astring>();
+
+	// constexpr auto f = psl::serialization::format::parse("identifi : object<float> {};"_ctstr);
+
+	/*constexpr auto f2	  = psl::serialization::format::parsing (psl::details::fixed_astring {
+	  "identifi : object<float> [inline{something}] { a : object { b : {''' ''', unguarded}; };  }; "});*/
+	// constexpr auto f_view = f2.value().view();
+	//  static_assert(field.value().name == "identifier"sv);
+	//  static_assert(field.value().type.name == "t"sv);
+	//  static_assert(field.value().value.value == "some_value   "sv);
 
 	// std::printf("%.*s\n", static_cast<int>(value.value().size()), value.value().data());
 	return 0;

--- a/psl/main/main.cpp
+++ b/psl/main/main.cpp
@@ -10,11 +10,12 @@
 int main(int argc, char* argv[]) {
 	using namespace psl::serialization::parser;
 
-	constexpr psl::string8::view text {"identifier : t<float> [inline]{ 'some_value', '5', '''3  3 ''' };"};
+	constexpr psl::string8::view text {"identifier : t<float> [inline] { 'some_value', '5', '''3  3 ''' };"};
+	constexpr psl::string8::view text2 {"i : object { a : object { b := {}; };  }; "};
 
-	constexpr auto size = psl::serialization::format::size::parse_field(text);
+	constexpr auto size = psl::serialization::format::size::parse(text2);
 	// constexpr std::array<char, size.value()> storage {};
-	// constexpr auto field = psl::serialization::format::parse_field(text);
+	constexpr auto field = psl::serialization::format::parse_field(text);
 	// static_assert(field.value().name == "identifier"sv);
 	// static_assert(field.value().type.name == "t"sv);
 	// static_assert(field.value().value.value == "some_value   "sv);

--- a/psl/main/main.cpp
+++ b/psl/main/main.cpp
@@ -10,13 +10,14 @@
 int main(int argc, char* argv[]) {
 	using namespace psl::serialization::parser;
 
-	constexpr psl::string8::view text {"identifier : t = { 'some_value   ' };"};
+	constexpr psl::string8::view text {"identifier : t = { 'some_value', '5', '''3  3 ''' };"};
 
-	constexpr auto field = psl::serialization::format::parse_field(text);
-	static_assert(field.value().name == "identifier"sv);
-	static_assert(field.value().type.name == "t"sv);
-	static_assert(field.value().value.value == "some_value   "sv);
-
+	constexpr auto size = psl::serialization::format::size::parse_field(text);
+	// constexpr std::array<char, size.value()> storage {};
+	// constexpr auto field = psl::serialization::format::parse_field(text);
+	// static_assert(field.value().name == "identifier"sv);
+	// static_assert(field.value().type.name == "t"sv);
+	// static_assert(field.value().value.value == "some_value   "sv);
 
 	// std::printf("%.*s\n", static_cast<int>(value.value().size()), value.value().data());
 	return 0;

--- a/psl/main/main.cpp
+++ b/psl/main/main.cpp
@@ -19,8 +19,9 @@ int main(int argc, char* argv[]) {
 	  "identifi : object<float> [inline{something}] { a : object { b : {''' ''', unguarded}; };  }; "};
 
 	constexpr psl::string8::view text5 {"b : {''' ''', unguarded}; "};
-	constexpr auto size = psl::serialization::format::size(text2);
-	auto view			= psl::serialization::format::parse_unsafe<size.value()>(text2);
+	constexpr psl::string8::view text6 {"#version 5; identifier : {5};"};
+	constexpr auto size = psl::serialization::format::size(text6);
+	constexpr auto view = psl::serialization::format::parse<size.value()>();
 	// constexpr auto size = psl::serialization::format::size::parse(text4);
 	//// constexpr std::array<char, size.value()> storage {};
 	// constexpr auto field = psl::serialization::format::parse_field(text);

--- a/psl/main/main.cpp
+++ b/psl/main/main.cpp
@@ -20,6 +20,7 @@ int main(int argc, char* argv[]) {
 
 	constexpr psl::string8::view text5 {"b : {''' ''', unguarded}; "};
 	constexpr auto size = psl::serialization::format::size(text2);
+	auto view			= psl::serialization::format::parse_unsafe<size.value()>(text2);
 	// constexpr auto size = psl::serialization::format::size::parse(text4);
 	//// constexpr std::array<char, size.value()> storage {};
 	// constexpr auto field = psl::serialization::format::parse_field(text);

--- a/psl/main/main.cpp
+++ b/psl/main/main.cpp
@@ -5,6 +5,19 @@
 // generated in the output's `bin` folder
 // --------------------------------------------------------------------------------------------------------------------
 
+#include "psl/serialization/format.hpp"
+
 int main(int argc, char* argv[]) {
+	using namespace psl::serialization::parser;
+
+	constexpr psl::string8::view text {"identifier : t = { 'some_value   ' };"};
+
+	constexpr auto field = psl::serialization::format::parse_field(text);
+	static_assert(field.value().name == "identifier"sv);
+	static_assert(field.value().type.name == "t"sv);
+	static_assert(field.value().value.value == "some_value   "sv);
+
+
+	// std::printf("%.*s\n", static_cast<int>(value.value().size()), value.value().data());
 	return 0;
 }

--- a/psl/main/main.cpp
+++ b/psl/main/main.cpp
@@ -1,3 +1,9 @@
+// --------------------------------------------------------------------------------------------------------------------
+// This main file exists for development purposes, here you can easily test out new features etc.. that are only
+// implemented in the [psl] library.
+// To activate this main file invoke cmake with `-DPE_DEV_MAKE_PSL_EXE=ON` and a new binary named `psl_main` will be
+// generated in the output's `bin` folder
+// --------------------------------------------------------------------------------------------------------------------
 
 int main(int argc, char* argv[]) {
 	return 0;

--- a/tests/src.txt
+++ b/tests/src.txt
@@ -4,6 +4,7 @@ src/ecs.cpp
 src/ecs/staged_sparse_memory_region.cpp
 src/math_tests.cpp
 src/memory.cpp
+src/serialization.cpp
 src/tests/generator.cpp
 src/task_test.cpp
 )

--- a/tests/src/serialization.cpp
+++ b/tests/src/serialization.cpp
@@ -1,0 +1,129 @@
+#include "psl/serialization/format.hpp"
+
+#include <litmus/expect.hpp>
+#include <litmus/section.hpp>
+#include <litmus/suite.hpp>
+
+#include <litmus/generator/range.hpp>
+
+using namespace litmus;
+
+struct text_data_t {
+	psl::string8::view text;
+	size_t identifiers;
+	size_t identifiers_size;
+	size_t values;
+	size_t values_size;
+	size_t types;
+	size_t types_size;
+	size_t directives;
+	size_t directives_size;
+	size_t directive_values;
+	size_t directive_values_size;
+	bool valid;
+};
+
+constexpr std::array data {
+  text_data_t {
+	.text				   = "identifier : object { val0 : {}; val1 : {'something'};};"sv,
+	.identifiers		   = 3,
+	.identifiers_size	   = 18,
+	.values				   = 2,
+	.values_size		   = 9,
+	.types				   = 3,
+	.types_size			   = 6,
+	.directives			   = 0,
+	.directives_size	   = 0,
+	.directive_values	   = 0,
+	.directive_values_size = 0,
+	.valid				   = true,
+  },
+  text_data_t {
+	.text = "identifier : object { obj0 : object { val0: {''' ''', '--' }; obj1 :{}; }; val1 : {'something'};};"sv,
+	.identifiers		   = 5,
+	.identifiers_size	   = 26,
+	.values				   = 4,
+	.values_size		   = 12,
+	.types				   = 5,
+	.types_size			   = 12,
+	.directives			   = 0,
+	.directives_size	   = 0,
+	.directive_values	   = 0,
+	.directive_values_size = 0,
+	.valid				   = true,
+  },
+  text_data_t {
+	.text =
+	  "#version 1; identifier : object { obj0 : object { val0: {''' ''', '--' }; obj1 :{}; }; val1 : {'something'};}; #import hello.txt;"sv,
+	.identifiers		   = 5,
+	.identifiers_size	   = 26,
+	.values				   = 4,
+	.values_size		   = 12,
+	.types				   = 5,
+	.types_size			   = 12,
+	.directives			   = 2,
+	.directives_size	   = 13,
+	.directive_values	   = 2,
+	.directive_values_size = 10,
+	.valid				   = true,
+  },
+  text_data_t {
+	// directive statements within an object aren't allowed
+	.text  = "obj : f { #version 5; }"sv,
+	.valid = false,
+  },
+  text_data_t {
+	// here we don't get to parse the entire view, which should result in an error.
+	.text  = "#version 5; }"sv,
+	.valid = false,
+  },
+};
+
+template <size_t N>
+struct vpack_for_array {
+	using type = decltype([]<size_t... Indices>(std::index_sequence<Indices...>) {
+		return vpack<Indices...> {};
+	}(std::make_index_sequence<N> {}));
+};
+
+template <size_t N>
+using vpack_for_array_t = typename vpack_for_array<N>::type;
+
+namespace {
+auto t0 = suite<"psl::serialization::format">().templates<vpack<true, false>, vpack_for_array_t<data.size()>>() =
+  []<typename IsConstexpr, typename Index>() {
+	  constexpr auto is_constexpr = IsConstexpr::value;
+	  constexpr auto index		  = Index::value;
+
+	  auto tests = [](auto const& result, auto const& data) {
+		  expect(result) == data.valid;
+
+		  // if the data is invalid, we don't expect any result to be correct beyond this point
+		  if(!data.valid) {
+			  return;
+		  }
+
+		  expect(result.value().identifiers.count) == data.identifiers;
+		  expect(result.value().identifiers.size) == data.identifiers_size;
+		  expect(result.value().values.count) == data.values;
+		  expect(result.value().values.size) == data.values_size;
+		  expect(result.value().types.count) == data.types;
+		  expect(result.value().types.size) == data.types_size;
+		  expect(result.value().directives.count) == data.directives;
+		  expect(result.value().directives.size) == data.directives_size;
+		  expect(result.value().directives_values.count) == data.directive_values;
+		  expect(result.value().directives_values.size) == data.directive_values_size;
+	  };
+
+	  // no point in testing invalid data as it will result in a compile error
+	  if constexpr(is_constexpr) {
+		  if(data[index].valid) {
+			  constexpr auto result = psl::serialization::format::size(data[index].text);
+			  tests(result, data[index]);
+		  }
+	  } else {
+		  auto result = psl::serialization::format::size(data[index].text);
+		  tests(result, data[index]);
+	  }
+  };
+}


### PR DESCRIPTION
This PR adds a new serialization format with the following stated goals:

- versioning on a per-object level (through attribute).
- complex user defined type support
- supports attributes that can validate and transform data
- compile time parsing support
- value validation
- binary support, both on a per-value as well as the format as a whole (though string based for user friendlines is required).

One of the common issues with dataformats for games is that often times these data formats are used to define design related values. This in itself isn't a problem (in fact the opposite), but it becomes painful to deal with when you change values in refactors or the natural process of developing your project.

As example, imagine a game where you set the damage values of enemies in your config files, during a rebalance you realize that the maximum damage is too high and should be lowered, so you run a find-replace on your data. You accidentally miss one value, and now players are likely unhappy with this overpowered enemy (or in some cases this can result in exploits). This is where attributes can come in. In our case you could define a `prototype` that defines the fields of all enemies, see it as a base class. All instances of this prototype inherit the fields present, including the damage field. During a refactor you add an attribute to the field that stipulates the min/max damage range, and now you can run all datafiles through the validator to see if you accidentally forgot any.

Other attributes could be `[deprecate]` -> indicates a field should warn when defined.