### PR TITLE
Fix/stream-encoder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,15 +3,15 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
     message(FATAL_ERROR "ERROR: detected an in-tree build. please create a sub-directory and invoke cmake from there, or a location outside the project.")
 endif()
 
-if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
-    message(FATAL_ERROR "we require a 64bit build platform")
-endif()
-
 cmake_minimum_required(VERSION 3.16)
 set(PE_NAME paradigm CACHE INTERNAL "")
 project(${PE_NAME} VERSION 1.0.0 LANGUAGES CXX C)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(CMakeDependentOption)
+
+if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+    message(FATAL_ERROR "we require a 64bit build platform, got sizeof void* being ${CMAKE_SIZEOF_VOID_P} bytes")
+endif()
 
 if (UNIX AND NOT APPLE AND NOT ANDROID)
     set(LINUX TRUE)

--- a/core/inc/core/data/stream.hpp
+++ b/core/inc/core/data/stream.hpp
@@ -244,8 +244,8 @@ class vertex_stream_t {
 			std::visit(
 			  [&serializer]<typename T>(T& value) {
 				  psl::serialization::property<"TYPE", type> typeProp {T::memory_stream_type};
-				  psl::serialization::property<"DATA", psl::array_view<typename T::unit_t>> data {value.value()};
-				  serializer << typeProp << data;
+				  serializer << typeProp;
+				  serializer.template parse<"DATA">(value.value());
 			  },
 			  m_Stream);
 		}

--- a/psl/inc/psl/platform_utils.hpp
+++ b/psl/inc/psl/platform_utils.hpp
@@ -202,7 +202,7 @@ namespace file {
 	/// \param[in] filename the path to the file.
 	/// \returns true in case the file was successfuly erased.
 	/// \todo android lacks an implementation.
-	static bool erase(psl::string_view filename);
+	bool erase(psl::string_view filename);
 
 	/// \brief reads the given filepath's contents into a psl::char_t container.
 	/// \param[in] filename the path to the file.


### PR DESCRIPTION
Fixes the `core::vertex_stream_t` encoder (compile error) and the incorrect signature of erasing files.

Additionally the cmake's pointer size detection was improved.