### PR TITLE
improved cmake and logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,9 @@ OPTION(PE_VULKAN "controls Vulkan support (experimental - not done)" ON)
 OPTION(PE_MOLTEN "controls Metal support (not implemented)" OFF)
 OPTION(PE_WEBGPU_NATIVE "controls native WebGPU support" OFF)
 OPTION(PE_WEBGPU "controls WebGPU support, note this is also on when PE_WEBGPU_NATIVE is enabled." OFF)
-OPTION(PE_MAKE_EXE "make example executable based on Paradigm" ON)
+OPTION(PE_MAKE_EXE "make example executable based on Paradigm" ${PROJECT_IS_TOP_LEVEL})
 OPTION(PE_DEV_MAKE_PSL_EXE "For development you can make an executable " OFF)
-OPTION(PE_TESTS "make the tests" ON)
+OPTION(PE_TESTS "make the tests" ${PROJECT_IS_TOP_LEVEL})
 OPTION(PE_PCH "enable usage of the precompiled header" ON)
 OPTION(PE_CCACHE "enable ccache" ON)
 OPTION(PE_CORE "generate the paradigm core, turn this off if you only want the PSL to generate" ON)
@@ -62,6 +62,8 @@ set(ANDROID_GRADLE "" CACHE PATH "override gradle location")
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 OPTION(PE_ECS_DISABLE_LOOKUP_CACHE_BEHAVIOUR "Disable the usage of the lookup cache for psl::ecs::state_t" OFF)
+
+set(PE_INTERNAL_SET_BUILD_DIR ${PROJECT_IS_TOP_LEVEL})
 
 if(${PE_CCACHE})
 	find_program(CCACHE "ccache")
@@ -233,20 +235,6 @@ endif()
 ###############################################################################
 ###                    setup output directories                             ###
 ###############################################################################
-get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-if(is_multi_config)
-	foreach(OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
-		string(TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG)
-		string(TOLOWER ${OUTPUTCONFIG} OUTPUTCONFIG_FOLDERNAME)
-		
-		file(MAKE_DIRECTORY "${PE_BUILD_DIR}/${OUTPUTCONFIG_FOLDERNAME}/bin")
-		file(MAKE_DIRECTORY "${PE_BUILD_DIR}/${OUTPUTCONFIG_FOLDERNAME}/lib")
-	endforeach()
-else()		
-	file(MAKE_DIRECTORY "${PE_BUILD_DIR}/default/bin")
-	file(MAKE_DIRECTORY "${PE_BUILD_DIR}/default/lib")
-endif()
-
 if(PE_ANALYZE)
 	if(MSVC)
 	

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -6,34 +6,36 @@ macro(set_target_output_directory)
     if(NOT DEFINED ${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY})
         set(${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY} "")
     endif()
-    foreach(targ ${SET_TARGET_OUTPUT_DIRECTORY_TARGET})
-        get_target_property(target_type ${targ} TYPE)
-        foreach(OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
-            string(TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG)
-            string(TOLOWER ${OUTPUTCONFIG} OUTPUTCONFIG_FOLDERNAME)
-            # mostly done so the directories don't get created in the output for binaries when unneeded.
+    if(${PE_INTERNAL_SET_BUILD_DIR})
+        foreach(targ ${SET_TARGET_OUTPUT_DIRECTORY_TARGET})
+            get_target_property(target_type ${targ} TYPE)
+            foreach(OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
+                string(TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG)
+                string(TOLOWER ${OUTPUTCONFIG} OUTPUTCONFIG_FOLDERNAME)
+                # mostly done so the directories don't get created in the output for binaries when unneeded.
+                if (target_type STREQUAL "EXECUTABLE")
+                    set_target_properties(${targ}
+                        PROPERTIES
+                        RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} "${PE_BUILD_DIR}/${OUTPUTCONFIG_FOLDERNAME}/${ARCHI}/bin/${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY}")
+                else()
+                    set_target_properties(${targ}
+                        PROPERTIES
+                        ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} "${PE_BUILD_DIR}/${OUTPUTCONFIG_FOLDERNAME}/${ARCHI}/lib/${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY}"
+                        LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} "${PE_BUILD_DIR}/${OUTPUTCONFIG_FOLDERNAME}/${ARCHI}/lib/${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY}"
+                        RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} "${PE_BUILD_DIR}/${OUTPUTCONFIG_FOLDERNAME}/${ARCHI}/bin/${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY}")
+                endif()
+            endforeach()
             if (target_type STREQUAL "EXECUTABLE")
                 set_target_properties(${targ}
                     PROPERTIES
-                    RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} "${PE_BUILD_DIR}/${OUTPUTCONFIG_FOLDERNAME}/${ARCHI}/bin/${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY}")
-            else()
+                    RUNTIME_OUTPUT_DIRECTORY "${PE_BUILD_DIR}/default/bin/${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY}")
+            else ()
                 set_target_properties(${targ}
                     PROPERTIES
-                    ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} "${PE_BUILD_DIR}/${OUTPUTCONFIG_FOLDERNAME}/${ARCHI}/lib/${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY}"
-                    LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} "${PE_BUILD_DIR}/${OUTPUTCONFIG_FOLDERNAME}/${ARCHI}/lib/${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY}"
-                    RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} "${PE_BUILD_DIR}/${OUTPUTCONFIG_FOLDERNAME}/${ARCHI}/bin/${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY}")
+                    ARCHIVE_OUTPUT_DIRECTORY "${PE_BUILD_DIR}/default/lib/${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY}"
+                    LIBRARY_OUTPUT_DIRECTORY "${PE_BUILD_DIR}/default/lib/${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY}"
+                    RUNTIME_OUTPUT_DIRECTORY "${PE_BUILD_DIR}/default/bin/${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY}")
             endif()
         endforeach()
-        if (target_type STREQUAL "EXECUTABLE")
-            set_target_properties(${targ}
-                PROPERTIES
-                RUNTIME_OUTPUT_DIRECTORY "${PE_BUILD_DIR}/default/bin/${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY}")
-        else ()
-            set_target_properties(${targ}
-                PROPERTIES
-                ARCHIVE_OUTPUT_DIRECTORY "${PE_BUILD_DIR}/default/lib/${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY}"
-                LIBRARY_OUTPUT_DIRECTORY "${PE_BUILD_DIR}/default/lib/${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY}"
-                RUNTIME_OUTPUT_DIRECTORY "${PE_BUILD_DIR}/default/bin/${SET_TARGET_OUTPUT_DIRECTORY_DIRECTORY}")
-        endif()
-    endforeach()
+    endif()
 endmacro()

--- a/core/inc/core/logging.hpp
+++ b/core/inc/core/logging.hpp
@@ -39,5 +39,5 @@ extern psl::profiling::profiler profiler;
 namespace {
 	bool _loggers_initialized = false;
 }
-auto initialize_loggers() -> void;
+auto initialize_loggers(bool to_file = true) -> void;
 }	 // namespace core

--- a/core/src/logging.cpp
+++ b/core/src/logging.cpp
@@ -107,13 +107,13 @@ auto core::initialize_loggers(bool to_file) -> void {
 #else
 
 	#include "spdlog/sinks/android_sink.h"
-auto core::initialize_loggers() -> void {
+auto core::initialize_loggers([[maybe_unused]] bool to_file) -> void {
 	if(core::_loggers_initialized) {
 		return;
 	}
 
 	core::_loggers_initialized = true;
-	core::log				   = spdlog::android_logger_mt("main", "paradigm");
+	core::log				   = spdlog::android_logger_mt("core", "paradigm");
 	core::systems::log		   = spdlog::android_logger_mt("systems", "paradigm");
 	core::os::log			   = spdlog::android_logger_mt("os", "paradigm");
 	core::data::log			   = spdlog::android_logger_mt("data", "paradigm");

--- a/core/src/logging.cpp
+++ b/core/src/logging.cpp
@@ -40,7 +40,7 @@ inline std::tm localtime_safe(std::time_t timer) {
 	return bt;
 }
 
-auto core::initialize_loggers() -> void {
+auto core::initialize_loggers(bool to_file) -> void {
 	if(core::_loggers_initialized) {
 		return;
 	}
@@ -54,16 +54,31 @@ auto core::initialize_loggers() -> void {
 	time.resize(20);
 	strftime(time.data(), 20, "%Y-%m-%d %H-%M-%S", &now_tm);
 	time[time.size() - 1] = '/';
-	psl::string sub_path  = "logs/" + time;
-	if(!psl::utility::platform::file::exists(psl::utility::application::path::get_path() + sub_path + "main.log"))
-		psl::utility::platform::file::write(psl::utility::application::path::get_path() + sub_path + "main.log", "");
+	auto path			  = psl::utility::application::path::get_path();
+	psl::string sub_path  = path + "logs/" + time;
 	std::vector<spdlog::sink_ptr> sinks;
 
+	auto make_sink = [](std::shared_ptr<spdlog::logger>& target,
+						psl::string_view name,
+						std::optional<psl::string_view> path,
+						auto&... additional_sinks) {
+		std::vector<spdlog::sink_ptr> sinks;
+		sinks.reserve(sizeof...(additional_sinks) + 1);
+		if(path) {
+			sinks.emplace_back(
+			  std::make_shared<spdlog::sinks::basic_file_sink_mt>(psl::string {path.value()} + name + ".log", true));
+		}
+		(sinks.emplace_back(additional_sinks), ...);
+		auto logger = std::make_shared<spdlog::logger>(psl::string {name}, begin(sinks), end(sinks));
+		spdlog::register_logger(logger);
+		target = logger;
+	};
+
 	auto mainlogger = std::make_shared<spdlog::sinks::dist_sink_mt>();
-	mainlogger->add_sink(std::make_shared<spdlog::sinks::basic_file_sink_mt>(
-	  psl::utility::application::path::get_path() + sub_path + "main.log", true));
-	mainlogger->add_sink(std::make_shared<spdlog::sinks::basic_file_sink_mt>(
-	  psl::utility::application::path::get_path() + "logs/latest.log", true));
+	if(to_file) {
+		mainlogger->add_sink(std::make_shared<spdlog::sinks::basic_file_sink_mt>(sub_path + "main.log", true));
+		mainlogger->add_sink(std::make_shared<spdlog::sinks::basic_file_sink_mt>(path + "logs/latest.log", true));
+	}
 	#ifdef _MSC_VER
 	mainlogger->add_sink(std::make_shared<spdlog::sinks::msvc_sink_mt>());
 	#else
@@ -72,97 +87,21 @@ auto core::initialize_loggers() -> void {
 	mainlogger->add_sink(outlogger);
 	#endif
 
-	auto ivklogger = std::make_shared<spdlog::sinks::basic_file_sink_mt>(
-	  psl::utility::application::path::get_path() + sub_path + "ivk.log", true);
-
-	auto igleslogger = std::make_shared<spdlog::sinks::basic_file_sink_mt>(
-	  psl::utility::application::path::get_path() + sub_path + "igles.log", true);
-
-	auto iwgpulogger = std::make_shared<spdlog::sinks::basic_file_sink_mt>(
-	  psl::utility::application::path::get_path() + sub_path + "iwgpu.log", true);
-
-	auto gfxlogger = std::make_shared<spdlog::sinks::basic_file_sink_mt>(
-	  psl::utility::application::path::get_path() + sub_path + "gfx.log", true);
-
-	auto systemslogger = std::make_shared<spdlog::sinks::basic_file_sink_mt>(
-	  psl::utility::application::path::get_path() + sub_path + "systems.log", true);
-
-	auto oslogger = std::make_shared<spdlog::sinks::basic_file_sink_mt>(
-	  psl::utility::application::path::get_path() + sub_path + "os.log", true);
-
-	auto datalogger = std::make_shared<spdlog::sinks::basic_file_sink_mt>(
-	  psl::utility::application::path::get_path() + sub_path + "data.log", true);
-
-	auto corelogger = std::make_shared<spdlog::sinks::basic_file_sink_mt>(
-	  psl::utility::application::path::get_path() + sub_path + "core.log", true);
-
-	sinks.push_back(mainlogger);
-	sinks.push_back(corelogger);
-
-	auto logger = std::make_shared<spdlog::logger>("main", begin(sinks), end(sinks));
-	spdlog::register_logger(logger);
-	core::log = logger;
-
-
-	sinks.clear();
-	sinks.push_back(mainlogger);
-	sinks.push_back(systemslogger);
-
-	auto system_logger = std::make_shared<spdlog::logger>("systems", begin(sinks), end(sinks));
-	spdlog::register_logger(system_logger);
-	core::systems::log = system_logger;
-
-	sinks.clear();
-	sinks.push_back(mainlogger);
-	sinks.push_back(oslogger);
-
-	auto os_logger = std::make_shared<spdlog::logger>("os", begin(sinks), end(sinks));
-	spdlog::register_logger(os_logger);
-	core::os::log = os_logger;
-
-	sinks.clear();
-	sinks.push_back(mainlogger);
-	sinks.push_back(datalogger);
-
-	auto data_logger = std::make_shared<spdlog::logger>("data", begin(sinks), end(sinks));
-	spdlog::register_logger(data_logger);
-	core::data::log = data_logger;
-
-	sinks.clear();
-	sinks.push_back(mainlogger);
-	sinks.push_back(gfxlogger);
-
-	auto gfx_logger = std::make_shared<spdlog::logger>("gfx", begin(sinks), end(sinks));
-	spdlog::register_logger(gfx_logger);
-	core::gfx::log = gfx_logger;
-
-	#ifdef PE_VULKAN
-	sinks.clear();
-	sinks.push_back(mainlogger);
-	sinks.push_back(ivklogger);
-
-	auto ivk_logger = std::make_shared<spdlog::logger>("ivk", begin(sinks), end(sinks));
-	spdlog::register_logger(ivk_logger);
-	core::ivk::log = ivk_logger;
+	make_sink(core::log, "core", to_file ? std::make_optional(sub_path) : std::nullopt, mainlogger);
+	make_sink(core::gfx::log, "gfx", to_file ? std::make_optional(sub_path) : std::nullopt, mainlogger);
+	#if defined(PE_VULKAN)
+	make_sink(core::ivk::log, "ivk", to_file ? std::make_optional(sub_path) : std::nullopt, mainlogger);
 	#endif
-	#ifdef PE_GLES
-	sinks.clear();
-	sinks.push_back(mainlogger);
-	sinks.push_back(igleslogger);
-
-	auto igles_logger = std::make_shared<spdlog::logger>("igles", begin(sinks), end(sinks));
-	spdlog::register_logger(igles_logger);
-	core::igles::log = igles_logger;
+	#if defined(PE_GLES)
+	make_sink(core::igles::log, "igles", to_file ? std::make_optional(sub_path) : std::nullopt, mainlogger);
 	#endif
-	#ifdef PE_WEBGPU
-	sinks.clear();
-	sinks.push_back(mainlogger);
-	sinks.push_back(iwgpulogger);
-
-	auto iwgpu_logger = std::make_shared<spdlog::logger>("iwgpu", begin(sinks), end(sinks));
-	spdlog::register_logger(iwgpu_logger);
-	core::iwgpu::log = iwgpu_logger;
+	#if defined(PE_WEBGPU)
+	make_sink(core::iwgpu::log, "iwgpu", to_file ? std::make_optional(sub_path) : std::nullopt, mainlogger);
 	#endif
+	make_sink(core::data::log, "data", to_file ? std::make_optional(sub_path) : std::nullopt, mainlogger);
+	make_sink(core::systems::log, "systems", to_file ? std::make_optional(sub_path) : std::nullopt, mainlogger);
+	make_sink(core::os::log, "os", to_file ? std::make_optional(sub_path) : std::nullopt, mainlogger);
+
 	spdlog::set_pattern("%8T.%6f [%=8n] [%=8l] %^%v%$ %@", spdlog::pattern_time_type::utc);
 }
 #else

--- a/psl/inc/psl/logging.hpp
+++ b/psl/inc/psl/logging.hpp
@@ -3,13 +3,13 @@
 
 
 #ifndef DISABLE_LOGGING
-	#define LOG(...) spdlog::get("main")->info(__VA_ARGS__)
+	#define LOG(...) spdlog::get("core")->info(__VA_ARGS__)
 	#define LOG_INFO(...) LOG(__VA_ARGS__)
-	#define LOG_ERROR(...) spdlog::get("main")->error(__VA_ARGS__)
-	#define LOG_WARNING(...) spdlog::get("main")->warn(__VA_ARGS__)
-	#define LOG_PROFILE(...) spdlog::get("main")->trace(__VA_ARGS__)
-	#define LOG_DEBUG(...) spdlog::get("main")->debug(__VA_ARGS__)
-	#define LOG_FATAL(...) spdlog::get("main")->critical(__VA_ARGS__)
+	#define LOG_ERROR(...) spdlog::get("core")->error(__VA_ARGS__)
+	#define LOG_WARNING(...) spdlog::get("core")->warn(__VA_ARGS__)
+	#define LOG_PROFILE(...) spdlog::get("core")->trace(__VA_ARGS__)
+	#define LOG_DEBUG(...) spdlog::get("core")->debug(__VA_ARGS__)
+	#define LOG_FATAL(...) spdlog::get("core")->critical(__VA_ARGS__)
 #else
 	#define TimeLog
 	#define LOG


### PR DESCRIPTION
Now the cmake project's output will depend on if this is being consumed by another project or not. If it is then it will disable the tests, and put the output in the default location. If it is not then it will keep its current behaviour

Additionally logging can now be set to conditionally output to a file.