### PR TITLE
fixed breaking change to github CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,7 +23,7 @@ jobs:
     - name: setup dependencies
       run: python3 tools/generate_project_info.py
     - name: initialize
-      run: cmake --preset=${{ matrix.target }}-release -DPE_BENCHMARKS=${{ matrix.benchmarks }} -DPE_TESTS=${{ matrix.tests }} -DCMAKE_C_COMPILER=$(brew --prefix llvm)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++
+      run: cmake --preset=${{ matrix.target }}-release -DPE_BENCHMARKS=${{ matrix.benchmarks }} -DPE_TESTS=${{ matrix.tests }} -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++
     - name: compile
       run: cmake --build --preset=${{ matrix.target }}-release -j ${{ steps.cpu-cores.outputs.count }}
     - name: test


### PR DESCRIPTION
MacOS's github CI image had another breaking change w.r.t. the location for LLVM. This PR resolves that