### PR TITLE
`order_by` performance improvement

### DIFF
--- a/benchmarks/src/ecs.cpp
+++ b/benchmarks/src/ecs.cpp
@@ -472,12 +472,13 @@ class filtering_fixture : public ::benchmark::Fixture {
 		state.filter<Ts...>();
 	}
 
-	void order_by(benchmark::State& gState) {
-		gState.PauseTiming();
-		auto entities = state.filter<int>();
-		gState.ResumeTiming();
-
-		psl::ecs::details::order_by<std::less<int>, int>(state, std::begin(entities), std::end(entities));
+	void order_by(benchmark::State& gState, auto par) {
+		[this, &gState, &par]<typename U, typename... Rest>() {
+			gState.PauseTiming();
+			auto entities = state.filter<U>();
+			gState.ResumeTiming();
+			psl::ecs::details::order_by<std::less<U const&>, U>(par, state, std::begin(entities), std::end(entities));
+		}.template operator()<Ts...>();
 	}
 
 	void on_condition(benchmark::State& gState) {
@@ -520,10 +521,125 @@ BENCHMARK_TEMPLATE_DEFINE_F(filtering_fixture, trivial_filtering_float_int_char,
 	}
 }
 
-BENCHMARK_TEMPLATE_DEFINE_F(filtering_fixture, trivial_filtering_order_by)
+struct small_complex_type_t {
+	small_complex_type_t() : value(0) {}
+	small_complex_type_t(uint64_t v) : value(v) {}
+	small_complex_type_t(const small_complex_type_t& other) : value(other.value), data(other.data) {}
+	small_complex_type_t(small_complex_type_t&& other) noexcept : value(other.value), data(std::move(other.data)) {
+		other.value = 0;
+	}
+	small_complex_type_t& operator=(const small_complex_type_t& other) {
+		if(this != &other) {
+			value = other.value;
+			data  = other.data;
+		}
+		return *this;
+	}
+	small_complex_type_t& operator=(small_complex_type_t&& other) noexcept {
+		if(this != &other) {
+			value		= other.value;
+			data		= std::move(other.data);
+			other.value = 0;
+		}
+		return *this;
+	}
+	bool operator<(const small_complex_type_t& other) const {
+		return value < other.value;
+	}
+	bool operator==(const small_complex_type_t& other) const {
+		return value == other.value;
+	}
+	bool operator!=(const small_complex_type_t& other) const {
+		return value != other.value;
+	}
+	bool operator>(const small_complex_type_t& other) const {
+		return value > other.value;
+	}
+	~small_complex_type_t() {};
+	uint64_t value {0};
+	std::array<uint8_t, 32> data {0};
+};
+struct big_complex_type_t {
+	big_complex_type_t() : value(0) {}
+	big_complex_type_t(uint64_t v) : value(v) {}
+	big_complex_type_t(const big_complex_type_t& other) : value(other.value), data(other.data) {}
+	big_complex_type_t(big_complex_type_t&& other) noexcept : value(other.value), data(std::move(other.data)) {
+		other.value = 0;
+	}
+	big_complex_type_t& operator=(const big_complex_type_t& other) {
+		if(this != &other) {
+			value = other.value;
+			data  = other.data;
+		}
+		return *this;
+	}
+	big_complex_type_t& operator=(big_complex_type_t&& other) noexcept {
+		if(this != &other) {
+			value		= other.value;
+			data		= std::move(other.data);
+			other.value = 0;
+		}
+		return *this;
+	}
+	bool operator<(const big_complex_type_t& other) const {
+		return value < other.value;
+	}
+	bool operator==(const big_complex_type_t& other) const {
+		return value == other.value;
+	}
+	bool operator!=(const big_complex_type_t& other) const {
+		return value != other.value;
+	}
+	bool operator>(const big_complex_type_t& other) const {
+		return value > other.value;
+	}
+	~big_complex_type_t() {};
+	uint64_t value {0};
+	std::array<uint8_t, 256> data {0};
+};
+
+BENCHMARK_TEMPLATE_DEFINE_F(filtering_fixture, trivial_filtering_order_by_seq, int)
 (benchmark::State& gState) {
 	for(auto _ : gState) {
-		order_by(gState);
+		order_by(gState, psl::ecs::execution::seq);
+	}
+}
+BENCHMARK_TEMPLATE_DEFINE_F(filtering_fixture, complex_small_filtering_order_by_seq, small_complex_type_t)
+(benchmark::State& gState) {
+	auto entities = state.filter<int>();
+	state.add_components(entities, [](small_complex_type_t& val) { val.value = std::rand() % 1000; });
+	for(auto _ : gState) {
+		order_by(gState, psl::ecs::execution::seq);
+	}
+}
+BENCHMARK_TEMPLATE_DEFINE_F(filtering_fixture, complex_big_filtering_order_by_seq, big_complex_type_t)
+(benchmark::State& gState) {
+	auto entities = state.filter<int>();
+	state.add_components(entities, [](big_complex_type_t& val) { val.value = std::rand() % 1000; });
+	for(auto _ : gState) {
+		order_by(gState, psl::ecs::execution::seq);
+	}
+}
+BENCHMARK_TEMPLATE_DEFINE_F(filtering_fixture, trivial_filtering_order_by_par, int)
+(benchmark::State& gState) {
+	for(auto _ : gState) {
+		order_by(gState, psl::ecs::execution::par);
+	}
+}
+BENCHMARK_TEMPLATE_DEFINE_F(filtering_fixture, complex_small_filtering_order_by_par, small_complex_type_t)
+(benchmark::State& gState) {
+	auto entities = state.filter<int>();
+	state.add_components(entities, [](small_complex_type_t& val) { val.value = std::rand() % 1000; });
+	for(auto _ : gState) {
+		order_by(gState, psl::ecs::execution::par);
+	}
+}
+BENCHMARK_TEMPLATE_DEFINE_F(filtering_fixture, complex_big_filtering_order_by_par, big_complex_type_t)
+(benchmark::State& gState) {
+	auto entities = state.filter<int>();
+	state.add_components(entities, [](big_complex_type_t& val) { val.value = std::rand() % 1000; });
+	for(auto _ : gState) {
+		order_by(gState, psl::ecs::execution::par);
 	}
 }
 BENCHMARK_TEMPLATE_DEFINE_F(filtering_fixture, trivial_filtering_on_condition)
@@ -542,7 +658,24 @@ BENCHMARK_REGISTER_F(filtering_fixture, trivial_filtering_char_int_float)
 BENCHMARK_REGISTER_F(filtering_fixture, trivial_filtering_float_int_char)
   ->Unit(benchmark::kMicrosecond)
   ->DenseRange(0, 3);
-BENCHMARK_REGISTER_F(filtering_fixture, trivial_filtering_order_by)->Unit(benchmark::kMicrosecond)->DenseRange(0, 3);
+BENCHMARK_REGISTER_F(filtering_fixture, trivial_filtering_order_by_seq)
+  ->Unit(benchmark::kMicrosecond)
+  ->DenseRange(0, 3);
+BENCHMARK_REGISTER_F(filtering_fixture, complex_small_filtering_order_by_seq)
+  ->Unit(benchmark::kMicrosecond)
+  ->DenseRange(0, 3);
+BENCHMARK_REGISTER_F(filtering_fixture, complex_big_filtering_order_by_seq)
+  ->Unit(benchmark::kMicrosecond)
+  ->DenseRange(0, 3);
+BENCHMARK_REGISTER_F(filtering_fixture, trivial_filtering_order_by_par)
+  ->Unit(benchmark::kMicrosecond)
+  ->DenseRange(0, 3);
+BENCHMARK_REGISTER_F(filtering_fixture, complex_small_filtering_order_by_par)
+  ->Unit(benchmark::kMicrosecond)
+  ->DenseRange(0, 3);
+BENCHMARK_REGISTER_F(filtering_fixture, complex_big_filtering_order_by_par)
+  ->Unit(benchmark::kMicrosecond)
+  ->DenseRange(0, 3);
 BENCHMARK_REGISTER_F(filtering_fixture, trivial_filtering_on_condition)
   ->Unit(benchmark::kMicrosecond)
   ->DenseRange(0, 3);

--- a/psl/inc/psl/ecs/order_by.hpp
+++ b/psl/inc/psl/ecs/order_by.hpp
@@ -6,15 +6,57 @@
 #include <future>
 
 namespace psl::ecs::details {
+template <typename T>
+struct get_pair_type {
+	using pair_t = std::pair<T, entity_t>;
+	static constexpr auto is_big {false};
+
+	static psl::array<pair_t> make_array(const psl::ecs::state_t& state,
+										 psl::array<entity_t>::iterator begin,
+										 psl::array<entity_t>::iterator end) {
+		auto const count = (size_t)std::distance(begin, end);
+		psl::array_view<entity_t> view(begin, end);
+		auto data = state.get<T>(view);
+		psl::array<pair_t> result {};
+		result.reserve(std::distance(begin, end));
+		for(auto i = size_t {0}; i < count; ++i, ++begin) {
+			result.emplace_back(std::move(data[i]), *begin);
+		}
+		return result;
+	}
+};
+
+template <typename T>
+	requires(sizeof(T) > sizeof(void*))
+struct get_pair_type<T> {
+	using pair_t = std::pair<T*, entity_t>;
+	static constexpr auto is_big {true};
+
+	static psl::array<pair_t> make_array(const psl::ecs::state_t& state,
+										 psl::array<entity_t>::iterator begin,
+										 psl::array<entity_t>::iterator end) {
+		auto const count = (size_t)std::distance(begin, end);
+		psl::array_view<entity_t> view(begin, end);
+		auto data = state.try_get_component<T>(view);
+		psl::array<pair_t> result {};
+		result.reserve(std::distance(begin, end));
+		for(auto i = size_t {0}; i < count; ++i, ++begin) {
+			result.emplace_back(data[i], *begin);
+		}
+		return result;
+	}
+};
+
 template <typename Pred, typename T>
 static inline void order_by(psl::ecs::execution::no_exec,
 							const psl::ecs::state_t& state,
 							psl::array<entity_t>::iterator begin,
 							psl::array<entity_t>::iterator end) noexcept {
-	const auto pred = Pred {};
-	std::sort(begin, end, [&state, &pred](entity_t lhs, entity_t rhs) -> bool {
-		return std::invoke(pred, state.get<T>(lhs), state.get<T>(rhs));
-	});
+	auto sortable = get_pair_type<T>::make_array(state, begin, end);
+	order_by<Pred, T>(psl::ecs::execution::no_exec {}, state, sortable.begin(), sortable.end());
+	for(size_t i = 0; i < sortable.size(); ++i) {
+		*(begin + i) = sortable[i].second;
+	}
 }
 
 template <typename Pred, typename T>
@@ -22,18 +64,49 @@ static inline void order_by(psl::ecs::execution::sequenced_policy,
 							const psl::ecs::state_t& state,
 							psl::array<entity_t>::iterator begin,
 							psl::array<entity_t>::iterator end) noexcept {
-	const auto pred = Pred {};
-	std::sort(psl::ecs::execution::seq, begin, end, [&state, &pred](entity_t lhs, entity_t rhs) -> bool {
-		return std::invoke(pred, state.get<T>(lhs), state.get<T>(rhs));
+	auto sortable = get_pair_type<T>::make_array(state, begin, end);
+	order_by<Pred, T>(psl::ecs::execution::sequenced_policy {}, state, sortable.begin(), sortable.end());
+	for(size_t i = 0; i < sortable.size(); ++i) {
+		*(begin + i) = sortable[i].second;
+	}
+}
+
+template <typename Pred, typename T>
+static inline void order_by(psl::ecs::execution::no_exec,
+							const psl::ecs::state_t& state,
+							typename psl::array<typename get_pair_type<T>::pair_t>::iterator begin,
+							typename psl::array<typename get_pair_type<T>::pair_t>::iterator end) noexcept {
+	std::sort(begin, end, [](auto& lhs, auto& rhs) -> bool {
+		if constexpr(get_pair_type<T>::is_big) {
+			return Pred {}(*lhs.first, *rhs.first);
+		} else {
+			return Pred {}(lhs.first, rhs.first);
+		}
 	});
 }
+
+template <typename Pred, typename T>
+static inline void order_by(psl::ecs::execution::sequenced_policy,
+							const psl::ecs::state_t& state,
+							typename psl::array<typename get_pair_type<T>::pair_t>::iterator begin,
+							typename psl::array<typename get_pair_type<T>::pair_t>::iterator end) noexcept {
+	std::sort(psl::ecs::execution::seq, begin, end, [](auto& lhs, auto& rhs) -> bool {
+		if constexpr(get_pair_type<T>::is_big) {
+			return Pred {}(*lhs.first, *rhs.first);
+		} else {
+			return Pred {}(lhs.first, rhs.first);
+		}
+	});
+}
+
 template <typename Pred, typename T>
 static inline void order_by(psl::ecs::execution::parallel_policy,
 							const psl::ecs::state_t& state,
-							psl::array<entity_t>::iterator begin,
-							psl::array<entity_t>::iterator end,
+							typename psl::array<typename get_pair_type<T>::pair_t>::iterator begin,
+							typename psl::array<typename get_pair_type<T>::pair_t>::iterator end,
 							size_t max) noexcept {
 	auto size = std::distance(begin, end);
+
 	if(size <= static_cast<decltype(size)>(max)) {
 		psl::ecs::details::order_by<Pred, T>(psl::ecs::execution::seq, state, begin, end);
 	} else {
@@ -49,16 +122,23 @@ static inline void order_by(psl::ecs::execution::parallel_policy,
 
 		psl::ecs::details::order_by<Pred, T>(psl::ecs::execution::par, state, middle, end, max);
 
-		const auto pred = Pred {};
 		future.wait();
 		if constexpr(std::is_same_v<psl::ecs::execution::parallel_unsequenced_policy, psl::ecs::execution::no_exec>) {
-			std::inplace_merge(begin, middle, end, [&state, &pred](entity_t lhs, entity_t rhs) -> bool {
-				return std::invoke(pred, state.get<T>(lhs), state.get<T>(rhs));
+			std::inplace_merge(begin, middle, end, [&state](auto const& lhs, auto const& rhs) -> bool {
+				if constexpr(get_pair_type<T>::is_big) {
+					return Pred {}(*lhs.first, *rhs.first);
+				} else {
+					return Pred {}(lhs.first, rhs.first);
+				}
 			});
 		} else {
 			std::inplace_merge(
-			  psl::ecs::execution::par_unseq, begin, middle, end, [&state, &pred](entity_t lhs, entity_t rhs) -> bool {
-				  return std::invoke(pred, state.get<T>(lhs), state.get<T>(rhs));
+			  psl::ecs::execution::par_unseq, begin, middle, end, [&state](auto const& lhs, auto const& rhs) -> bool {
+				  if constexpr(get_pair_type<T>::is_big) {
+					  return Pred {}(*lhs.first, *rhs.first);
+				  } else {
+					  return Pred {}(lhs.first, rhs.first);
+				  }
 			  });
 		}
 	}
@@ -68,9 +148,25 @@ template <typename Pred, typename T>
 static inline void order_by(psl::ecs::execution::parallel_policy,
 							const psl::ecs::state_t& state,
 							psl::array<entity_t>::iterator begin,
+							psl::array<entity_t>::iterator end,
+							size_t max) noexcept {
+	auto size	  = std::distance(begin, end);
+	auto sortable = get_pair_type<T>::make_array(state, begin, end);
+
+	order_by<Pred, T>(psl::ecs::execution::parallel_policy {}, state, sortable.begin(), sortable.end(), max);
+
+	for(size_t i = 0; i < sortable.size(); ++i) {
+		*(begin + i) = sortable[i].second;
+	}
+}
+
+template <typename Pred, typename T>
+static inline void order_by(psl::ecs::execution::parallel_policy,
+							const psl::ecs::state_t& state,
+							psl::array<entity_t>::iterator begin,
 							psl::array<entity_t>::iterator end) noexcept {
 	auto size		 = std::distance(begin, end);
-	auto thread_size = std::max<size_t>(1u, std::min<size_t>(std::thread::hardware_concurrency(), size % 1024u));
+	auto thread_size = std::max<size_t>(1u, std::min<size_t>(std::thread::hardware_concurrency(), size % (1 << 12)));
 	size /= thread_size;
 
 


### PR DESCRIPTION
`order_by` will now do bulk operations instead of fetching one by one. Additionally caching will be used.

A specialization is present for component types that exceed a specific size to lower the amount of copying.

Lastly some additional benchmarks were added to cover the different scenario's