### PR TITLE
Added missing patching step

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -96,6 +96,11 @@ if(PE_GLES)
 	endif()
 endif()
 
+add_custom_target(core_patcher
+	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../tools/patch.py --project ${CMAKE_BINARY_DIR}
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
+	COMMENT "Patching build files")
+
 add_custom_target(core_generator)
 add_custom_command(TARGET core_generator
 	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../tools/generate_project_info.py
@@ -106,7 +111,7 @@ add_custom_command(TARGET core_generator
 add_library(core STATIC ${FWD} ${SRC} ${INC} ${GEN} ${INC_GLES} ${SRC_GLES} ${INC_VULKAN} ${SRC_VULKAN} ${INC_WEBGPU} ${SRC_WEBGPU} ${NATVIS})
 add_library(paradigm::core ALIAS core)
 
-add_dependencies(core core_generator)
+add_dependencies(core core_generator core_patcher)
 
 if(${PE_PCH})
 	target_precompile_headers(core PUBLIC ${INC_PCH})

--- a/core/inc/core/gles/igles.hpp
+++ b/core/inc/core/gles/igles.hpp
@@ -3,8 +3,10 @@
 #ifdef SURFACE_WIN32
 	// including wgl first as it also includes windows.h, not doing so creates warnings about redefinition of some
 	// defines
-	#include "glad/glad.h"
 	#include "glad/glad_wgl.h"
+
+	// note: added extra space here to satisfy the earlier comment and to avoid any include reordering to affect this
+	#include "glad/glad.h"
 #endif
 #ifdef SURFACE_XCB
 	#include <GLES3/gl32.h>

--- a/tools/patch.py
+++ b/tools/patch.py
@@ -110,9 +110,8 @@ def patch_msvc(root):
     elif os.path.isfile(os.path.join(root, "paradigm/core/core.vcxproj")):
         fObj = File(os.path.join(root, "paradigm/core/core.vcxproj"))
     else:
-        raise Exception(
-            f"No project files found at path '{root}', did you supply the correct path?"
-        )
+        return
+
     fObj.patch()
 
 
@@ -155,6 +154,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.project:
+        print(f"patching {args.project}")
         patch(args.project)
     if args.utf8:
         patch_utf8(args.utf8)


### PR DESCRIPTION
The patching of neither the vcxproj or the vulkan header was being done anymore. This now makes it a custom target that will run before a build happens.

Additionally when PCH was enabled, there was a macro redefinition caused by incorrectly ordered includes. The comment above indicated this to be the case but likely an include reformatting tool moved them around. Added an extra comment + additional separation lines to avoid this in the future