### PR TITLE
Fixed Android CI build issue

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -90,9 +90,12 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libgl1-mesa-dev libegl1-mesa-dev -y
+    # installing the android sdk deps manually due to issues with permissions
     - name: dependencies
       if: ${{ matrix.target == 'android' }}
-      run: yes | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --licenses
+      run: |
+        yes | sudo ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --licenses
+        sudo ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "platform-tools" "ndk;27.3.13750724" "cmake;3.31.0" "platforms;android-33-ext4"
     - name: initialize
       run: cmake --preset=${{ matrix.target }}-release-${{ matrix.graphics }} -DPE_BENCHMARKS=${{ matrix.benchmarks }} -DPE_TESTS=${{ matrix.tests }}
     - name: compile

--- a/core/main/android/build.gradle
+++ b/core/main/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:8.7.0'
     }
 }
 

--- a/core/main/android/main/build.gradle
+++ b/core/main/android/main/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 31
-    ndkVersion '25.2.9519653'
+    ndkVersion '27.3.13750724'
     assetPacks = [":package_0"]
     namespace 'com.paradigmengine.main'
     defaultConfig {
@@ -31,7 +31,7 @@ android {
     }
     externalNativeBuild {
         cmake {
-            version '3.22.1'
+            version '3.31.0'
             path 'src/main/CMakeLists.txt'
         }
     }

--- a/core/src/os/context_android.cpp
+++ b/core/src/os/context_android.cpp
@@ -119,7 +119,7 @@ bool core::os::context::tick() noexcept {
 	// If not animating, we will block forever waiting for events.
 	// If animating, we loop until all events are read, then continue
 	// to draw the next frame of animation.
-	while((ident = ALooper_pollAll(m_Paused ? -1 : 0, nullptr, &events, (void**)&source)) >= 0) {
+	while((ident = ALooper_pollOnce(m_Paused ? -1 : 0, nullptr, &events, (void**)&source)) >= 0) {
 		// Process this event.
 		if(source != nullptr) {
 			source->process(m_Application, source);

--- a/psl/src/platform_utils.cpp
+++ b/psl/src/platform_utils.cpp
@@ -287,6 +287,7 @@ bool psl::utility::platform::file::read(psl::string_view filename, std::vector<p
 	size_t currChunk;
 	out.reserve(length);
 
+	psl::array<char> buffer;
 	// while we have still some data to read
 	while(remaining != 0) {
 		// set proper size for our next chunk
@@ -295,13 +296,13 @@ bool psl::utility::platform::file::read(psl::string_view filename, std::vector<p
 		} else {
 			currChunk = remaining;
 		}
-		char chunk[currChunk];
+		buffer.resize(currChunk);
 
 		// read data chunk
-		if(AAsset_read(asset, chunk, currChunk) > 0)	// returns less than 0 on error
+		if(AAsset_read(asset, buffer.data(), currChunk) > 0)	// returns less than 0 on error
 		{
 			// and append it to our vector
-			out.insert(out.end(), chunk, chunk + currChunk);
+			out.insert(out.end(), buffer.data(), buffer.data() + currChunk);
 			remaining = AAsset_getRemainingLength64(asset);
 		}
 	}
@@ -355,6 +356,7 @@ bool psl::utility::platform::file::read(psl::string_view filename, psl::string& 
 	off64_t remaining = AAsset_getRemainingLength64(asset);
 	size_t Mb		  = 1000 * 1024;	// 1Mb is maximum chunk size for compressed assets
 	size_t currChunk;
+	psl::array<char> buffer;
 	out.reserve(length);
 
 	// while we have still some data to read
@@ -365,13 +367,13 @@ bool psl::utility::platform::file::read(psl::string_view filename, psl::string& 
 		} else {
 			currChunk = remaining;
 		}
-		char chunk[currChunk];
+		buffer.resize(currChunk);
 
 		// read data chunk
-		if(AAsset_read(asset, chunk, currChunk) > 0)	// returns less than 0 on error
+		if(AAsset_read(asset, buffer.data(), currChunk) > 0)	// returns less than 0 on error
 		{
 			// and append it to our vector
-			out.insert(out.end(), chunk, chunk + currChunk);
+			out.insert(out.end(), buffer.data(), buffer.data() + currChunk);
 			remaining = AAsset_getRemainingLength64(asset);
 		}
 	}

--- a/tools/android.py
+++ b/tools/android.py
@@ -70,17 +70,22 @@ class Android:
                 if sdk != None
                 else "sdkmanager"
             )
-            run_command(
-                command=[application, package, f"--channel={str(channel)}"],
-                print_stdout=True,
-                catch_stdout=False,
-            )
+            try:
+                run_command(
+                    command=[application, "--install", f'"{package}"', f"--channel={str(channel)}"],
+                    print_stdout=True,
+                    catch_stdout=False,
+                )
+            except Exception as e:
+                print(f"Failed to install '{package}': {e}. This could be caused by permission issues, please install it manually.")
+                exit(1)
         else:
             raise Exception(f"Could not find the required sdk package '{package}'")
 
     def _parse_installed_packages(channel=0, sdk=None):
+        backup_dir = os.path.join(sdk, "cmdline-tools", "latest", "bin", "sdkmanager")
         application = (
-            os.path.join(sdk, "cmdline-tools", "latest", "bin", "sdkmanager")
+            backup_dir
             if sdk != None
             else "sdkmanager"
         )
@@ -105,9 +110,10 @@ class Android:
 
     def dependencies():
         return [
+            ("platform-tools", 0),
             ("platforms;android-33-ext4", 0),
-            ("cmake;3.22.1", 3),
-            ("ndk;25.2.9519653", 1),
+            ("cmake;3.31.0", 0),
+            ("ndk;27.3.13750724", 0),
         ]
 
     def is_generated(self) -> bool:

--- a/tools/android.py
+++ b/tools/android.py
@@ -72,23 +72,26 @@ class Android:
             )
             try:
                 run_command(
-                    command=[application, "--install", f'"{package}"', f"--channel={str(channel)}"],
+                    command=[
+                        application,
+                        "--install",
+                        f'"{package}"',
+                        f"--channel={str(channel)}",
+                    ],
                     print_stdout=True,
                     catch_stdout=False,
                 )
             except Exception as e:
-                print(f"Failed to install '{package}': {e}. This could be caused by permission issues, please install it manually.")
+                print(
+                    f"Failed to install '{package}': {e}. This could be caused by permission issues, please install it manually."
+                )
                 exit(1)
         else:
             raise Exception(f"Could not find the required sdk package '{package}'")
 
     def _parse_installed_packages(channel=0, sdk=None):
         backup_dir = os.path.join(sdk, "cmdline-tools", "latest", "bin", "sdkmanager")
-        application = (
-            backup_dir
-            if sdk != None
-            else "sdkmanager"
-        )
+        application = backup_dir if sdk != None else "sdkmanager"
         sdkman_output = run_command(
             [application, "--list", f"--channel={str(channel)}"], catch_stdout=True
         )


### PR DESCRIPTION
Github forcibly updated the gradle minimum to 9.0.0, so we have to follow suite to guarantee the CI keeps working. This PR does the following changes:
- Updated ndk to latest stable
- Updated gradle to 9.0.0
- Fixed variable length array usage
- Fixed deprecated Android API usage