### PR TITLE
psl::ecs::on_mutate<> mutation information.

### DIFF
--- a/docs/ecs.md
+++ b/docs/ecs.md
@@ -200,6 +200,26 @@ The advantage of this is that you can now listen for the `psl::ecs::on_mutate<>`
 
 To have your component be marked as restricted you will need to specialize the `psl::ecs::component_trait_mutability_t<>` which can be found at [psl/ecs/component_traits.hpp](psl/inc/psl/ecs/component_traits.hpp).
 
+Following is a small sample of how the `on_mutate` filtering in a pack behaves.
+```cpp
+struct audio_t {
+    float volume;
+    bool is_playing;
+};
+
+// pay attention that we both request the audio_t component, as well as the on_mutate filtering instruction
+// if we did not, we would only get the mutation info of the audio_t component, but not the audio_t component itself.
+void system(psl::ecs::info& info, psl::ecs::pack<const audio_t, psl::ecs::on_mutate<audio_t>> audio_pack) {
+    for(auto [audio, mutation_info] : audio_pack)
+    {
+        if(mutation_info.has_mutated<&audio_t::volume>()) {
+            some_audio_system.set_volume(audio.volume);
+        }
+    }
+})
+
+```
+
 ## Packs
 The `ecs::pack<>` type is both a view into the component data, as well as a set of filtering instructions of what requirements the entities are supposed to have. This might seem like an odd combination, but simplifies systems, as well as makes clear the constraints of the data a variable will be working with.
 

--- a/psl/inc/psl/ecs/details/component_container.hpp
+++ b/psl/inc/psl/ecs/details/component_container.hpp
@@ -125,11 +125,9 @@ class component_container_t {
 		return 0;
 	};
 
-	size_t copy_from(component_container_t* source) noexcept {
-		auto entities	 = source->entities(stage_range_t::ALL);
-		auto source_data = source->data();
-
-		return copy_from(entities, source_data, false);
+	virtual size_t apply_mutation(component_container_t* source) noexcept {
+		psl_assert(false, "Component {} does not support mutation", m_Info.id.name());
+		return 0;
 	};
 
 	inline component_type_info_t const& component_type_info() const noexcept {
@@ -351,7 +349,7 @@ class component_container_typed_t final : public component_container_t {
 	details::staged_sparse_array<T, entity_t::size_type> m_Entities;
 };
 
-class component_container_flag_t : public component_container_t {
+class component_container_flag_t final : public component_container_t {
   public:
 	component_container_flag_t(component_type_info_t info)
 		: component_container_t({
@@ -468,7 +466,7 @@ class component_container_flag_t : public component_container_t {
 	bool m_Serializable {false};
 };
 
-class component_container_untyped_t : public component_container_t {
+class component_container_untyped_t final : public component_container_t {
 	using stage_range_t = details::stage_range_t;
 
   public:
@@ -560,6 +558,36 @@ class component_container_untyped_t : public component_container_t {
 		m_Entities.clear();
 		m_Info.serializable = false;
 	}
+
+	size_t apply_mutation(component_container_t* source) noexcept override {
+		auto entities	 = source->entities(stage_range_t::ALL);
+		auto source_data = source->data();
+
+		psl_assert((std::uintptr_t)source_data % m_Info.alignment == 0, "pointer has to be aligned");
+		psl_assert(source->component_type_info().alignment == m_Info.alignment,
+				   "components must have the same alignment");
+		psl_assert(source->component_type_info().size == m_Info.size, "components have to be the same size");
+
+		std::byte* src	= (std::byte*)source_data;
+		std::byte* diff = new std::byte[m_Info.size];
+		for(auto e : entities) {
+			auto dst = m_Entities.addressof(static_cast<entity_t::size_type>(e), stage_range_t::ALL);
+
+			// make a diff between the src and dst and store it in diff
+			// for every byte we compare, if they are different we set the byte in diff to 1, otherwise 0
+			for(size_t i = 0; i < m_Info.size; ++i) {
+				diff[i] = (src[i] != dst[i]) ? std::byte {0xff} : std::byte {0};
+			}
+
+			std::memcpy(dst, src, m_Info.size);
+			std::memcpy(src, diff, m_Info.size);
+			src += m_Info.size;
+		}
+
+		delete[] diff;
+
+		return m_Info.size * entities.size();
+	};
 
   protected:
 	void set_impl(entity_t entity, void* data) noexcept override {

--- a/psl/inc/psl/ecs/details/mutate_instruction.hpp
+++ b/psl/inc/psl/ecs/details/mutate_instruction.hpp
@@ -5,9 +5,29 @@
 #include <type_traits>
 
 namespace psl::ecs::details {
+template <typename T, auto Member>
+struct get_field_info_t {};
+
+template <typename T, typename FieldType, FieldType T::*Member>
+struct get_field_info_t<T, Member> {
+	using type		  = T;
+	using field_type  = FieldType;
+	using member_type = FieldType T::*;
+};
+
 // todo(jdl): pending mutations should be handled before serialization
 template <typename T>
-struct mutate_instruction_t : public T {};
+struct mutate_instruction_t final : private T {
+	/// \brief Queries the given field to see if it has been mutated.
+	template <auto T::*Member>
+	bool has_mutated() const noexcept {
+		using field_type = typename get_field_info_t<T, Member>::field_type;
+		auto ptr		 = reinterpret_cast<const std::uint8_t*>(this);
+		auto offset		 = reinterpret_cast<std::size_t>(&(reinterpret_cast<T const volatile*>(0)->*Member));
+		auto field_size	 = sizeof(field_type);
+		return std::any_of(ptr + offset, ptr + offset + field_size, [](std::uint8_t byte) { return byte != 0; });
+	}
+};
 
 template <typename T>
 struct is_mutate_instruction_t : public std::false_type {};
@@ -34,7 +54,7 @@ struct mutate_instruction_internal_type<mutate_instruction_t<T>> {
 };
 
 template <typename T>
-using mutate_instruction_underlying_t = typename mutate_instruction_internal_type<T>::type;
+using mutate_instruction_underlying_t = typename mutate_instruction_internal_type<std::remove_cvref_t<T>>::type;
 
 
 template <typename T>

--- a/psl/inc/psl/ecs/details/selectors.hpp
+++ b/psl/inc/psl/ecs/details/selectors.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../selectors.hpp"
+#include "psl/ecs/details/mutate_instruction.hpp"
 #include "psl/pack_view.hpp"
 
 namespace psl::ecs::details {
@@ -98,7 +99,7 @@ struct extract_on_mutate {
 
 template <typename T>
 struct extract_on_mutate<on_mutate<T>> {
-	using type = std::tuple<T>;
+	using type = std::tuple<const details::mutate_instruction_t<T>>;
 };
 
 template <typename T>
@@ -149,7 +150,7 @@ struct extract_physical<on_break<Ts...>> {
 
 template <typename T>
 struct extract_physical<on_mutate<T>> {
-	using type = std::tuple<T>;
+	using type = std::tuple<const details::mutate_instruction_t<T>>;
 };
 
 template <typename T>
@@ -222,7 +223,7 @@ struct decode_type<on_condition<Pred, Ts...>> {
 
 template <typename T>
 struct decode_type<on_mutate<T>> {
-	using type = std::tuple<T>;
+	using type = std::tuple<const details::mutate_instruction_t<T>>;
 };
 
 template <typename... Ts>

--- a/psl/inc/psl/ecs/details/system_information.hpp
+++ b/psl/inc/psl/ecs/details/system_information.hpp
@@ -3,6 +3,7 @@
 #include "../pack.hpp"
 #include "component_key.hpp"
 #include "psl/array_view.hpp"
+#include "psl/ecs/details/mutate_instruction.hpp"
 #include "psl/ecs/filtering.hpp"
 #include "psl/template_utils.hpp"
 #include <chrono>
@@ -85,7 +86,14 @@ class dependency_pack {
 		if constexpr(!std::is_same<typename std::decay<F>::type, psl::ecs::entity_t>::value) {
 			using component_t			  = F;
 			constexpr component_key_t key = details::component_key_t::generate<component_t>();
-			target.emplace_back(key, query.template operator()<component_t>());
+
+			if constexpr(details::IsMutateInstruction<F>) {
+				using underlying_t						 = details::mutate_instruction_underlying_t<component_t>;
+				constexpr component_key_t underlying_key = details::component_key_t::generate<underlying_t>();
+				target.emplace_back(underlying_key, query.template operator()<component_t>());
+			} else {
+				target.emplace_back(key, query.template operator()<component_t>());
+			}
 			m_Sizes[key] = sizeof(component_t);
 		}
 	}

--- a/psl/inc/psl/ecs/filtering.hpp
+++ b/psl/inc/psl/ecs/filtering.hpp
@@ -18,14 +18,20 @@ namespace details {
 		constexpr cached_container_entry_t(const details::component_key_t& target_key,
 										   details::component_container_t* target_container)
 			: key(target_key), container(target_container) {
-			psl_assert(target_container == nullptr || target_key == target_container->id(), "ID did not match");
+			psl_assert(target_container == nullptr || target_key == target_container->id(),
+					   "ID did not match. Was expecting '{}' but got '{}'",
+					   target_key.name(),
+					   target_container->id().name());
 		};
 		// specialized form for the on_mutate, as it masquerades as the container of another type.
 		constexpr cached_container_entry_t(const details::component_key_t& target_key,
 										   const details::component_key_t& container_key,
 										   details::component_container_t* target_container)
 			: key(target_key), container(target_container) {
-			psl_assert(target_container == nullptr || container_key == target_container->id(), "ID did not match");
+			psl_assert(target_container == nullptr || container_key == target_container->id(),
+					   "ID did not match. Was expecting '{}' but got '{}'",
+					   container_key.name(),
+					   target_container->id().name());
 		};
 
 		constexpr cached_container_entry_t(cached_container_entry_t const&)			   = default;

--- a/psl/inc/psl/ecs/state.hpp
+++ b/psl/inc/psl/ecs/state.hpp
@@ -120,18 +120,6 @@ class state_t final {
 			component_entities.reserve(expected_total_entities);
 			component_data.resize(expected_total_datasize);
 
-			// not ideal, but as we cannot serialize the mutations we have to apply them here.
-			// the good news is that this doesn't cause any issues for the tick behaviour as
-			// the mutation will be applied as before, but it does mean we have "double" work.
-			// we could consider not applying the mutations, but users might not be happy with
-			// "lost data".
-			// additionally it doesn't make sense to serialize the mutation instructions as that
-			// would load the components and immediately mutate them anyway (with exception that
-			// it would also fire mutation events in the first tick).
-			if(!all_keys.empty()) {
-				std::ignore = apply_mutations();
-			}
-
 			size_t data_offset {0};
 			for(const auto& key : all_keys) {
 				const auto& component = m_Components[key];

--- a/psl/src/ecs/state.cpp
+++ b/psl/src/ecs/state.cpp
@@ -211,7 +211,7 @@ psl::array<details::component_container_t*> state_t::apply_mutations() {
 			if(!targetCInfo) {
 				continue;
 			}
-			targetCInfo->copy_from(cInfo.get());
+			targetCInfo->apply_mutation(cInfo.get());
 		}
 	}
 	return mutated_components;
@@ -245,13 +245,6 @@ void state_t::tick(std::chrono::duration<float> dTime, psl::array_view<system_gr
 		filter(filter_result, modified_entities);
 	}
 
-	// we can clear the mutated component data now as we have the filtering information:
-	for(auto* cInfo : mutated_components) {
-		if(cInfo) {
-			cInfo->clear();
-		}
-	}
-
 	m_ModifiedEntities.clear();
 
 	// todo: we can optimize this, and additionally the filters should be refined for the systems that we'll actually
@@ -275,14 +268,6 @@ void state_t::tick(std::chrono::duration<float> dTime, psl::array_view<system_gr
 		m_ToBeOrphans.clear();
 
 		for(auto& [key, cInfo] : m_Components) cInfo->purge();
-
-		for(auto& info : info_buffer) {
-			execute_command_buffer(*info);
-		}
-		info_buffer.clear();
-
-		// purge;
-		++m_Tick;
 	} else {
 		auto system_indices = std::unordered_set<details::system_token>();
 
@@ -303,10 +288,23 @@ void state_t::tick(std::chrono::duration<float> dTime, psl::array_view<system_gr
 			}
 			prepare_system(dTime, dTime, (std::uintptr_t)m_Cache.data(), system);
 		}
-		for(auto& info : info_buffer) {
-			execute_command_buffer(*info);
+	}
+
+	// we can clear the mutated component data now as we have the filtering information:
+	for(auto* cInfo : mutated_components) {
+		if(cInfo) {
+			cInfo->clear();
 		}
-		info_buffer.clear();
+	}
+
+	for(auto& info : info_buffer) {
+		execute_command_buffer(*info);
+	}
+	info_buffer.clear();
+
+	if(groups.size() == 0) {
+		// purge;
+		++m_Tick;
 	}
 
 	if(m_NewSystemInformations.size() > 0) {

--- a/tests/src/ecs.cpp
+++ b/tests/src/ecs.cpp
@@ -862,13 +862,18 @@ auto t12 = suite<"ecs restricted mutability", "ecs", "psl">() = []() {
 	bool has_mutated {true};
 
 	state.declare([&has_mutated, &mutated_values](
-					psl::ecs::info_t& info, psl::ecs::pack_indirect_full_t<psl::ecs::on_mutate<foo_restricted>> pack) {
+					psl::ecs::info_t& info,
+					psl::ecs::pack_indirect_full_t<const foo_restricted, psl::ecs::on_mutate<foo_restricted>> pack) {
 		require(pack.size()) == ((has_mutated) ? 2 : 0);
 
-		for(auto [value] : pack) {
+		for(auto [value, mutator] : pack) {
 			require(value.value1) == mutated_values.value1;
 			require(value.value2) == mutated_values.value2;
 			require(value.value3) == mutated_values.value3;
+
+			require(mutator.has_mutated<&foo_restricted::value1>()) == has_mutated;
+			require(mutator.has_mutated<&foo_restricted::value2>()) == has_mutated;
+			require(mutator.has_mutated<&foo_restricted::value3>()) == has_mutated;
 		}
 	});
 
@@ -883,7 +888,7 @@ auto t12 = suite<"ecs restricted mutability", "ecs", "psl">() = []() {
 	has_mutated = false;
 	state.tick(std::chrono::duration<float>(1.0f));
 
-	mutated_values = {99, 2, true};
+	mutated_values = {99, 2, false};
 	state.mutate_components<foo_restricted>(modified_entities, mutated_values);
 	has_mutated = true;
 	state.tick(std::chrono::duration<float>(1.0f));
@@ -893,13 +898,18 @@ auto t13 = suite<"ecs restricted mutability - systems", "ecs", "psl">() = []() {
 	psl::ecs::state_t state {};
 	auto entities = state.create<foo_restricted>(static_cast<entity_t::size_type>(5), {0, 0, false});
 
-	state.declare([](psl::ecs::info_t& info, psl::ecs::pack_indirect_full_t<psl::ecs::on_mutate<foo_restricted>> pack) {
+	state.declare([](psl::ecs::info_t& info,
+					 psl::ecs::pack_indirect_full_t<const foo_restricted, psl::ecs::on_mutate<foo_restricted>> pack) {
 		require(pack.size()) == (info.tick == 0 ? 0 : 5);
 
-		for(auto [value] : pack) {
+		for(auto [value, mutator] : pack) {
 			require(value.value1) == (int)info.tick - 1;
 			require(value.value2) == 3.0f * (info.tick - 1);
 			require(value.value3) == true;
+
+			require(mutator.has_mutated<&foo_restricted::value1>()) == (info.tick == 1 ? false : true);
+			require(mutator.has_mutated<&foo_restricted::value2>()) == (info.tick == 1 ? false : true);
+			require(mutator.has_mutated<&foo_restricted::value3>()) == (info.tick == 1 ? true : false);
 		}
 	});
 


### PR DESCRIPTION
This improvement will allow you to query the `on_mutate<>` data to see which fields have modified. Previously this paramater in the pack contained the component data, you will need to query it separately now.

Additionally as this changes the components backing data mutations are no longer applied during the serialization process.