### PR TITLE
 make architecture part of the build folder setup

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,6 +12,7 @@ jobs:
         include:
           - benchmarks: OFF
             tests: ON
+            arch: x86_64
     name: build
     runs-on: macos-12
     steps:
@@ -28,5 +29,5 @@ jobs:
       run: cmake --build --preset=${{ matrix.target }}-release -j ${{ steps.cpu-cores.outputs.count }}
     - name: test
       if: ${{ matrix.tests == 'ON' }}
-      run: ./builds/default/bin/tests --formatter compact --no-source
+      run: ./builds/${{ matrix.target }}/${{ matrix.arch }}/default/bin/tests --formatter compact --no-source
       timeout-minutes: 20

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -33,6 +33,12 @@ jobs:
         compiler: [gcc, clang]
         graphics: [vulkan, all]
         include:
+          - target: gnu-linux
+            name: gnulinux
+            arch: x86_64
+          - target: android
+            name: android
+            arch: arm64
           - cc: gcc-12
             cxx: g++-12
             benchmarks: OFF
@@ -85,18 +91,18 @@ jobs:
       run: cmake --build --preset=${{ matrix.target }}-release-${{ matrix.graphics }} -j ${{ steps.cpu-cores.outputs.count }}
     - name: test
       if: ${{ matrix.tests == 'ON' }}
-      run: ./builds/default/bin/tests --formatter compact --no-source
+      run: ./builds/${{ matrix.name }}/${{ matrix.arch }}/default/bin/tests --formatter compact --no-source
     - name: finalize
       if: ${{ matrix.benchmarks == 'ON' }}
       uses: actions/upload-artifact@v3
       with:
         name: ubuntu-${{ matrix.compiler }}-${{ matrix.graphics }}-bin
-        path: builds/default/bin/benchmarks
+        path: builds/${{ matrix.name }}/${{ matrix.arch }}/default/bin/benchmarks
         if-no-files-found: error
         retention-days: 1
     - name: verify
       if: ${{ matrix.target == 'android' }}
-      run: python3 -c "import os;import sys;sys.exit(0) if os.path.exists('builds/android/main/build/outputs/bundle/release/main-release.aab') else sys.exit(1)"
+      run: python3 -c "import os;import sys;sys.exit(0) if os.path.exists('builds/${{ matrix.name }}/${{ matrix.arch }}/main/build/outputs/bundle/release/main-release.aab') else sys.exit(1)"
   # run benchmarks for the permutations that build the benchmarks binary
   benchmark:
     strategy:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,10 +16,8 @@ jobs:
             benchmarks: ON
           - arch: x86
             bitconfig: 32
-            output: Win32
           - arch: x86_64
             bitconfig: 64
-            output: x64
     name: build
     runs-on: windows-2022
     steps:
@@ -36,19 +34,19 @@ jobs:
       run: |
             python3 tools/generate_project_info.py
             cmake --preset=windows-${{ matrix.bitconfig }}-release-${{ matrix.graphics }} -DPE_BENCHMARKS=${{ matrix.benchmarks }}
-            python3 tools/patch.py --project ./project_files/${{ matrix.output }}/
+            python3 tools/patch.py --project ./project_files/${{ matrix.arch }}/
     - name: compile
       run: cmake --build --preset=windows-${{ matrix.bitconfig }}-release-${{ matrix.graphics }} -j ${{ steps.cpu-cores.outputs.count }}
     - name: test
       run: |
-            cd builds\${{ matrix.output }}\release\bin
+            cd builds/windows/${{ matrix.arch }}/release/bin
             .\tests.exe --formatter compact --no-source
     - name: finalize    
       if: ${{ matrix.benchmarks == 'ON' }}
       uses: actions/upload-artifact@v3
       with:
         name: windows-${{ matrix.graphics }}-bin
-        path: builds/${{ matrix.output }}/release/bin/benchmarks.exe
+        path: builds/windows/${{ matrix.arch }}/release/bin/benchmarks.exe
         if-no-files-found: error
         retention-days: 1
   benchmark:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,14 +139,14 @@ if(PE_PLATFORM STREQUAL "ANDROID" AND NOT EXISTS "${CMAKE_SOURCE_DIR}/AndroidMan
 	add_custom_target(paradigm_android_generate ALL)
 	add_custom_command(TARGET paradigm_android_generate
 		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tools/android.py
-			--output ${PE_BUILD_DIR}/android/${PE_ARCHITECTURE_LOWER}
+			--output ${PE_BUILD_DIR}
 			${ANDROID_PY_ARGS}
-		USES_TERMINAL BYPRODUCTS ${PE_BUILD_DIR}/android/gradle.properties)
+		USES_TERMINAL BYPRODUCTS ${PE_BUILD_DIR}/gradle.properties)
 
 	add_custom_target(paradigm_android_build ALL DEPENDS paradigm_android_generate)
 	add_custom_command(TARGET paradigm_android_build
 		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tools/android.py
-			--output ${PE_BUILD_DIR}/android/${PE_ARCHITECTURE_LOWER}
+			--output ${PE_BUILD_DIR}
 			--build gles ${PE_GLES} vulkan ${PE_VULKAN} vulkan.version ${PE_VULKAN_VERSION}
 			--type ${build_type}
 			${ANDROID_PY_ARGS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ set_property(CACHE PE_ARCHITECTURE PROPERTY STRINGS AUTO x86 x86_64 ARM64)
 OPTION(PE_USE_NATVIS "Configure project to use Visual Studio native visualizers when building for visual studio" TRUE)
 OPTION(PE_BENCHMARKS "Enable the generation of benchmarks" OFF)
 
-set(PE_BUILD_DIR "${CMAKE_BINARY_DIR}/builds/" CACHE PATH "target location where to build the project to")
+set(PE_BUILD_DIR "" CACHE PATH "target location where to build the project to")
 set(PE_DEFINES -DUNICODE;-D_UNICODE;-DNOMINMAX CACHE INTERNAL "")
 OPTION(PE_DEFAULT_COMPILE_OPTIONS "Use the default set of compile options (check 'compile options' section in the CMakelists.txt file)" TRUE)
 set(ANDROID_SDK "" CACHE PATH "override root android sdk location")
@@ -110,7 +110,18 @@ endif()
 string(TOUPPER ${PE_ARCHITECTURE} PE_ARCHITECTURE)
 list(APPEND PE_DEFINES -DPE_ARCHITECTURE_${PE_ARCHITECTURE})
 
+if(PE_BUILD_DIR STREQUAL "")
+	string(TOLOWER ${PE_PLATFORM} PE_PLATFORM_LOWER)
+	string(TOLOWER ${PE_ARCHITECTURE} PE_ARCHITECTURE_LOWER)
+	if(PE_PLATFORM_LOWER STREQUAL "linux")
+		set(PE_PLATFORM_LOWER gnulinux)
+	endif()
+	set(PE_BUILD_DIR "${CMAKE_SOURCE_DIR}/builds/${PE_PLATFORM_LOWER}/${PE_ARCHITECTURE_LOWER}")
+endif()
+
 if(PE_PLATFORM STREQUAL "ANDROID" AND NOT EXISTS "${CMAKE_SOURCE_DIR}/AndroidManifest.xml")
+	string(TOLOWER ${PE_ARCHITECTURE} PE_ARCHITECTURE_LOWER)
+
 	SET(Python_ADDITIONAL_VERSIONS 3 3.0)
 	find_package(PythonInterp REQUIRED)
 	set(ANDROID_PY_ARGS)
@@ -128,14 +139,14 @@ if(PE_PLATFORM STREQUAL "ANDROID" AND NOT EXISTS "${CMAKE_SOURCE_DIR}/AndroidMan
 	add_custom_target(paradigm_android_generate ALL)
 	add_custom_command(TARGET paradigm_android_generate
 		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tools/android.py
-			--output ${PE_BUILD_DIR}/android
+			--output ${PE_BUILD_DIR}/android/${PE_ARCHITECTURE_LOWER}
 			${ANDROID_PY_ARGS}
 		USES_TERMINAL BYPRODUCTS ${PE_BUILD_DIR}/android/gradle.properties)
 
 	add_custom_target(paradigm_android_build ALL DEPENDS paradigm_android_generate)
 	add_custom_command(TARGET paradigm_android_build
 		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tools/android.py
-			--output ${PE_BUILD_DIR}/android
+			--output ${PE_BUILD_DIR}/android/${PE_ARCHITECTURE_LOWER}
 			--build gles ${PE_GLES} vulkan ${PE_VULKAN} vulkan.version ${PE_VULKAN_VERSION}
 			--type ${build_type}
 			${ANDROID_PY_ARGS}
@@ -210,8 +221,8 @@ if(is_multi_config)
 		string(TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG)
 		string(TOLOWER ${OUTPUTCONFIG} OUTPUTCONFIG_FOLDERNAME)
 		
-		file(MAKE_DIRECTORY "${PE_BUILD_DIR}/${OUTPUTCONFIG_FOLDERNAME}/${ARCHI}/bin")
-		file(MAKE_DIRECTORY "${PE_BUILD_DIR}/${OUTPUTCONFIG_FOLDERNAME}/${ARCHI}/lib")
+		file(MAKE_DIRECTORY "${PE_BUILD_DIR}/${OUTPUTCONFIG_FOLDERNAME}/bin")
+		file(MAKE_DIRECTORY "${PE_BUILD_DIR}/${OUTPUTCONFIG_FOLDERNAME}/lib")
 	endforeach()
 else()		
 	file(MAKE_DIRECTORY "${PE_BUILD_DIR}/default/bin")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,10 +11,6 @@
             "name": "settings-project",
             "binaryDir": "${sourceDir}/project_files",
             "cacheVariables": {
-                "PE_BUILD_DIR": {
-                    "type": "STRING",
-                    "value": "${sourceDir}/builds"
-                },
                 "PE_GLES": "OFF",
                 "PE_VULKAN": "OFF",
                 "PE_MOLTEN": "OFF",
@@ -182,14 +178,11 @@
         },
         {
             "hidden": true,
-            "name": "windows-64-base",
-            "displayName": "Windows 64bit",
+            "name": "windows-base",
+            "displayName": "Windows",
             "inherits": [
                 "settings-project"
             ],
-            "generator": "Visual Studio 17 2022",
-            "architecture": "x64",
-            "binaryDir": "${sourceDir}/project_files/x64",
             "description": "Base configuration for Windows",
             "condition": {
                 "type": "equals",
@@ -197,11 +190,20 @@
                 "rhs": "Windows"
             },
             "cacheVariables": {
-                "PE_PLATFORM": "WINDOWS",
-                "PE_BUILD_DIR": {
-                    "type": "STRING",
-                    "value": "${sourceDir}/builds/x64"
-                },
+                "PE_PLATFORM": "WINDOWS"
+            }
+        },
+        {
+            "hidden": true,
+            "name": "windows-64-base",
+            "displayName": "Windows 64bit",
+            "inherits": [
+                "windows-base"
+            ],
+            "binaryDir": "${sourceDir}/project_files/x86_64",
+            "generator": "Visual Studio 17 2022",
+            "architecture": "x64",
+            "cacheVariables": {
                 "PE_ARCHITECTURE": "x86_64"
             }
         },
@@ -210,23 +212,12 @@
             "name": "windows-32-base",
             "displayName": "Windows 32bit",
             "inherits": [
-                "settings-project"
+                "windows-base"
             ],
+            "binaryDir": "${sourceDir}/project_files/x86",
             "generator": "Visual Studio 17 2022",
             "architecture": "Win32",
-            "binaryDir": "${sourceDir}/project_files/Win32",
-            "description": "Base configuration for Windows",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            },
             "cacheVariables": {
-                "PE_PLATFORM": "WINDOWS",
-                "PE_BUILD_DIR": {
-                    "type": "STRING",
-                    "value": "${sourceDir}/builds/Win32"
-                },
                 "PE_ARCHITECTURE": "x86"
             }
         },
@@ -390,7 +381,7 @@
         {
             "hidden": true,
             "name": "wasm-base",
-			"generator": "Ninja",
+            "generator": "Ninja",
             "inherits": [
                 "settings-project"
             ],

--- a/tools/android.py
+++ b/tools/android.py
@@ -162,7 +162,7 @@ class Android:
 
 def main():
     parser = ArgumentParser()
-    parser.add_argument("--output", default=os.path.join(ROOT_DIR, "builds", "android"))
+    parser.add_argument("--output", type=str, help="output directory for the build, the provided cmake script typically sets this to builds/android/{arch}")
     parser.add_argument("--sdk", default=None, help="set to override the used android sdk, falls back to path available one")
     parser.add_argument("--gradle", default=None, help="set to override the used gradle, falls back to path available one")
     parser.add_argument("--bundletool", default=None, help="set to override the used bundletool, falls back to path available one")
@@ -187,4 +187,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
Streamlines the build folder setup to now by default be `$PLATFORM/$ARCH`. Furthermore the cmake script is now responsible for generating it by default.