### PR TITLE
feature: ECS system groups

### DIFF
--- a/docs/ecs.md
+++ b/docs/ecs.md
@@ -15,7 +15,7 @@ Hopefully after this short introduction & examples you will have enough of an id
 ## concepts
 ### state
  Often other ECS implementations refer to this as their "world". The `state` contains the actual `component` data, to which `entity` the `component` maps, and a list of `systems` that should be executed per invocation.
- Its most notable methods are [`add_components`](#state::add_components), `remove_components`, `create`, `destroy`, `filter`, and `tick`. There are several others, but they are mostly self explanatory and explained in the reference documentation.
+ Its most notable methods are `add_components`, `remove_components`, `create`, `destroy`, `filter`, and `tick`. There are several others, but they are mostly self explanatory and explained in the reference documentation.
  
 ### command_buffer
  Due to the fact that the ECS can run multithreaded, we cannot allow the `state` to be mutated during the execution of systems (it would lead to a lock-mess when creating/destroying entities). This is where the `command_buffer` comes into play.
@@ -234,6 +234,16 @@ Next table is a reference chart of what the different combinations result in. `N
 | -- | -- | -- |
 | **pack<whole,...>** | single thread, invoked once per frame | equivalent to threading::sequential
 | **pack<partial,...>** | multi-context (but not concurrent), invoked N times per frame | Invoked N times, concurrently per frame.
+
+### System Groups
+
+Sometimes you want systems to not tick at the same rate as others, as example physics is often ran at a fixed timestep rather than every tick. For this the concept of system groups exists. You can create a group by calling the member function `create_system_group()` on an instance of `psl::ecs::state_t`. This will return you an opaque handle to a group. You can then subsequently use this when you are declaring your systems (`state_t::declare()`) as one of its arguments.
+
+#### limitations and caveats 
+
+As component lifetime events such as `on_add`, `on_remove`, `on_combine`, `on_break` are properties of the component these will not be propogated to anything but the default system group (invoking `state_t::tick()` without the group arguments). At runtime an exception will be thrown if you try to register a system that belongs to a group which does one of these operations.
+
+As a side consequence if you add components or entities during the ticking of a system group, these will not be visible until you do a normal tick.
 
 ### examples
 A single threaded system that filters on all entities that have a `position` component. Note that position is *not* marked `const` because we will be adjusting the position value in our imaginary example. If it was marked as `const`, we would only get a read-only view into the data.

--- a/psl/inc/psl/ecs/details/system_information.hpp
+++ b/psl/inc/psl/ecs/details/system_information.hpp
@@ -378,6 +378,7 @@ auto compress_from_dependency_pack(psl::type_pack_t<Ts...>, std::vector<dependen
 class system_information;
 class system_token {
 	friend class system_information;
+	friend std::hash<system_token>;
 	constexpr system_token(size_t id) noexcept : id(id) {};
 
   public:
@@ -436,3 +437,10 @@ class system_information final {
 	system_token m_ID {0};
 };
 }	 // namespace psl::ecs::details
+
+namespace std {
+template <>
+struct hash<psl::ecs::details::system_token> {
+	size_t operator()(const psl::ecs::details::system_token& token) const noexcept { return token.id; }
+};
+}	 // namespace std

--- a/psl/inc/psl/ecs/filtering.hpp
+++ b/psl/inc/psl/ecs/filtering.hpp
@@ -320,6 +320,12 @@ namespace details {
 					 std::begin(on_break), std::end(on_break), std::begin(other.on_break), std::end(other.on_break));
 		}
 
+		// returns true if this filter is a basic filter, meaning it only filters on components, not special events
+		// such as on_add, on_remove, on_combine, on_break
+		bool is_basic_filter() const noexcept {
+			return on_add.size() == 0 && on_remove.size() == 0 && on_combine.size() == 0 && on_break.size() == 0;
+		}
+
 	  private:
 		friend class ::psl::ecs::state_t;
 

--- a/psl/inc/psl/ecs/state.hpp
+++ b/psl/inc/psl/ecs/state.hpp
@@ -51,6 +51,20 @@ struct converter<psl::ecs::entity_t> {
 /// \brief Entity Component System
 ///
 namespace psl::ecs {
+class state_t;
+
+class system_group_t final {
+	friend class state_t;
+	system_group_t(size_t id, psl::string_view debugName = "") : m_Id(id), m_DebugName(debugName) {}
+
+  public:
+	system_group_t() = default;
+
+  private:
+	size_t m_Id {std::numeric_limits<size_t>::max()};
+	psl::string_view m_DebugName;
+};
+
 class state_t final {
 	friend class psl::serialization::accessor;
 	static constexpr auto serialization_name {"ECS"};
@@ -483,6 +497,8 @@ class state_t final {
 	}
 
 	void tick(std::chrono::duration<float> dTime);
+	void tick(std::chrono::duration<float> dTime, system_group_t group);
+	void tick(std::chrono::duration<float> dTime, psl::array_view<system_group_t> groups);
 
 	void reset(psl::array_view<entity_t> entities) noexcept;
 
@@ -509,23 +525,40 @@ class state_t final {
 	size_t systems() const noexcept { return m_SystemInformations.size() - m_ToRevoke.size(); }
 
 	template <psl::details::fixed_astring DebugName = "", typename Fn>
-	auto declare(Fn&& fn, bool seedWithExisting = false) {
-		return declare_impl(threading::sequential, std::forward<Fn>(fn), (void*)nullptr, seedWithExisting, DebugName);
+	auto declare(Fn&& fn, bool seedWithExisting = false, std::optional<system_group_t> systemGroup = std::nullopt) {
+		return declare_impl(
+		  threading::sequential, std::forward<Fn>(fn), (void*)nullptr, seedWithExisting, DebugName, systemGroup);
 	}
 
 
 	template <psl::details::fixed_astring DebugName = "", typename Fn>
-	auto declare(threading threading, Fn&& fn, bool seedWithExisting = false) {
-		return declare_impl(threading, std::forward<Fn>(fn), (void*)nullptr, seedWithExisting, DebugName);
+	auto declare(threading threading,
+				 Fn&& fn,
+				 bool seedWithExisting					   = false,
+				 std::optional<system_group_t> systemGroup = std::nullopt) {
+		return declare_impl(threading, std::forward<Fn>(fn), (void*)nullptr, seedWithExisting, DebugName, systemGroup);
 	}
 
 	template <psl::details::fixed_astring DebugName = "", typename Fn, typename T>
-	auto declare(Fn&& fn, T* ptr, bool seedWithExisting = false) {
-		return declare_impl(threading::sequential, std::forward<Fn>(fn), ptr, seedWithExisting, DebugName);
+	auto
+	declare(Fn&& fn, T* ptr, bool seedWithExisting = false, std::optional<system_group_t> systemGroup = std::nullopt) {
+		return declare_impl(threading::sequential, std::forward<Fn>(fn), ptr, seedWithExisting, DebugName, systemGroup);
 	}
 	template <psl::details::fixed_astring DebugName = "", typename Fn, typename T>
-	auto declare(threading threading, Fn&& fn, T* ptr, bool seedWithExisting = false) {
-		return declare_impl(threading, std::forward<Fn>(fn), ptr, seedWithExisting, DebugName);
+	auto declare(threading threading,
+				 Fn&& fn,
+				 T* ptr,
+				 bool seedWithExisting					   = false,
+				 std::optional<system_group_t> systemGroup = std::nullopt) {
+		return declare_impl(threading, std::forward<Fn>(fn), ptr, seedWithExisting, DebugName, systemGroup);
+	}
+
+	template <psl::details::fixed_astring DebugName = "">
+	[[nodiscard]] auto create_system_group() noexcept {
+		m_SystemGroups.emplace(m_SystemGroupCounter, psl::array<details::system_token> {});
+		auto group = system_group_t {m_SystemGroupCounter, DebugName};
+		++m_SystemGroupCounter;
+		return group;
 	}
 
 	bool revoke(details::system_token id) noexcept {
@@ -966,8 +999,12 @@ class state_t final {
 	}
 
 	template <typename Fn, typename T = void>
-	auto
-	declare_impl(threading threading, Fn&& fn, T* ptr, bool seedWithExisting = false, psl::string_view debugName = "") {
+	auto declare_impl(threading threading,
+					  Fn&& fn,
+					  T* ptr,
+					  bool seedWithExisting						= false,
+					  psl::string_view debugName				= "",
+					  std::optional<system_group_t> systemGroup = std::nullopt) {
 		using function_args	  = typename psl::templates::func_traits<typename std::decay<Fn>::type>::arguments_t;
 		using pack_type		  = typename get_packs<function_args>::type;
 		auto filter_groups	  = make_filter_group(pack_type {});
@@ -980,6 +1017,20 @@ class state_t final {
 				  return get_component_untyped_info<Z>();
 			  });
 		};
+
+		// make sure systems don't have any non-basic filter operations if they are part of a system group
+		// the reason for this is that the tracking for component lifetime events is not done on a per system level
+		// but handled by the storage of the components themselves. This means that if a group is ticked on a different
+		// cadence than every tick, the system would miss out on component lifetime events.
+		if(systemGroup != std::nullopt) {
+			for(auto const& filter_group : filter_groups) {
+				if(!filter_group.is_basic_filter()) {
+					throw std::runtime_error(
+					  "system groups can only contain basic filter operations, no on_add, on_break, on_combine, or "
+					  "on_remove");
+				}
+			}
+		}
 
 		auto system_tick = create_system_tick_functional<Fn, T, pack_type>(fn, ptr);
 		auto& sys_info	 = (m_LockState) ? m_NewSystemInformations : m_SystemInformations;
@@ -994,15 +1045,28 @@ class state_t final {
 		}
 
 
-		sys_info.emplace_back(threading,
-							  std::move(pack_generator),
-							  std::move(system_tick),
-							  shared_filter_groups,
-							  shared_transform_groups,
-							  ++m_SystemCounter,
-							  seedWithExisting,
-							  debugName);
-		return sys_info[sys_info.size() - 1].id();
+		auto system_id = sys_info
+						   .emplace_back(threading,
+										 std::move(pack_generator),
+										 std::move(system_tick),
+										 shared_filter_groups,
+										 shared_transform_groups,
+										 ++m_SystemCounter,
+										 seedWithExisting,
+										 debugName)
+						   .id();
+
+		if(systemGroup != std::nullopt) {
+			auto it = m_SystemGroups.find(systemGroup->m_Id);
+			psl_assert(it != std::end(m_SystemGroups),
+					   "system group not found, are you sure you registered it with this container? Do note that "
+					   "groups do not persist a reset.");
+
+			m_SystemGroupIndices.emplace(system_id);
+			it->second.push_back(system_id);
+		}
+
+		return system_id;
 	}
 
 	::memory::raw_region m_Cache {1024 * 1024 * 256};
@@ -1014,6 +1078,9 @@ class state_t final {
 
 	psl::array<details::system_token> m_ToRevoke {};
 	psl::array<details::system_information> m_NewSystemInformations {};
+	std::unordered_map<size_t, psl::array<details::system_token>> m_SystemGroups {};
+	std::unordered_set<details::system_token> m_SystemGroupIndices {};
+	size_t m_SystemGroupCounter {0};
 
 	mutable std::unordered_map<details::component_key_t, std::unique_ptr<details::component_container_t>>
 	  m_Components {};

--- a/psl/src/ecs/state.cpp
+++ b/psl/src/ecs/state.cpp
@@ -197,7 +197,14 @@ void state_t::prepare_system(std::chrono::duration<float> dTime,
 	}
 }
 
+
 void state_t::tick(std::chrono::duration<float> dTime) {
+	tick(dTime, psl::array_view<system_group_t> {});
+}
+void state_t::tick(std::chrono::duration<float> dTime, system_group_t group) {
+	tick(dTime, psl::array_view<system_group_t> {&group, 1});
+}
+void state_t::tick(std::chrono::duration<float> dTime, psl::array_view<system_group_t> groups) {
 	m_LockState = 1;
 	// remove filters that are no longer in use
 	m_Filters.erase(std::remove_if(begin(m_Filters),
@@ -218,23 +225,60 @@ void state_t::tick(std::chrono::duration<float> dTime) {
 
 	m_ModifiedEntities.clear();
 
-	// tick systems;
-	for(auto& system : m_SystemInformations) {
-		prepare_system(dTime, dTime, (std::uintptr_t)m_Cache.data(), system);
+	// todo: we can optimize this, and additionally the filters should be refined for the systems that we'll actually
+	// use
+	//
+	// when ticking if the system is a group we go down an alternate pathway where we do not do any component promotion
+	// or filtering, but instead we just execute the systems in the group
+	// additionally the tick value does not increment.
+	// new systems can be added and removed during this tick, but that's the only shared functionality between the two.
+	// as group ticks can not use advanced filtering operations they will additionally not see new components until a
+	// normal tick is performed.
+	if(groups.size() == 0) {
+		for(auto& system : m_SystemInformations) {
+			if(m_SystemGroupIndices.find(system.id()) != std::end(m_SystemGroupIndices)) {
+				continue;
+			}
+			prepare_system(dTime, dTime, (std::uintptr_t)m_Cache.data(), system);
+		}
+
+		m_Orphans.insert(std::end(m_Orphans), std::begin(m_ToBeOrphans), std::end(m_ToBeOrphans));
+		m_ToBeOrphans.clear();
+
+		for(auto& [key, cInfo] : m_Components) cInfo->purge();
+
+		for(auto& info : info_buffer) {
+			execute_command_buffer(*info);
+		}
+		info_buffer.clear();
+
+		// purge;
+		++m_Tick;
+	} else {
+		auto system_indices = std::unordered_set<details::system_token>();
+
+		// for every group, get all the systems and append them to system_indices
+		for(auto& group : groups) {
+			auto group_it = m_SystemGroups.find(group.m_Id);
+			if(group_it == std::end(m_SystemGroups)) {
+				continue;
+			}
+			for(auto& system : group_it->second) {
+				system_indices.insert(system);
+			}
+		}
+
+		for(auto& system : m_SystemInformations) {
+			if(system_indices.find(system.id()) == std::end(system_indices)) {
+				continue;
+			}
+			prepare_system(dTime, dTime, (std::uintptr_t)m_Cache.data(), system);
+		}
+		for(auto& info : info_buffer) {
+			execute_command_buffer(*info);
+		}
+		info_buffer.clear();
 	}
-
-	m_Orphans.insert(std::end(m_Orphans), std::begin(m_ToBeOrphans), std::end(m_ToBeOrphans));
-	m_ToBeOrphans.clear();
-
-	for(auto& [key, cInfo] : m_Components) cInfo->purge();
-
-	for(auto& info : info_buffer) {
-		execute_command_buffer(*info);
-	}
-	info_buffer.clear();
-
-	// purge;
-	++m_Tick;
 
 	if(m_NewSystemInformations.size() > 0) {
 		for(auto& system : m_NewSystemInformations) m_SystemInformations.emplace_back(std::move(system));
@@ -892,5 +936,8 @@ void state_t::clear(bool release_memory) noexcept {
 	m_LockState = 0;
 	m_ModifiedEntities.clear();
 	m_ToRevoke.clear();
+	m_SystemGroupCounter = 0;
+	m_SystemGroups.clear();
+	m_SystemGroupIndices.clear();
 	++m_ComponentGeneration;
 }


### PR DESCRIPTION
Adds support for marking special groups of systems as not to tick by default, but instead tick them on-request. This comes with some limitations such as not being able to do queries on lifetime operations of components.