### PR TITLE
Added timeout for MacOS CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,3 +29,4 @@ jobs:
     - name: test
       if: ${{ matrix.tests == 'ON' }}
       run: ./builds/default/bin/tests --formatter compact --no-source
+      timeout-minutes: 20


### PR DESCRIPTION
Added a reasonable timeout as the tests sometimes fail to report and the platform currently is non-critical anyway