### PR TITLE
cppfront

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "extern/strtype"]
 	path = extern/strtype
 	url = https://github.com/JessyDL/strtype.git
+[submodule "extern/cppfront"]
+	path = extern/cppfront
+	url = https://github.com/hsutter/cppfront.git

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -101,10 +101,20 @@ add_custom_command(TARGET core_generator
 	BYPRODUCTS ${CMAKE_CURRENT_SOURCE_DIR}/gen/core/paradigm.hpp
 	COMMENT "Generating headers for Paradigm")
 
-add_library(core STATIC ${FWD} ${SRC} ${INC} ${GEN} ${INC_GLES} ${SRC_GLES} ${INC_VULKAN} ${SRC_VULKAN} ${NATVIS})
+add_custom_target(core_cppfront)
+list(TRANSFORM SRC_GEN_CPP2 PREPEND ${CMAKE_CURRENT_SOURCE_DIR}/)
+add_custom_command(TARGET core_cppfront
+	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../tools/cppfront.py -c $<TARGET_FILE:cppfront_compiler> -i ${SRC_CPP2} --generate
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	BYPRODUCTS ${SRC_GEN_CPP2}
+	COMMENT "Transpile cpp2 to cpp")
+
+add_dependencies(core_cppfront cppfront_compiler)
+
+add_library(core STATIC ${FWD} ${SRC} ${INC} ${GEN} ${INC_GLES} ${SRC_GLES} ${INC_VULKAN} ${SRC_VULKAN} ${NATVIS} ${SRC_GEN_CPP2})
 add_library(paradigm::core ALIAS core)
 
-add_dependencies(core core_generator)
+add_dependencies(core core_generator core_cppfront)
 
 if(${PE_PCH})
 	target_precompile_headers(core PUBLIC ${INC_PCH})
@@ -119,7 +129,7 @@ if(VK_STATIC AND PE_VULKAN)
 	list(APPEND PE_DL_LIBS ${vk_lib_name})
 endif()
 
-target_link_libraries(core PUBLIC paradigm::psl ${CMAKE_DL_LIBS} ${PE_DL_LIBS} ${TEST_LIBS})
+target_link_libraries(core PUBLIC paradigm::psl ${CMAKE_DL_LIBS} ${PE_DL_LIBS} ${TEST_LIBS} cppfront_interface)
 set_target_output_directory(core)
 target_include_directories(core
 	PUBLIC 

--- a/core/src.txt
+++ b/core/src.txt
@@ -108,8 +108,6 @@ if(${PE_GLES})
 endif()
 
 set(SRC_CPP2
-	hello
-	other
 )
 
 list(TRANSFORM SRC_CPP2 PREPEND src/)

--- a/core/src.txt
+++ b/core/src.txt
@@ -106,3 +106,14 @@ if(${PE_GLES})
 	list(TRANSFORM SRC_GLES PREPEND src/gles/)
 	list(TRANSFORM SRC_GLES APPEND .cpp)
 endif()
+
+set(SRC_CPP2
+	hello
+	other
+)
+
+list(TRANSFORM SRC_CPP2 PREPEND src/)
+set(SRC_GEN_CPP2 ${SRC_CPP2})
+list(TRANSFORM SRC_GEN_CPP2 APPEND .gen.cpp)
+list(TRANSFORM SRC_CPP2 APPEND .cpp2)
+set_source_files_properties(${SRC_GEN_CPP2} PROPERTIES GENERATED 1)

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -33,3 +33,24 @@ if(NOT TARGET strtype)
     add_subdirectory(strtype)
 endif()
 set_property(TARGET strtype PROPERTY FOLDER "extern")
+
+# setup cppfront which lacks a cmake integration
+add_executable(cppfront_compiler cppfront/source/cppfront.cpp)
+set_target_properties(
+    cppfront_compiler
+    PROPERTIES
+    OUTPUT_NAME cppfront
+    EXPORT_NAME cppfront
+)
+target_compile_features(cppfront_compiler PRIVATE cxx_std_20)
+
+add_library(cppfront_interface INTERFACE)
+target_compile_features(cppfront_interface INTERFACE cxx_std_20)
+target_sources(
+    cppfront_interface
+    INTERFACE
+    FILE_SET HEADERS
+    BASE_DIRS cppfront/include
+    FILES cppfront/include/cpp2util.h
+)
+target_include_directories(cppfront_interface SYSTEM INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cppfront/include>")

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -35,22 +35,10 @@ endif()
 set_property(TARGET strtype PROPERTY FOLDER "extern")
 
 # setup cppfront which lacks a cmake integration
-add_executable(cppfront_compiler cppfront/source/cppfront.cpp)
-set_target_properties(
-    cppfront_compiler
-    PROPERTIES
-    OUTPUT_NAME cppfront
-    EXPORT_NAME cppfront
-)
-target_compile_features(cppfront_compiler PRIVATE cxx_std_20)
+add_executable(cppfront_compiler "${CMAKE_CURRENT_SOURCE_DIR}/cppfront/source/cppfront.cpp")
+target_include_directories(cppfront_compiler PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/cppfront/source")
+set_target_properties(cppfront_compiler PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED TRUE OUTPUT_NAME cppfront EXPORT_NAME cppfront)
 
-add_library(cppfront_interface INTERFACE)
-target_compile_features(cppfront_interface INTERFACE cxx_std_20)
-target_sources(
-    cppfront_interface
-    INTERFACE
-    FILE_SET HEADERS
-    BASE_DIRS cppfront/include
-    FILES cppfront/include/cpp2util.h
-)
+add_library(cppfront_interface INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/cppfront/include/cpp2util.h")
+set_target_properties(cppfront_interface PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED TRUE)
 target_include_directories(cppfront_interface SYSTEM INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cppfront/include>")

--- a/tools/cppfront.py
+++ b/tools/cppfront.py
@@ -1,0 +1,37 @@
+from typing import List
+from argparse import ArgumentParser
+import subprocess
+import os
+
+def get_path(file: str):
+    filename, extension = os.path.splitext(file)
+    return (file, f"{filename}.gen{extension[:-1]}") if extension in [".cpp2", ".hpp2"] else (None, None)
+
+
+def clean(files : List[str]):
+    for file in files:
+        source, destination = get_path(file)
+        if source and destination and os.path.exists(destination):
+            os.remove(destination)
+
+def generate(compiler : str, files : List[str]):
+    for file in files:
+        source, destination = get_path(file)
+        if source and destination:
+            process = subprocess.run([compiler, source, "-o", destination])
+            assert(process.returncode == 0)
+
+if __name__ == "__main__":
+    argParse = ArgumentParser(description='Generate cppfront files for the current project.')
+    argParse.add_argument("-i", "--input", default=[], nargs='?')
+    argParse.add_argument("-c", "--compiler")
+    argParse.add_argument("--clean", action='store_true')
+    argParse.add_argument("--generate", action='store_true')
+
+    args = argParse.parse_args()
+    
+    if args.input is not None and len(args.input) > 0:    
+        if(args.clean):
+            clean(args.input)
+        if(args.generate):
+            generate(args.compiler, args.input)


### PR DESCRIPTION
Adds cppfront as a potential language to use in `paradigm`. With the latest version of cppfront facilities for reflection were added, and so it could be a good idea to migrate existing serialization solutions to this.