### PR TITLE
precommit hooks and clang-format command support

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,19 +11,8 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
-    - name: run formatter
-      run: python3 tools/clang-format.py
     - name: verify c++ formatting
-      run: |
-        output=$(git diff --stat HEAD)
-        if [[ -n $output ]]; then
-          echo "changes detected, please apply the following patch"
-          git diff --patch-with-stat --color-words HEAD
-          exit 1
-        else
-          echo "success"
-          exit 0
-        fi
+      run: python3 tools/clang-format.py --verify
     - name: verify python formatting
       uses: psf/black@stable
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vs/
 builds/
+tools/.config.json
 tools/cache/
 tests/common/build/
 docker/cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,13 @@ if(PE_ECS_DISABLE_LOOKUP_CACHE_BEHAVIOUR)
 	list(APPEND PE_DEFINES -DPE_ECS_DISABLE_LOOKUP_CACHE)
 endif()
 
+# here we register the local hooks for git, this is done to ensure that the
+# formatting is done before the commit is made
+find_package(Git QUIET REQUIRED)
+execute_process(
+    COMMAND ${GIT_EXECUTABLE} config --local core.hooksPath tools/hooks/
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
 ###############################################################################
 ###                    validation                                           ###
 ###############################################################################

--- a/tools/clang-format.py
+++ b/tools/clang-format.py
@@ -9,7 +9,15 @@ CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 PROJECT_DIR = os.path.join(CURRENT_DIR, os.path.pardir)
 CONFIG_FILE = os.path.join(CURRENT_DIR, ".config.json")
 
-def run_command(command=[], directory=None, print_stdout=False, catch_stdout=False, error_out=True, shell=False):
+
+def run_command(
+    command=[],
+    directory=None,
+    print_stdout=False,
+    catch_stdout=False,
+    error_out=True,
+    shell=False,
+):
     process = subprocess.Popen(
         command,
         stdout=os.sys.stdout if print_stdout and not catch_stdout else subprocess.PIPE,
@@ -37,6 +45,7 @@ def run_command(command=[], directory=None, print_stdout=False, catch_stdout=Fal
         )
     return [output, process.returncode]
 
+
 def _get_clang_format_settings(path: str = None):
     shell = False
     command = [path or "clang-format"]
@@ -51,43 +60,66 @@ def _get_clang_format_settings(path: str = None):
 
     return {"command": command, "shell": shell}
 
-def format(folders, cformat: str = None, dry_run: bool = False, only_staged: bool = True):
-    print("formatting...");
+
+def format(
+    folders, cformat: str = None, dry_run: bool = False, only_staged: bool = True
+):
+    print("formatting...")
     settings = _get_clang_format_settings(cformat)
 
     folders = [os.path.abspath(folder) for folder in folders]
     files = []
     if only_staged:
-        staged_files = run_command(["git", "diff", "--name-only", "--staged"], directory=PROJECT_DIR, catch_stdout=True)[0]
+        staged_files = run_command(
+            ["git", "diff", "--name-only", "--staged"],
+            directory=PROJECT_DIR,
+            catch_stdout=True,
+        )[0]
         if len(staged_files) == 1:
-            staged_files = staged_files[0].split("\n")		
-            files = [file for file in staged_files if re.search(".*?\.(cpp|hpp|h)", file) and any(os.path.abspath(file).startswith(folder) for folder in folders)]
+            staged_files = staged_files[0].split("\n")
+            files = [
+                file
+                for file in staged_files
+                if re.search(".*?\.(cpp|hpp|h)", file)
+                and any(os.path.abspath(file).startswith(folder) for folder in folders)
+            ]
     else:
-        files = [os.path.relpath(os.path.abspath(os.path.join(r, file)), PROJECT_DIR).replace("\\", "/") for folder in folders for r, d, f, in os.walk(folder) for file in f if re.search(".*?\.(cpp|hpp|h)", file)]
+        files = [
+            os.path.relpath(
+                os.path.abspath(os.path.join(r, file)), PROJECT_DIR
+            ).replace("\\", "/")
+            for folder in folders
+            for r, d, f, in os.walk(folder)
+            for file in f
+            if re.search(".*?\.(cpp|hpp|h)", file)
+        ]
 
     marked_files = []
     for file in files:
         if re.search(".*?\.(cpp|hpp|h)", file):
             commands = settings["command"] + [file, "-i", "-style=file"]
             if dry_run:
-	            commands.extend(["--dry-run", "-Werror"])
+                commands.extend(["--dry-run", "-Werror"])
 
             [_, errorCode] = run_command(
-	            commands,
-	            print_stdout=not dry_run,
-	            error_out=not dry_run,
-	            directory=PROJECT_DIR,
-	            shell= settings["shell"],
+                commands,
+                print_stdout=not dry_run,
+                error_out=not dry_run,
+                directory=PROJECT_DIR,
+                shell=settings["shell"],
             )
             if dry_run and errorCode != 0:
                 marked_files.append(file)
 
     if dry_run and len(marked_files) > 0:
-        marked_file_str = ', '.join(f"'{file}'" for file in marked_files)
-        print(f"ERROR: clang-format should be run before committing on the following files: {marked_file_str}")
+        marked_file_str = ", ".join(f"'{file}'" for file in marked_files)
+        print(
+            f"ERROR: clang-format should be run before committing on the following files: {marked_file_str}"
+        )
         exit(1)
 
-    print("formatting finished");
+    print("formatting finished")
+
 
 if __name__ == "__main__":
     parser = ArgumentParser()
@@ -104,16 +136,22 @@ if __name__ == "__main__":
         ],
         help="Set the directories you wish to format recursively",
     )
-    parser.add_argument("--staged", action="store_true", help="Check only staged files instead of all")
+    parser.add_argument(
+        "--staged", action="store_true", help="Check only staged files instead of all"
+    )
     parser.add_argument(
         "--clang-format",
         type=str,
         default=None,
         help="Path to clang-format in case it's not in the path, or you wish to override it.",
     )
-    parser.add_argument("--verify",
-		action="store_true",
-		help="Verify that the code is formatted correctly")
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Verify that the code is formatted correctly",
+    )
     args = parser.parse_args()
 
-    format(args.directory, args.clang_format, dry_run = args.verify, only_staged=args.staged)
+    format(
+        args.directory, args.clang_format, dry_run=args.verify, only_staged=args.staged
+    )

--- a/tools/clang-format.py
+++ b/tools/clang-format.py
@@ -3,14 +3,19 @@ import io
 import os
 import re
 import subprocess
+import json
 
+CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
+PROJECT_DIR = os.path.join(CURRENT_DIR, os.path.pardir)
+CONFIG_FILE = os.path.join(CURRENT_DIR, ".config.json")
 
-def run_command(command=[], directory=None, print_stdout=False, catch_stdout=False):
+def run_command(command=[], directory=None, print_stdout=False, catch_stdout=False, error_out=True, shell=False):
     process = subprocess.Popen(
         command,
         stdout=os.sys.stdout if print_stdout and not catch_stdout else subprocess.PIPE,
-        stderr=os.sys.stderr,
+        stderr=os.sys.stderr if print_stdout else subprocess.PIPE,
         cwd=directory,
+        shell=shell,
     )
     output = []
     if catch_stdout:
@@ -26,25 +31,63 @@ def run_command(command=[], directory=None, print_stdout=False, catch_stdout=Fal
                 output.append(line[: len(line) - 1])
         process.stdout.close()
     process.wait()
-    if process.returncode != 0:
+    if error_out and process.returncode != 0:
         raise Exception(
             f"Raised exitcode '{process.returncode}' while trying to run the command '{' '.join(comm for comm in command)}'"
         )
-    return output
+    return [output, process.returncode]
 
+def _get_clang_format_settings(path: str = None):
+    shell = False
+    command = [path or "clang-format"]
+    if path is None:
+        if os.path.exists(CONFIG_FILE):
+            with open(CONFIG_FILE, "r") as f:
+                config = json.load(f)
+                command = config["formatting"]["clang-format"]
+                if isinstance(command, str):
+                    command = [command]
+                shell = config["formatting"]["shell"] or False
 
-def format(folders, cformat):
-    if cformat is None:
-        cformat = "clang-format"
-    for folder in folders:
-        for r, d, f in os.walk(folder):
-            for file in f:
-                if re.search(".*?\.(cpp|hpp|h)", file):
-                    run_command(
-                        [cformat, "-i", "-style=file", os.path.join(r, file)],
-                        print_stdout=True,
-                    )
+    return {"command": command, "shell": shell}
 
+def format(folders, cformat: str = None, dry_run: bool = False, only_staged: bool = True):
+    print("formatting...");
+    settings = _get_clang_format_settings(cformat)
+
+    folders = [os.path.abspath(folder) for folder in folders]
+    files = []
+    if only_staged:
+        staged_files = run_command(["git", "diff", "--name-only", "--staged"], directory=PROJECT_DIR, catch_stdout=True)[0]
+        if len(staged_files) == 1:
+            staged_files = staged_files[0].split("\n")		
+            files = [file for file in staged_files if re.search(".*?\.(cpp|hpp|h)", file) and any(os.path.abspath(file).startswith(folder) for folder in folders)]
+    else:
+        files = [os.path.relpath(os.path.abspath(os.path.join(r, file)), PROJECT_DIR).replace("\\", "/") for folder in folders for r, d, f, in os.walk(folder) for file in f if re.search(".*?\.(cpp|hpp|h)", file)]
+
+    marked_files = []
+    for file in files:
+        if re.search(".*?\.(cpp|hpp|h)", file):
+            commands = settings["command"] + [file, "-i", "-style=file"]
+            if dry_run:
+	            commands.extend(["--dry-run", "-Werror"])
+
+            [_, errorCode] = run_command(
+	            commands,
+	            print_stdout=not dry_run,
+	            error_out=not dry_run,
+	            directory=PROJECT_DIR,
+	            shell= settings["shell"],
+            )
+            if dry_run and errorCode != 0:
+                marked_files.append(file)
+
+    if dry_run and len(marked_files) > 0:
+        marked_file_str = ', '.join(f"'{file}'" for file in marked_files)
+        print(f"ERROR: clang-format should be run before committing on the following files: {marked_file_str}")
+        exit(1)
+
+    print("formatting finished");
 
 if __name__ == "__main__":
     parser = ArgumentParser()
@@ -61,12 +104,16 @@ if __name__ == "__main__":
         ],
         help="Set the directories you wish to format recursively",
     )
+    parser.add_argument("--staged", action="store_true", help="Check only staged files instead of all")
     parser.add_argument(
         "--clang-format",
         type=str,
         default=None,
         help="Path to clang-format in case it's not in the path, or you wish to override it.",
     )
+    parser.add_argument("--verify",
+		action="store_true",
+		help="Verify that the code is formatted correctly")
     args = parser.parse_args()
 
-    format(args.directory, args.clang_format)
+    format(args.directory, args.clang_format, dry_run = args.verify, only_staged=args.staged)

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+python tools/clang-format.py --verify --staged

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -1,2 +1,4 @@
 #!/bin/sh
 python tools/clang-format.py --verify --staged
+echo "Running python black formatter..."
+python -m black ./tools --check


### PR DESCRIPTION
This PR adds required pre-commit hooks to avoid committing unformatted code. Additionally improves the `tools/clang-format.py` script to have a dry-run support (using the `--verify` flag), and to only apply to staged files (`--staged`) to avoid formatting local files.

Additionally the clang-format can be a set in a config file named `tools/.config.json` (gitignored) allowing you to link to the preferred clang-formatter directly, or have it be a shell command.

For example, on Windows where clang-format is installed on `wsl` the following contents could be set:
```
{
  "formatting": {
    "clang-format": [ "wsl", "-e", "clang-format" ],
    "shell": true
  }
}
```