### PR TITLE
ci: runs will now cancel on new push

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,6 +2,10 @@ name: macos
 
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !(startsWith(github.ref, 'release/') || github.ref == 'develop')}}
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,6 +2,10 @@ name: ubuntu
 
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !(startsWith(github.ref, 'release/') || github.ref == 'develop')}}
+
 jobs:
   # verify the project's formatting, errors out if a difference is detected and generates a patch
   # the user should apply to fix it.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,6 +2,10 @@ name: windows
 
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !(startsWith(github.ref, 'release/') || github.ref == 'develop')}}
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
With exception to the release and develop branches runs will now auto-cancel when new pushes appear