### PR TITLE
Render perf improvements

### DIFF
--- a/core/inc/core/ecs/systems/geometry_instance.hpp
+++ b/core/inc/core/ecs/systems/geometry_instance.hpp
@@ -26,6 +26,12 @@ class geometry_instancing {
 		uint32_t id;
 	};
 
+	struct instance_id_sort {
+		inline bool operator()(const instance_id& lhs, const instance_id& rhs) const noexcept {
+			return lhs.id < rhs.id;
+		}
+	};
+
   public:
 	geometry_instancing(psl::ecs::state_t& state);
 	~geometry_instancing() = default;
@@ -41,6 +47,32 @@ class geometry_instancing {
 									psl::ecs::filter<const core::ecs::components::dynamic_tag>,
 									psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> pack);
 	*/
+	void dynamic_add(
+	  psl::ecs::info_t& info,
+	  psl::ecs::pack_indirect_full_t<
+		psl::ecs::entity_t,
+		core::ecs::components::renderable,
+		const core::ecs::components::transform,
+		psl::ecs::filter<core::ecs::components::dynamic_tag>,
+		psl::ecs::except<core::ecs::components::dont_render_tag>,
+		psl::ecs::on_combine<core::ecs::components::renderable, core::ecs::components::transform>> geometry_pack);
+
+	void dynamic_remove(
+	  psl::ecs::info_t& info,
+	  psl::ecs::pack_direct_partial_t<
+		psl::ecs::entity_t,
+		core::ecs::components::renderable,
+		const instance_id,
+		psl::ecs::filter<core::ecs::components::dynamic_tag>,
+		psl::ecs::except<core::ecs::components::dont_render_tag>,
+		psl::ecs::on_break<core::ecs::components::renderable, core::ecs::components::transform, instance_id>> pack);
+	void dynamic_update(psl::ecs::info_t& info,
+						psl::ecs::pack_indirect_partial_t<core::ecs::components::renderable,
+														  const core::ecs::components::transform,
+														  const instance_id,
+														  psl::ecs::filter<core::ecs::components::dynamic_tag>,
+														  psl::ecs::except<core::ecs::components::dont_render_tag>,
+														  psl::ecs::order_by<instance_id_sort, instance_id>> pack);
 	void dynamic_system(
 	  psl::ecs::info_t& info,
 	  psl::ecs::pack_direct_full_t<core::ecs::components::renderable,
@@ -81,6 +113,7 @@ class geometry_instancing {
 														const instance_id,
 														psl::ecs::except<core::ecs::components::transform>,
 														psl::ecs::on_remove<core::ecs::components::renderable>> pack);
+	std::mutex m_Mutex;
 	// void static_disable();
 	// void static_enable(psl::ecs::info& info, psl::ecs::pack_direct_full_t<psl::ecs::entity_t, const
 	// core::ecs::components::renderable, const instance_id, core::ecs::components::dont_render_tag> dont_render);

--- a/core/src/ecs/systems/geometry_instance.cpp
+++ b/core/src/ecs/systems/geometry_instance.cpp
@@ -19,12 +19,186 @@ geometry_instancing::geometry_instancing(psl::ecs::state_t& state) {
 	state.declare<"geometry_instancing::static_add">(psl::ecs::threading::seq, &geometry_instancing::static_add, this);
 	state.declare<"geometry_instancing::static_remove">(
 	  psl::ecs::threading::seq, &geometry_instancing::static_remove, this);
-	state.declare<"geometry_instancing::dynamic_system">(
-	  psl::ecs::threading::seq, &geometry_instancing::dynamic_system, this);
+	/*state.declare<"geometry_instancing::dynamic_system">(
+	  psl::ecs::threading::seq, &geometry_instancing::dynamic_system, this);*/
 	state.declare<"geometry_instancing::static_geometry_add">(
 	  psl::ecs::threading::seq, &geometry_instancing::static_geometry_add, this);
 	state.declare<"geometry_instancing::static_geometry_remove">(
 	  psl::ecs::threading::seq, &geometry_instancing::static_geometry_remove, this);
+	state.declare<"geometry_instancing::dynamic_add">(
+	  psl::ecs::threading::seq, &geometry_instancing::dynamic_add, this);
+	state.declare<"geometry_instancing::dynamic_remove">(
+	  psl::ecs::threading::par, &geometry_instancing::dynamic_remove, this);
+	state.declare<"geometry_instancing::dynamic_update">(
+	  psl::ecs::threading::par, &geometry_instancing::dynamic_update, this);
+}
+
+
+void geometry_instancing::dynamic_add(info_t& info,
+									  pack_indirect_full_t<entity_t,
+														   renderable,
+														   const transform,
+														   filter<dynamic_tag>,
+														   except<dont_render_tag>,
+														   on_combine<renderable, transform>> geometry_pack) {
+	if(geometry_pack.size() == 0) {
+		return;
+	}
+
+	auto instantiate = [&info](renderable& rend,
+							   const transform* first,
+							   const transform* last,
+							   entity_t* first_ent,
+							   entity_t* last_ent,
+							   uint32_t count) {
+		if(!rend.bundle || !rend.geometry || count == 0) {
+			return;
+		}
+		auto instancesID = rend.bundle->instantiate(rend.geometry, count);
+		psl::array<psl::mat4x4> modelMats {};
+		modelMats.reserve(count);
+		psl::array<instance_id> instanceIDs {};
+		instanceIDs.reserve(count);
+
+		for(auto [startIndex, endIndex] : instancesID) {
+			auto const range = endIndex - startIndex;
+			for(auto i = 0u; i < range; ++i, ++first) {
+				const psl::mat4x4 translationMat = translate(first->position);
+				const psl::mat4x4 rotationMat	 = to_matrix(first->rotation);
+				const psl::mat4x4 scaleMat		 = scale(first->scale);
+				modelMats.emplace_back(translationMat * rotationMat * scaleMat);
+				instanceIDs.emplace_back(instance_id {startIndex + i});
+			}
+
+			if(!rend.bundle->set(
+				 rend.geometry, startIndex, psl::string {core::gfx::constants::INSTANCE_MODELMATRIX}, modelMats))
+				core::log->error(
+				  "could not set the instance data for the dynamic elements in geometry: {} startIndex: {} size: "
+				  "{}",
+				  rend.geometry,
+				  startIndex,
+				  modelMats.size());
+			modelMats.clear();
+		}
+		info.command_buffer.add_components<instance_id>(psl::array_view<entity_t>(first_ent, last_ent), instanceIDs);
+	};
+
+	core::resource::handle<core::gfx::bundle> lastBundle {};
+	uint32_t count {0};
+	transform const* first {geometry_pack.get<const transform>().data()};
+	transform const* last {nullptr};
+	auto* render_it = geometry_pack.get<renderable>().data();
+	psl::array<psl::mat4x4> modelMats {};
+	psl::array<instance_id> instanceIDs {};
+	entity_t* first_ent = geometry_pack.get<entity_t>().data();
+	entity_t* last_ent {nullptr};
+	for(auto [ent, render, trns] : geometry_pack) {
+		auto bundleHandle = render.bundle;
+		last_ent		  = &ent;
+		last			  = &trns;
+		render_it		  = &render;
+		if(bundleHandle != lastBundle && lastBundle && bundleHandle && count > 0) {
+			instantiate(*render_it, first, last + 1, first_ent, last_ent + 1, count);
+			first	  = &trns;
+			count	  = 0;
+			first_ent = &ent;
+		}
+
+		lastBundle = bundleHandle;
+		++count;
+	}
+
+	if(count > 0) {
+		instantiate(*render_it, first, last + 1, first_ent, last_ent + 1, count);
+	}
+}
+
+void geometry_instancing::dynamic_remove(info_t& info,
+										 pack_direct_partial_t<entity_t,
+															   renderable,
+															   const instance_id,
+															   filter<dynamic_tag>,
+															   except<dont_render_tag>,
+															   on_break<renderable, transform, instance_id>> pack) {
+	for(auto [e, r, id] : pack) {
+		if(r.bundle && r.geometry) {
+			r.bundle->release(r.geometry, id.id);
+		}
+	}
+
+	info.command_buffer.remove_components<instance_id>(pack.get<entity_t>());
+}
+
+void geometry_instancing::dynamic_update(info_t& info,
+										 pack_indirect_partial_t<renderable,
+																 const transform,
+																 const instance_id,
+																 filter<dynamic_tag>,
+																 except<dont_render_tag>,
+																 order_by<instance_id_sort, instance_id>> pack) {
+	if(pack.empty()) {
+		return;
+	}
+	struct temp {
+		instance_id id;
+		psl::mat4x4 model;
+	};
+	std::unordered_map<psl::UID, std::unordered_map<psl::UID, std::pair<renderable*, psl::array<temp>>>> combos;
+	psl::UID lastBundleUID {};
+	psl::UID lastGeometryUID {};
+	std::pair<renderable*, psl::array<temp>>* currentArray = nullptr;
+	for(auto [r, t, id] : pack) {
+		const psl::mat4x4 translationMat = translate(t.position);
+		const psl::mat4x4 rotationMat	 = to_matrix(t.rotation);
+		const psl::mat4x4 scaleMat		 = scale(t.scale);
+		const auto modelMat				 = translationMat * rotationMat * scaleMat;
+		if(r.bundle.uid() == lastBundleUID && r.geometry.uid() == lastGeometryUID && currentArray) {
+			currentArray->second.emplace_back(temp {id, modelMat});
+		} else {
+			lastBundleUID	= r.bundle.uid();
+			lastGeometryUID = r.geometry.uid();
+			currentArray	= &combos[r.bundle][r.geometry];
+			currentArray->second.emplace_back(temp {id, modelMat});
+			if(currentArray->first == nullptr) {
+				currentArray->first = &r;
+				currentArray->second.reserve(pack.size());
+			}
+		}
+	}
+
+	psl::array<psl::mat4x4> modelMats {};
+	modelMats.reserve(pack.size());
+	for(auto& [bundleUID, geomMap] : combos) {
+		for(auto& [geometryUID, instanceData] : geomMap) {
+			std::sort(instanceData.second.begin(), instanceData.second.end(), [](const temp& lhs, const temp& rhs) {
+				return lhs.id.id < rhs.id.id;
+			});
+
+			size_t index	  = 0;
+			size_t totalCount = 0;
+			while(index < instanceData.second.size()) {
+				totalCount = index;
+				// figure out contiguous ranges
+				auto* firstModelMat = &instanceData.second[index].model;
+				auto firstId		= instanceData.second[index].id.id;
+				modelMats.emplace_back(instanceData.second[index].model);
+				while(index + 1 < instanceData.second.size() &&
+					  firstId + index + 1 == instanceData.second[index + 1].id.id) {
+					++index;
+					modelMats.emplace_back(instanceData.second[index].model);
+				}
+
+				totalCount = index - totalCount + 1;
+
+				auto scoped_lock   = std::scoped_lock(m_Mutex);
+				auto* lastModelMat = &instanceData.second[index].model;
+				instanceData.first->bundle->set(
+				  instanceData.first->geometry, firstId, core::gfx::constants::INSTANCE_MODELMATRIX, modelMats);
+				++index;
+				modelMats.clear();
+			}
+		}
+	}
 }
 
 
@@ -41,9 +215,11 @@ void geometry_instancing::dynamic_system(info_t& info,
 
 	{
 		auto renderers = geometry_pack.get<renderable>();
-		for(auto renderable : renderers)
-			if(renderable.bundle)
+		for(auto renderable : renderers) {
+			if(renderable.bundle) {
 				renderable.bundle->release_all();
+			}
+		}
 	}
 
 	core::profiler.scope_end();
@@ -128,7 +304,7 @@ void geometry_instancing::static_add(info_t& info,
 	core::profiler.scope_begin("create_all");
 	std::vector<psl::mat4x4> modelMats;
 	psl::array<entity_t> eIds;
-	eIds.resize(1);
+	psl::array<instance_id> instanceIds;
 	for(const auto& unique_bundle : UniqueCombinations) {
 		modelMats.clear();
 
@@ -141,6 +317,9 @@ void geometry_instancing::static_add(info_t& info,
 
 			uint32_t indicesCompleted = 0;
 			for(auto [startIndex, endIndex] : instancesID) {
+				eIds.reserve(endIndex - startIndex);
+				instanceIds.reserve(endIndex - startIndex);
+				modelMats.reserve(endIndex - startIndex);
 				for(auto i = startIndex; i < endIndex; ++i, ++indicesCompleted) {
 					const auto& transform = std::get<const core::ecs::components::transform&>(
 					  geometry_pack[indicesCompleted + geometryData.startIndex]);
@@ -149,13 +328,16 @@ void geometry_instancing::static_add(info_t& info,
 					const psl::mat4x4 scaleMat		 = scale(transform.scale);
 					modelMats.emplace_back(translationMat * rotationMat * scaleMat);
 
-					eIds[0] = std::get<entity_t&>(geometry_pack[indicesCompleted + geometryData.startIndex]);
-					info.command_buffer.add_components<instance_id>(eIds, instance_id {i});
+					eIds.emplace_back(std::get<entity_t&>(geometry_pack[indicesCompleted + geometryData.startIndex]));
+					instanceIds.emplace_back(instance_id {i});
 				}
+				info.command_buffer.add_components<instance_id>(eIds, instanceIds);
 				bundleHandle->set(
 				  geometryHandle, startIndex, psl::string {core::gfx::constants::INSTANCE_MODELMATRIX}, modelMats);
 
 				modelMats.clear();
+				eIds.clear();
+				instanceIds.clear();
 			}
 		}
 	}
@@ -188,16 +370,15 @@ void geometry_instancing::static_geometry_add(
 							   psl::ecs::on_add<core::ecs::components::renderable>> pack) {
 	if(pack.size() == 0)
 		return;
-	psl::array<entity_t> eIds;
-	eIds.resize(1);
+	psl::array<instance_id> instanceIds;
 	for(auto [entity, render] : pack) {
 		auto bundleHandle	= render.bundle;
 		auto geometryHandle = render.geometry;
 
 		auto instancesID = bundleHandle->instantiate(geometryHandle, 1);
-		eIds[0]			 = entity;
-		info.command_buffer.add_components<instance_id>(eIds, instance_id {instancesID[0].first});
+		instanceIds.emplace_back(instancesID[0].first);
 	}
+	info.command_buffer.add_components<instance_id>(pack.get<entity_t>(), instanceIds);
 }
 
 

--- a/core/src/ecs/systems/geometry_instance.cpp
+++ b/core/src/ecs/systems/geometry_instance.cpp
@@ -70,8 +70,7 @@ void geometry_instancing::dynamic_add(info_t& info,
 				instanceIDs.emplace_back(instance_id {startIndex + i});
 			}
 
-			if(!rend.bundle->set(
-				 rend.geometry, startIndex, psl::string {core::gfx::constants::INSTANCE_MODELMATRIX}, modelMats))
+			if(!rend.bundle->set(rend.geometry, startIndex, core::gfx::constants::INSTANCE_MODELMATRIX, modelMats))
 				core::log->error(
 				  "could not set the instance data for the dynamic elements in geometry: {} startIndex: {} size: "
 				  "{}",
@@ -264,7 +263,7 @@ void geometry_instancing::dynamic_system(info_t& info,
 				}
 
 				if(!bundleHandle->set(
-					 geometryHandle, startIndex, psl::string {core::gfx::constants::INSTANCE_MODELMATRIX}, modelMats))
+					 geometryHandle, startIndex, core::gfx::constants::INSTANCE_MODELMATRIX, modelMats))
 					core::log->error(
 					  "could not set the instance data for the dynamic elements in geometry: {} startIndex: {} size: "
 					  "{}",
@@ -332,8 +331,7 @@ void geometry_instancing::static_add(info_t& info,
 					instanceIds.emplace_back(instance_id {i});
 				}
 				info.command_buffer.add_components<instance_id>(eIds, instanceIds);
-				bundleHandle->set(
-				  geometryHandle, startIndex, psl::string {core::gfx::constants::INSTANCE_MODELMATRIX}, modelMats);
+				bundleHandle->set(geometryHandle, startIndex, core::gfx::constants::INSTANCE_MODELMATRIX, modelMats);
 
 				modelMats.clear();
 				eIds.clear();

--- a/core/src/gfx/details/instance.cpp
+++ b/core/src/gfx/details/instance.cpp
@@ -92,8 +92,10 @@ void data::add(core::resource::handle<material_t> material) {
 
 			for(auto& [uid, obj] : m_InstanceData) {
 				auto res = m_VertexInstanceBuffer->reserve(obj.id_generator.capacity() * d.description.size_of_element);
-				if(!res)
+				if(!res) {
 					core::gfx::log->error("could not allocate");
+					continue;
+				}
 
 				obj.data.emplace_back(res.value());
 				obj.description.emplace_back(d.description);
@@ -110,12 +112,14 @@ void data::add(core::resource::handle<material_t> material) {
 std::vector<std::pair<uint32_t, uint32_t>> data::add(core::resource::tag<core::gfx::geometry_t> uid, uint32_t count) {
 	auto it = m_InstanceData.find(uid);
 	if(it == std::end(m_InstanceData)) {
-		auto size {(count > default_capacity) ? count << 2 : default_capacity};
-		it = m_InstanceData.emplace(uid, object {uid, size}).first;
+		auto const size = std::max(count, default_capacity);
+		it				= m_InstanceData.emplace(uid, object {uid, size}).first;
 		for(const auto& b : m_UniqueBindings) {
 			auto res = m_VertexInstanceBuffer->reserve(it->second.id_generator.capacity() * b.first.size_of_element);
-			if(!res)
+			if(!res) {
 				core::gfx::log->error("could not allocate");
+				continue;
+			}
 			it->second.data.emplace_back(res.value());
 			it->second.description.emplace_back(b.first);
 		}
@@ -123,20 +127,29 @@ std::vector<std::pair<uint32_t, uint32_t>> data::add(core::resource::tag<core::g
 
 	if(it->second.id_generator.available() < count) {
 		auto size	  = it->second.id_generator.size();
-		auto new_size = (it->second.id_generator.available() + count) << 2;
+		auto new_size = std::max(size + count, size + (size >> 1));
 		if(!it->second.id_generator.resize(new_size))
 			core::gfx::log->error("could not increase the id_generator size from {} to {}", size, new_size);
 		else {
-			for(auto& d : it->second.data) {
-				auto res =
-				  m_VertexInstanceBuffer->reserve(it->second.id_generator.capacity() * d.range().size() / size);
-				if(!res)
+			psl_assert(it->second.data.size() == it->second.description.size(),
+					   "Assuming that descriptions and data are always 1-1 match");
+			auto dataIt	 = std::begin(it->second.data);
+			auto descrIt = std::begin(it->second.description);
+			for(; dataIt != std::end(it->second.data) && descrIt != std::end(it->second.description);
+				++dataIt, ++descrIt) {
+				auto& d					   = *dataIt;
+				const auto requested_bytes = it->second.id_generator.capacity() * descrIt->size_of_element;
+				auto res				   = m_VertexInstanceBuffer->reserve(requested_bytes);
+				if(!res) {
 					core::gfx::log->error("could not allocate");
+					continue;
+				}
+				auto& value = res.value();
 				m_VertexInstanceBuffer->copy_from(
 				  m_VertexInstanceBuffer.value(),
-				  {core::gfx::memory_copy {d.range().begin, res.value().range().begin, d.range().size()}});
-				std::swap(d, res.value());
-				m_VertexInstanceBuffer->deallocate(res.value());
+				  {core::gfx::memory_copy {d.range().begin, value.range().begin, d.range().size()}});
+				std::swap(d, value);
+				m_VertexInstanceBuffer->deallocate(value);
 			}
 		}
 	}
@@ -218,7 +231,9 @@ bool data::erase(core::resource::tag<core::gfx::geometry_t> geometry, uint32_t i
 		it->second.id_generator.destroy(id);
 
 		if(it->second.id_generator.size() == 0) {
-			for(auto& segment : it->second.data) m_VertexInstanceBuffer->deallocate(segment);
+			for(auto& segment : it->second.data) {
+				m_VertexInstanceBuffer->deallocate(segment);
+			}
 
 			m_InstanceData.erase(it);
 		}
@@ -228,7 +243,9 @@ bool data::erase(core::resource::tag<core::gfx::geometry_t> geometry, uint32_t i
 }
 bool data::clear(core::resource::tag<core::gfx::geometry_t> geometry) noexcept {
 	if(auto it = m_InstanceData.find(geometry); it != std::end(m_InstanceData)) {
-		for(auto& segment : it->second.data) m_VertexInstanceBuffer->deallocate(segment);
+		for(auto& segment : it->second.data) {
+			m_VertexInstanceBuffer->deallocate(segment);
+		}
 
 		m_InstanceData.erase(it);
 		return true;
@@ -237,7 +254,9 @@ bool data::clear(core::resource::tag<core::gfx::geometry_t> geometry) noexcept {
 }
 bool data::clear() noexcept {
 	for(auto& [uid, obj] : m_InstanceData) {
-		for(auto& segment : obj.data) m_VertexInstanceBuffer->deallocate(segment);
+		for(auto& segment : obj.data) {
+			m_VertexInstanceBuffer->deallocate(segment);
+		}
 	}
 	m_InstanceData.clear();
 	return true;
@@ -281,8 +300,9 @@ bool data::set(core::resource::tag<core::gfx::material_t> material,
 			   size_t size,
 			   size_t offset) noexcept {
 	auto it = m_MaterialInstanceData.find(material);
-	if(it == std::end(m_MaterialInstanceData))
+	if(it == std::end(m_MaterialInstanceData)) {
 		return false;
+	}
 
 	return m_MaterialInstanceBuffer->buffer->commit(
 	  {core::gfx::commit_instruction {(void*)data, size, it->second.segment, memory::range_t {offset, offset + size}}});
@@ -290,8 +310,9 @@ bool data::set(core::resource::tag<core::gfx::material_t> material,
 
 bool data::bind_material(core::resource::handle<core::gfx::material_t> material) {
 	auto it = m_MaterialInstanceData.find(material);
-	if(it == std::end(m_MaterialInstanceData))
+	if(it == std::end(m_MaterialInstanceData)) {
 		return false;
+	}
 
 	return material->bind_instance_data(it->second.descriptor.binding(),
 										static_cast<uint32_t>(it->second.segment.range().begin));

--- a/examples/Shared/inc/examples/engine_instance.hpp
+++ b/examples/Shared/inc/examples/engine_instance.hpp
@@ -53,11 +53,11 @@ class engine_instance_t {
 		} instance_buffer {};
 
 		struct {
-			size_t size {8_mb};
+			size_t size {32_mb};
 		} instance_material_buffer {};
 
 		struct {
-			size_t size {8_mb};
+			size_t size {32_mb};
 		} instance_material_binding {};
 
 		struct {

--- a/examples/Shared/src/engine_instance.cpp
+++ b/examples/Shared/src/engine_instance.cpp
@@ -46,6 +46,8 @@ engine_instance_t::engine_instance_t(options_t options, std::unique_ptr<core::os
 
 	auto window_data = cache.create<core::data::window>();
 	window_data->name(options.window_title);
+	window_data->width(1600);
+	window_data->height(900);
 	m_SurfaceHandle = cache.create<core::os::surface>(window_data);
 	if(!m_SurfaceHandle) {
 		core::log->critical("Could not create a OS surface to draw on.");

--- a/psl/inc/psl/assertions.hpp
+++ b/psl/inc/psl/assertions.hpp
@@ -192,7 +192,7 @@ namespace details {
 			const auto output_str	 = fmt::format(output_rt_str, std::get<Is>(args)...);
 			print_to_cout(output_str);
 	#else
-			print_to_cout("\x1Ftodo: todo: assert log not supported in release\x1F");
+			print_to_cout("\x1Ftodo: assert log not supported in release\x1F");
 	#endif
 		}
 

--- a/psl/inc/psl/ecs/details/components_cache.hpp
+++ b/psl/inc/psl/ecs/details/components_cache.hpp
@@ -427,7 +427,7 @@ class components_cache_t {
 		} else if constexpr(mode == details::add_component_behaviour_mode_t::callable_1) {
 			create_storage<type>();
 			add_component_impl(
-			  get_component_untyped_info<type>(), entities, [prototype](std::uintptr_t location, size_t count) {
+			  get_component_untyped_info<type>(), entities, [&prototype](std::uintptr_t location, size_t count) {
 				  for(auto i = size_t {0}; i < count; ++i) {
 					  std::invoke(prototype, *((underlying_t*)(location) + i));
 				  }
@@ -436,7 +436,7 @@ class components_cache_t {
 			create_storage<type>();
 			add_component_impl(get_component_untyped_info<type>(),
 							   entities,
-							   [prototype, &entities](std::uintptr_t location, size_t count) {
+							   [&prototype, &entities](std::uintptr_t location, size_t count) {
 								   for(auto i = size_t {0}; i < count; ++i) {
 									   std::invoke(prototype, *((underlying_t*)(location) + i), entities[i]);
 								   }

--- a/psl/inc/psl/ecs/order_by.hpp
+++ b/psl/inc/psl/ecs/order_by.hpp
@@ -106,6 +106,9 @@ static inline void order_by(psl::ecs::execution::parallel_policy,
 							typename psl::array<typename get_pair_type<T>::pair_t>::iterator end,
 							size_t max) noexcept {
 	auto size = std::distance(begin, end);
+	if(size == 0) {
+		return;
+	}
 
 	if(size <= static_cast<decltype(size)>(max)) {
 		psl::ecs::details::order_by<Pred, T>(psl::ecs::execution::seq, state, begin, end);
@@ -150,7 +153,10 @@ static inline void order_by(psl::ecs::execution::parallel_policy,
 							psl::array<entity_t>::iterator begin,
 							psl::array<entity_t>::iterator end,
 							size_t max) noexcept {
-	auto size	  = std::distance(begin, end);
+	auto size = std::distance(begin, end);
+	if(size == 0) {
+		return;
+	}
 	auto sortable = get_pair_type<T>::make_array(state, begin, end);
 
 	order_by<Pred, T>(psl::ecs::execution::parallel_policy {}, state, sortable.begin(), sortable.end(), max);
@@ -165,7 +171,10 @@ static inline void order_by(psl::ecs::execution::parallel_policy,
 							const psl::ecs::state_t& state,
 							psl::array<entity_t>::iterator begin,
 							psl::array<entity_t>::iterator end) noexcept {
-	auto size		 = std::distance(begin, end);
+	auto size = std::distance(begin, end);
+	if(size == 0) {
+		return;
+	}
 	auto thread_size = std::max<size_t>(1u, std::min<size_t>(std::thread::hardware_concurrency(), size % (1 << 12)));
 	size /= thread_size;
 


### PR DESCRIPTION
Uses batched operations to update static and dynamic geometry. This does break removal of instanced data for dynamic objects, but we'll deal with that soon. The old code still exists if needed to be used. This prioritizes #139 

As a result of these changes dynamic objects render perf 5x'ed, and static render perf similarly massively improved (8x for single frame load). For static render objects this isn't a real problem as the framehit is only one frame, but for dynamic objects which need their WVP recalculated every frame this resulted in an improvement of 100'000 dynamic objects at +-25ms, to 512'000 at +-25ms.