### PR TITLE
Instanced data rewrite

### DIFF
--- a/core/inc/core/ecs/systems/geometry_instance.hpp
+++ b/core/inc/core/ecs/systems/geometry_instance.hpp
@@ -38,26 +38,23 @@ class geometry_instancing {
 	geometry_instancing& operator=(geometry_instancing&& other) noexcept = delete;
 
   private:
-	void dynamic_add(
-	  psl::ecs::info_t& info,
-	  psl::ecs::pack_indirect_partial_t<
-		psl::ecs::entity_t,
-		const core::ecs::components::renderable,
-		const core::ecs::components::transform,
-		psl::ecs::filter<core::ecs::components::dynamic_tag>,
-		psl::ecs::except<core::ecs::components::dont_render_tag>,
-		psl::ecs::on_combine<core::ecs::components::renderable, core::ecs::components::transform>> geometry_pack);
+	void add(psl::ecs::info_t& info,
+			 psl::ecs::pack_indirect_partial_t<
+			   psl::ecs::entity_t,
+			   const core::ecs::components::renderable,
+			   const core::ecs::components::transform,
+			   psl::ecs::except<core::ecs::components::dont_render_tag>,
+			   psl::ecs::on_combine<core::ecs::components::renderable, core::ecs::components::transform>,
+			   psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> geometry_pack);
 
-	void dynamic_remove(
-	  psl::ecs::info_t& info,
-	  psl::ecs::pack_indirect_full_t<
-		psl::ecs::entity_t,
-		const core::ecs::components::renderable,
-		const instance_id,
-		psl::ecs::filter<core::ecs::components::dynamic_tag>,
-		psl::ecs::except<core::ecs::components::dont_render_tag>,
-		psl::ecs::on_break<core::ecs::components::renderable, core::ecs::components::transform, instance_id>,
-		psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> pack);
+	void remove(psl::ecs::info_t& info,
+				psl::ecs::pack_indirect_full_t<
+				  psl::ecs::entity_t,
+				  const core::ecs::components::renderable,
+				  const instance_id,
+				  psl::ecs::except<core::ecs::components::dont_render_tag>,
+				  psl::ecs::on_break<core::ecs::components::renderable, core::ecs::components::transform, instance_id>,
+				  psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> pack);
 	void dynamic_update(
 	  psl::ecs::info_t& info,
 	  psl::ecs::pack_indirect_partial_t<const core::ecs::components::renderable,
@@ -66,24 +63,6 @@ class geometry_instancing {
 										psl::ecs::filter<core::ecs::components::dynamic_tag>,
 										psl::ecs::except<core::ecs::components::dont_render_tag>,
 										psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> pack);
-
-	void
-	static_add(psl::ecs::info_t& info,
-			   psl::ecs::pack_indirect_full_t<
-				 psl::ecs::entity_t,
-				 const core::ecs::components::renderable,
-				 const core::ecs::components::transform,
-				 psl::ecs::except<core::ecs::components::dynamic_tag>,
-				 psl::ecs::on_combine<const core::ecs::components::renderable, const core::ecs::components::transform>,
-				 psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> geometry_pack);
-	void static_remove(
-	  psl::ecs::info_t& info,
-	  psl::ecs::pack_direct_full_t<psl::ecs::entity_t,
-								   core::ecs::components::renderable,
-								   const instance_id,
-								   psl::ecs::except<core::ecs::components::dynamic_tag>,
-								   psl::ecs::on_break<const core::ecs::components::renderable,
-													  const core::ecs::components::transform>> geometry_pack);
 
 	void static_geometry_add(
 	  psl::ecs::info_t& info,

--- a/core/inc/core/ecs/systems/geometry_instance.hpp
+++ b/core/inc/core/ecs/systems/geometry_instance.hpp
@@ -40,7 +40,7 @@ class geometry_instancing {
   private:
 	void dynamic_add(
 	  psl::ecs::info_t& info,
-	  psl::ecs::pack_indirect_partial_t<
+	  psl::ecs::pack_direct_partial_t<
 		psl::ecs::entity_t,
 		const core::ecs::components::renderable,
 		const core::ecs::components::transform,
@@ -87,11 +87,11 @@ class geometry_instancing {
 
 	void static_geometry_add(
 	  psl::ecs::info_t& info,
-	  psl::ecs::pack_indirect_full_t<psl::ecs::entity_t,
-									 const core::ecs::components::renderable,
-									 psl::ecs::except<core::ecs::components::transform>,
-									 psl::ecs::on_add<core::ecs::components::renderable>,
-									 psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> pack);
+	  psl::ecs::pack_direct_full_t<psl::ecs::entity_t,
+								   const core::ecs::components::renderable,
+								   psl::ecs::except<core::ecs::components::transform>,
+								   psl::ecs::on_add<core::ecs::components::renderable>,
+								   psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> pack);
 
 
 	void

--- a/core/inc/core/ecs/systems/geometry_instance.hpp
+++ b/core/inc/core/ecs/systems/geometry_instance.hpp
@@ -40,7 +40,7 @@ class geometry_instancing {
   private:
 	void dynamic_add(
 	  psl::ecs::info_t& info,
-	  psl::ecs::pack_direct_partial_t<
+	  psl::ecs::pack_indirect_partial_t<
 		psl::ecs::entity_t,
 		const core::ecs::components::renderable,
 		const core::ecs::components::transform,
@@ -69,7 +69,7 @@ class geometry_instancing {
 
 	void
 	static_add(psl::ecs::info_t& info,
-			   psl::ecs::pack_direct_full_t<
+			   psl::ecs::pack_indirect_full_t<
 				 psl::ecs::entity_t,
 				 const core::ecs::components::renderable,
 				 const core::ecs::components::transform,
@@ -103,8 +103,7 @@ class geometry_instancing {
 														psl::ecs::on_remove<core::ecs::components::renderable>> pack);
 
 	psl::array<instance_id> make_instances(core::ecs::components::renderable const& renderable,
-										   const core::ecs::components::transform* first,
-										   const core::ecs::components::transform* last);
+										   psl::array<core::ecs::components::transform const*> transforms);
 	std::mutex m_Mutex;
 };
 }	 // namespace core::ecs::systems

--- a/core/inc/core/ecs/systems/geometry_instance.hpp
+++ b/core/inc/core/ecs/systems/geometry_instance.hpp
@@ -17,10 +17,6 @@ class geometry_instancing {
 				return lhs.geometry.uid() < rhs.geometry.uid();
 		}
 	};
-	struct geometry_instance {
-		size_t startIndex;
-		size_t count;
-	};
 
 	struct instance_id {
 		uint32_t id;
@@ -42,16 +38,11 @@ class geometry_instancing {
 	geometry_instancing& operator=(geometry_instancing&& other) noexcept = delete;
 
   private:
-	/* void dynamic_add(psl::ecs::info& info,
-					 psl::ecs::pack_direct_full_t<core::ecs::components::renderable,
-									psl::ecs::filter<const core::ecs::components::dynamic_tag>,
-									psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> pack);
-	*/
 	void dynamic_add(
 	  psl::ecs::info_t& info,
-	  psl::ecs::pack_indirect_full_t<
+	  psl::ecs::pack_indirect_partial_t<
 		psl::ecs::entity_t,
-		core::ecs::components::renderable,
+		const core::ecs::components::renderable,
 		const core::ecs::components::transform,
 		psl::ecs::filter<core::ecs::components::dynamic_tag>,
 		psl::ecs::except<core::ecs::components::dont_render_tag>,
@@ -59,27 +50,22 @@ class geometry_instancing {
 
 	void dynamic_remove(
 	  psl::ecs::info_t& info,
-	  psl::ecs::pack_direct_partial_t<
+	  psl::ecs::pack_indirect_full_t<
 		psl::ecs::entity_t,
-		core::ecs::components::renderable,
+		const core::ecs::components::renderable,
 		const instance_id,
 		psl::ecs::filter<core::ecs::components::dynamic_tag>,
 		psl::ecs::except<core::ecs::components::dont_render_tag>,
-		psl::ecs::on_break<core::ecs::components::renderable, core::ecs::components::transform, instance_id>> pack);
-	void dynamic_update(psl::ecs::info_t& info,
-						psl::ecs::pack_indirect_partial_t<core::ecs::components::renderable,
-														  const core::ecs::components::transform,
-														  const instance_id,
-														  psl::ecs::filter<core::ecs::components::dynamic_tag>,
-														  psl::ecs::except<core::ecs::components::dont_render_tag>,
-														  psl::ecs::order_by<instance_id_sort, instance_id>> pack);
-	void dynamic_system(
+		psl::ecs::on_break<core::ecs::components::renderable, core::ecs::components::transform, instance_id>,
+		psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> pack);
+	void dynamic_update(
 	  psl::ecs::info_t& info,
-	  psl::ecs::pack_direct_full_t<core::ecs::components::renderable,
-								   const core::ecs::components::transform,
-								   const core::ecs::components::dynamic_tag,
-								   psl::ecs::except<core::ecs::components::dont_render_tag>,
-								   psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> geometry_pack);
+	  psl::ecs::pack_indirect_partial_t<const core::ecs::components::renderable,
+										const core::ecs::components::transform,
+										const instance_id,
+										psl::ecs::filter<core::ecs::components::dynamic_tag>,
+										psl::ecs::except<core::ecs::components::dont_render_tag>,
+										psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> pack);
 
 	void
 	static_add(psl::ecs::info_t& info,
@@ -99,11 +85,13 @@ class geometry_instancing {
 								   psl::ecs::on_break<const core::ecs::components::renderable,
 													  const core::ecs::components::transform>> geometry_pack);
 
-	void static_geometry_add(psl::ecs::info_t& info,
-							 psl::ecs::pack_direct_full_t<psl::ecs::entity_t,
-														  const core::ecs::components::renderable,
-														  psl::ecs::except<core::ecs::components::transform>,
-														  psl::ecs::on_add<core::ecs::components::renderable>> pack);
+	void static_geometry_add(
+	  psl::ecs::info_t& info,
+	  psl::ecs::pack_indirect_full_t<psl::ecs::entity_t,
+									 const core::ecs::components::renderable,
+									 psl::ecs::except<core::ecs::components::transform>,
+									 psl::ecs::on_add<core::ecs::components::renderable>,
+									 psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> pack);
 
 
 	void
@@ -113,9 +101,10 @@ class geometry_instancing {
 														const instance_id,
 														psl::ecs::except<core::ecs::components::transform>,
 														psl::ecs::on_remove<core::ecs::components::renderable>> pack);
+
+	psl::array<instance_id> make_instances(core::ecs::components::renderable const& renderable,
+										   const core::ecs::components::transform* first,
+										   const core::ecs::components::transform* last);
 	std::mutex m_Mutex;
-	// void static_disable();
-	// void static_enable(psl::ecs::info& info, psl::ecs::pack_direct_full_t<psl::ecs::entity_t, const
-	// core::ecs::components::renderable, const instance_id, core::ecs::components::dont_render_tag> dont_render);
 };
 }	 // namespace core::ecs::systems

--- a/core/inc/core/gfx/bundle.hpp
+++ b/core/inc/core/gfx/bundle.hpp
@@ -26,6 +26,7 @@ enum class geometry_type { STATIC = 0, DYNAMIC = 1 };
 namespace constants {
 	static constexpr psl::string_view INSTANCE_MODELMATRIX		  = "INSTANCE_TRANSFORM";
 	static constexpr psl::string_view INSTANCE_LEGACY_MODELMATRIX = "iModelMat";
+	using instance_size_type									  = std::uint32_t;
 }	 // namespace constants
 
 /// \detail
@@ -40,6 +41,8 @@ namespace constants {
 class bundle final {
 	friend class core::ivk::drawpass;
 	friend class core::igles::drawpass;
+
+	using instance_size_type = constants::instance_size_type;
 
 	/*
 	todo: Uses a simple allocate front/back mechanism for handling static (front) and dynamic (back) items. This
@@ -88,9 +91,9 @@ class bundle final {
 	/// \brief returns the instance count currently used for the given piece of geometry.
 	/// \param[in] geometry UID to check
 	uint32_t instances(core::resource::tag<core::gfx::geometry_t> geometry) const noexcept;
-	std::vector<std::pair<uint32_t, uint32_t>> instantiate(core::resource::tag<core::gfx::geometry_t> geometry,
-														   uint32_t count	  = 1,
-														   geometry_type type = geometry_type::STATIC);
+	std::vector<uint32_t> instantiate(core::resource::tag<core::gfx::geometry_t> geometry,
+									  uint32_t count	 = 1,
+									  geometry_type type = geometry_type::STATIC);
 
 	/// \brief returns how many instances are currently active for the given geometry.
 	/// \param[in] geometry UID to check
@@ -105,6 +108,7 @@ class bundle final {
 	/// \param[in] id instance ID
 	/// \returns true in case the instance was successfully transitioned from active to deactivated.
 	bool release(core::resource::tag<core::gfx::geometry_t> geometry, uint32_t id) noexcept;
+	bool release(core::resource::tag<core::gfx::geometry_t> geometry, std::span<uint32_t const> ids) noexcept;
 
 	/// \brief release all instance data.
 	/// \param[in] type optionally target only static or dynamic data
@@ -112,24 +116,28 @@ class bundle final {
 
 	/// \brief set instance data for the given instance (and range)
 	/// \param[in] geometry target UID
-	/// \param[in] id first instance ID
+	/// \param[in] ids instance IDs
 	/// \param[in] name name of the buffer (present in the shader)
 	/// \param[in] values the values to set, where the size + id indicates the end of the range
 	/// \returns true if the geometry was found, all instances were present, and the upload dispatched. The upload
 	/// is async.
 	template <typename T>
 	bool set(core::resource::tag<core::gfx::geometry_t> geometry,
-			 uint32_t id,
+			 std::span<uint32_t const> ids,
 			 psl::string_view name,
-			 const psl::array<T>& values) {
+			 psl::array<T> values) {
 		static_assert(std::is_trivially_copyable<T>::value, "the type has to be trivially copyable");
 		static_assert(std::is_standard_layout<T>::value, "the type has to be is_standard_layout");
+		psl_assert(ids.size() == values.size(),
+				   "the number of ids ({}) has to match the number of values ({})",
+				   ids.size(),
+				   values.size());
 		auto res = m_InstanceData.segment(geometry, name);
 		if(!res) {
 			core::gfx::log->error("The element name {} was not found on geometry {}", name, geometry.uid().to_string());
 			return false;
 		}
-		return set(geometry, id, res.value().first, res.value().second, values.data(), sizeof(T), values.size());
+		return set(geometry, ids, res.value().first, res.value().second, (std::byte*)values.data(), sizeof(T));
 	}
 
 	template <typename T>
@@ -167,14 +175,22 @@ class bundle final {
 		return count;
 	}
 
+	void apply();
+
   private:
 	bool set(core::resource::tag<core::gfx::geometry_t> geometry,
 			 uint32_t id,
 			 memory::segment segment,
 			 uint32_t size_of_element,
-			 const void* data,
+			 void* data,
 			 size_t size,
 			 size_t count = 1);
+	bool set(core::resource::tag<core::gfx::geometry_t> geometry,
+			 std::span<uint32_t const> ids,
+			 memory::segment segment,
+			 uint32_t size_of_element,
+			 std::byte* data,
+			 size_t size);
 
 	bool set(core::resource::tag<core::gfx::material_t> material, const void* data, size_t size, size_t offset);
 

--- a/core/inc/core/gfx/bundle.hpp
+++ b/core/inc/core/gfx/bundle.hpp
@@ -26,7 +26,6 @@ enum class geometry_type { STATIC = 0, DYNAMIC = 1 };
 namespace constants {
 	static constexpr psl::string_view INSTANCE_MODELMATRIX		  = "INSTANCE_TRANSFORM";
 	static constexpr psl::string_view INSTANCE_LEGACY_MODELMATRIX = "iModelMat";
-	using instance_size_type									  = std::uint32_t;
 }	 // namespace constants
 
 /// \detail
@@ -41,13 +40,6 @@ namespace constants {
 class bundle final {
 	friend class core::ivk::drawpass;
 	friend class core::igles::drawpass;
-
-	using instance_size_type = constants::instance_size_type;
-
-	/*
-	todo: Uses a simple allocate front/back mechanism for handling static (front) and dynamic (back) items. This
-	helps in mitigating stalls and useless uploads to the GPU.
-	*/
 
   public:
 	bundle(core::resource::cache_t& cache,
@@ -91,9 +83,11 @@ class bundle final {
 	/// \brief returns the instance count currently used for the given piece of geometry.
 	/// \param[in] geometry UID to check
 	uint32_t instances(core::resource::tag<core::gfx::geometry_t> geometry) const noexcept;
-	std::vector<uint32_t> instantiate(core::resource::tag<core::gfx::geometry_t> geometry,
-									  uint32_t count	 = 1,
-									  geometry_type type = geometry_type::STATIC);
+
+	/// \brief instantiate one or more instances for the given geometry, returning their IDs.
+	std::vector<instancing_size_type> instantiate(core::resource::tag<core::gfx::geometry_t> geometry,
+												  instancing_size_type count = 1,
+												  geometry_type type		 = geometry_type::STATIC);
 
 	/// \brief returns how many instances are currently active for the given geometry.
 	/// \param[in] geometry UID to check
@@ -107,23 +101,25 @@ class bundle final {
 	/// \param[in] geometry target UID
 	/// \param[in] id instance ID
 	/// \returns true in case the instance was successfully transitioned from active to deactivated.
-	bool release(core::resource::tag<core::gfx::geometry_t> geometry, uint32_t id) noexcept;
-	bool release(core::resource::tag<core::gfx::geometry_t> geometry, std::span<uint32_t const> ids) noexcept;
+	bool release(core::resource::tag<core::gfx::geometry_t> geometry, instancing_size_type id) noexcept;
+	bool release(core::resource::tag<core::gfx::geometry_t> geometry,
+				 std::span<instancing_size_type const> ids) noexcept;
 
 	/// \brief release all instance data.
 	/// \param[in] type optionally target only static or dynamic data
 	bool release_all(std::optional<geometry_type> type = {}) noexcept;
 
-	/// \brief set instance data for the given instance (and range)
+	/// \brief set instance data for the given instances
 	/// \param[in] geometry target UID
 	/// \param[in] ids instance IDs
 	/// \param[in] name name of the buffer (present in the shader)
 	/// \param[in] values the values to set, where the size + id indicates the end of the range
 	/// \returns true if the geometry was found, all instances were present, and the upload dispatched. The upload
 	/// is async.
+	/// \warning This method is not thread safe, and should be externally synchronized.
 	template <typename T>
 	bool set(core::resource::tag<core::gfx::geometry_t> geometry,
-			 std::span<uint32_t const> ids,
+			 std::span<instancing_size_type const> ids,
 			 psl::string_view name,
 			 psl::array<T> values) {
 		static_assert(std::is_trivially_copyable<T>::value, "the type has to be trivially copyable");
@@ -179,14 +175,7 @@ class bundle final {
 
   private:
 	bool set(core::resource::tag<core::gfx::geometry_t> geometry,
-			 uint32_t id,
-			 memory::segment segment,
-			 uint32_t size_of_element,
-			 void* data,
-			 size_t size,
-			 size_t count = 1);
-	bool set(core::resource::tag<core::gfx::geometry_t> geometry,
-			 std::span<uint32_t const> ids,
+			 std::span<instancing_size_type const> ids,
 			 memory::segment segment,
 			 uint32_t size_of_element,
 			 std::byte* data,

--- a/core/inc/core/gfx/details/instance.hpp
+++ b/core/inc/core/gfx/details/instance.hpp
@@ -7,6 +7,11 @@
 #include "psl/meta.hpp"
 #include "psl/sparse_array.hpp"
 
+// bundles consist out of N instances of unique geometry, and M instances of unique materials
+// they manage the instance data associated to these geometry/material combinations.
+// additionally they manage the instance data associated to the materials themselves (only 1 per material).
+// This data is shared between all drawcalls using this bundle.
+
 namespace std {
 #ifdef _MSC_VER
 template <typename T>
@@ -22,6 +27,62 @@ class material_t;
 }	 // namespace core::gfx
 
 namespace core::gfx::details::instance {
+
+struct storage_link {
+	struct swap_command {
+		uint32_t src;
+		uint32_t dst;
+		uint32_t count;
+	};
+	struct resize_command {
+		uint32_t new_size;
+	};
+	uint32_t m_MaxSize {std::numeric_limits<uint32_t>::max()};
+	std::vector<std::variant<swap_command, resize_command>> m_Commands;
+};
+
+/// \brief A virtual storage buffer that records commands instead of executing them
+/// \details This storage buffer does not actually store any data, but instead records commands that can
+/// be executed later. This is useful for recording operations that need to be performed on a GPU buffer.
+/// This is used as the backing storage for instance data in a `psl::sparse_array`.
+template <typename Key>
+class gpu_storage_buffer {
+  public:
+	gpu_storage_buffer([[maybe_unused]] Key max_size, std::shared_ptr<storage_link> link) : m_Link(link) {}
+	Key capacity() const noexcept {
+		return m_Link->m_MaxSize;
+	}
+
+	void swap([[maybe_unused]] Key first, [[maybe_unused]] Key second) {
+		m_Link->m_Commands.push_back(storage_link::swap_command {second, first, 1});
+	}
+	void reserve([[maybe_unused]] Key new_size) {
+		// reserve does nothing, as this is a virtual buffer
+		// we only resize when needed
+	}
+	void insert_space([[maybe_unused]] Key index, [[maybe_unused]] Key count) {
+		m_Size += count;
+		m_Link->m_Commands.push_back(storage_link::resize_command {m_Size});
+		// m_Link->m_Commands.push_back(storage_link::swap_command {index, index + count, m_Size - (index + count)});
+	}
+	void truncate([[maybe_unused]] Key new_size) {
+		m_Size = new_size;
+		m_Link->m_Commands.push_back(storage_link::resize_command {m_Size});
+	}
+	void clear([[maybe_unused]] bool release_memory = false) noexcept {
+		m_Size = 0;
+		m_Link->m_Commands.push_back(storage_link::resize_command {m_Size});
+	}
+
+	void emplace_back() {
+		++m_Size;
+		m_Link->m_Commands.push_back(storage_link::resize_command {m_Size});
+	};
+
+  private:
+	std::shared_ptr<storage_link> m_Link;
+	Key m_Size {0};
+};
 struct binding {
 	struct header final {
 		bool operator==(const header& b) const noexcept {
@@ -38,32 +99,46 @@ struct binding {
 	uint32_t slot;
 };
 
-struct object final {
-	object(psl::UID uid) : geometry(uid), id_generator(0) {};
-	object(psl::UID uid, uint32_t capacity) : geometry(uid), id_generator(capacity) {};
+// for every unique geometry we will have an instance of this that will manage the instance data
+// associated to this geometry for all materials in the bundle.
+struct geometry_instance_data {
+	struct entry {
+		memory::segment memory;
+		binding::header description;
+		uint32_t slot;
+	};
 
-	bool operator==(const object& rhs) const noexcept {
-		return rhs.geometry == geometry;
-	}
+	geometry_instance_data(uint32_t capacity) : manager(capacity, m_Link), instance_data(), m_Max(capacity) {}
 
-	const psl::UID geometry;	// Defines which geometry this object maps to
-	psl::generator<uint32_t> id_generator;
-	psl::array<binding::header> description;
-	psl::array<memory::segment> data;
+	std::shared_ptr<storage_link> m_Link {std::make_shared<storage_link>()};
+	psl::sparse_indice_array<std::uint32_t,
+							 std::uint32_t,
+							 4096,
+							 psl::details::default_buffer_growth_strategy_t,
+							 gpu_storage_buffer<std::uint32_t>>
+	  manager;
+	std::vector<entry> instance_data;
+
+	uint32_t m_Head {0};				// Head is always the highest allocated id + 1
+	std::vector<uint32_t> m_Orphans;	// Orphans are ids that were allocated but later freed, we can reuse these.
+										// Note that these will never be compacted.
+	uint32_t m_Max {0};					// Maximum number of instances allowed, set to numeric_limits::max to disable
+
+	uint32_t available() const noexcept;
+	size_t capacity() const noexcept;
+	void capacity(uint32_t max);
+	std::vector<uint32_t> add(uint32_t count);
+	uint32_t size() const noexcept;
+	void erase(uint32_t id);
+	void erase(auto&& first, auto&& last);
+	uint32_t offset_of(uint32_t id) const noexcept;
+	void clear() noexcept;
+	psl::array<core::gfx::memory_copy> consume();
 };
+
 }	 // namespace core::gfx::details::instance
 
-
 namespace std {
-template <>
-struct hash<core::gfx::details::instance::object> {
-	std::size_t operator()(const core::gfx::details::instance::object& s) const noexcept {
-		return std::hash<psl::UID> {}(s.geometry);
-	}
-	std::size_t operator()(const psl::UID& s) const noexcept {
-		return std::hash<psl::UID> {}(s);
-	}
-};
 
 template <>
 struct hash<core::gfx::details::instance::binding::header> {
@@ -103,7 +178,7 @@ class data final {
 	data(core::resource::handle<core::gfx::buffer_t> vertexBuffer,
 		 core::resource::handle<core::gfx::shader_buffer_binding> materialBuffer) noexcept;
 	void add(core::resource::handle<core::gfx::material_t> material);
-	std::vector<std::pair<uint32_t, uint32_t>> add(core::resource::tag<core::gfx::geometry_t> uid, uint32_t count = 1);
+	std::vector<uint32_t> add(core::resource::tag<core::gfx::geometry_t> uid, uint32_t count = 1);
 
 	bool remove(core::resource::handle<core::gfx::material_t> material) noexcept;
 
@@ -123,6 +198,7 @@ class data final {
 	core::resource::handle<core::gfx::buffer_t> material_buffer() const noexcept;
 
 	bool erase(core::resource::tag<core::gfx::geometry_t> geometry, uint32_t id) noexcept;
+	bool erase(core::resource::tag<core::gfx::geometry_t> geometry, std::span<uint32_t const> ids) noexcept;
 	bool clear(core::resource::tag<core::gfx::geometry_t> geometry) noexcept;
 	bool clear() noexcept;
 
@@ -135,7 +211,11 @@ class data final {
 	/// the bracket operator '[i]', otherwise it will default to '[0]' implicitly.
 	size_t offset_of(core::resource::tag<core::gfx::material_t> material, psl::string_view name) const noexcept;
 
+	size_t offset_of(core::resource::tag<core::gfx::geometry_t> geometry, std::uint32_t id) const noexcept;
 
+	void apply();
+
+  public:
 	/**
 	 * \brief bind the given material's instance data (if present).
 	 * \returns true if there was instance data found, otherwise propogates lower failure.
@@ -150,10 +230,11 @@ class data final {
   private:
 	std::unordered_map<psl::UID, psl::array<binding>> m_Bindings;		  // <material_t, bindings[]>
 	psl::array<std::pair<binding::header, uint32_t>> m_UniqueBindings;	  // unique binding and usage count
-	std::unordered_map<psl::UID, object> m_InstanceData;				  // <geometry_t, object>
 	std::unordered_map<psl::UID, material_instance_data> m_MaterialInstanceData {};
 	psl::array<size_t> m_MaterialDataSizes {};
 	core::resource::handle<core::gfx::buffer_t> m_VertexInstanceBuffer;
 	core::resource::handle<core::gfx::shader_buffer_binding> m_MaterialInstanceBuffer;
+	std::unordered_map<psl::UID, geometry_instance_data>
+	  m_GeometryInstanceData;	 // <geometry_t, geometry_instance_data>
 };
 }	 // namespace core::gfx::details::instance

--- a/core/inc/core/gfx/details/instance.hpp
+++ b/core/inc/core/gfx/details/instance.hpp
@@ -22,18 +22,37 @@ class material_t;
 }	 // namespace core::gfx
 
 namespace core::gfx::details::instance {
+class geometry_instance_data;
 
+/// \brief A link between a gpu_storage_buffer and the geometry_instance_data that owns it.
+/// \details This link is used to record commands that need to be executed on the gpu storage buffer.
+/// When the instance's apply is invoked, it will consume the commands recorded in this link and execute
+/// them on the actual gpu buffer.
+/// \warning This structure relies on implementation details of psl::sparse_array.
 struct storage_link {
+	friend class geometry_instance_data;
+
+  public:
 	struct swap_command {
 		instancing_size_type src;
 		instancing_size_type dst;
 		instancing_size_type count;
 	};
-	struct resize_command {
-		instancing_size_type new_size;
-	};
+	void swap(instancing_size_type first, instancing_size_type second, instancing_size_type count) {
+		m_Swaps.emplace_back(first, second, count);
+	}
+
+	instancing_size_type capacity() const noexcept {
+		return m_MaxSize;
+	}
+
+  private:
+	std::vector<swap_command>& consume() {
+		return m_Swaps;
+	}
+
 	instancing_size_type m_MaxSize {std::numeric_limits<instancing_size_type>::max()};
-	std::vector<std::variant<swap_command, resize_command>> m_Commands;
+	std::vector<swap_command> m_Swaps {};
 };
 
 /// \brief A virtual storage buffer that records commands instead of executing them
@@ -45,34 +64,24 @@ class gpu_storage_buffer {
   public:
 	gpu_storage_buffer([[maybe_unused]] Key max_size, std::shared_ptr<storage_link> link) : m_Link(link) {}
 	Key capacity() const noexcept {
-		return m_Link->m_MaxSize;
+		return m_Link->capacity();
 	}
 
 	void swap([[maybe_unused]] Key first, [[maybe_unused]] Key second) {
-		m_Link->m_Commands.push_back(storage_link::swap_command {second, first, 1});
+		// This relies on implementation details, but a swap always happens when an erase happens.
+		// The second element is always the last element that is being moved to the first element's
+		// position. And the first element will always be the element being erased.
+		m_Link->swap(second, first, 1);
 	}
 	void reserve([[maybe_unused]] Key new_size) {
 		// reserve does nothing, as this is a virtual buffer
 		// we only resize when needed
 	}
-	void insert_space([[maybe_unused]] Key index, [[maybe_unused]] Key count) {
-		m_Size += count;
-		m_Link->m_Commands.push_back(storage_link::resize_command {m_Size});
-		// m_Link->m_Commands.push_back(storage_link::swap_command {index, index + count, m_Size - (index + count)});
-	}
-	void truncate([[maybe_unused]] Key new_size) {
-		m_Size = new_size;
-		m_Link->m_Commands.push_back(storage_link::resize_command {m_Size});
-	}
-	void clear([[maybe_unused]] bool release_memory = false) noexcept {
-		m_Size = 0;
-		m_Link->m_Commands.push_back(storage_link::resize_command {m_Size});
-	}
+	void insert_space([[maybe_unused]] Key index, [[maybe_unused]] Key count) {}
+	void truncate([[maybe_unused]] Key new_size) {}
+	void clear([[maybe_unused]] bool release_memory = false) noexcept {}
 
-	void emplace_back() {
-		++m_Size;
-		m_Link->m_Commands.push_back(storage_link::resize_command {m_Size});
-	};
+	void emplace_back() {};
 
   private:
 	std::shared_ptr<storage_link> m_Link;
@@ -96,15 +105,70 @@ struct binding {
 
 // for every unique geometry we will have an instance of this that will manage the instance data
 // associated to this geometry for all materials in the bundle.
-struct geometry_instance_data {
+class geometry_instance_data {
+	/// \brief An entry containing the memory segment, description and slot for an instance data element.
 	struct entry {
 		memory::segment memory;
 		binding::header description;
 		uint32_t slot;
 	};
 
-	geometry_instance_data(uint32_t capacity) : manager(capacity, m_Link), instance_data(), m_Max(capacity) {}
+  public:
+	geometry_instance_data(instancing_size_type capacity)
+		: manager(capacity, m_Link), instance_data(), m_Max(capacity) {}
 
+
+	/// \brief returns the number of available instances that can be allocated without reallocating.
+	instancing_size_type available() const noexcept;
+	/// \brief returns the maximum number of instances that can be allocated.
+	instancing_size_type capacity() const noexcept;
+	/// \brief sets the maximum number of instances that can be allocated.
+	void capacity(instancing_size_type max);
+	/// \brief adds `count` instances and returns their ids.
+	/// \warning This does not dynamically resize the storage, if you exceed the capacity, an assertion will be
+	/// triggered. It is your responsibility to reserve enough capacity before adding instances.
+	/// \see capacity()
+	std::vector<instancing_size_type> add(instancing_size_type count);
+
+	/// \brief returns the number of currently allocated instances.
+	instancing_size_type count() const noexcept;
+
+	/// \brief removes the instance with the given id.
+	void erase(instancing_size_type id);
+	/// \brief removes all instances in the given range.
+	void erase(auto&& first, auto&& last);
+
+	/// \brief returns the offset of the instance data's member. Note that this is not accounting for the instance's size
+	instancing_size_type index_of(instancing_size_type id) const noexcept;
+
+	/// \brief clears all instances.
+	/// \warning This does not deallocate any memory, it only marks all instances as free.
+	void clear() noexcept;
+
+	/// \brief returns all recorded memory copy operations and clears the internal list.
+	psl::array<core::gfx::memory_copy> consume();
+
+	void add_binding(binding::header description, memory::segment segment, uint32_t slot);
+
+	auto begin() const noexcept {
+		return instance_data.begin();
+	}
+	auto begin() noexcept {
+		return instance_data.begin();
+	}
+
+	auto end() const noexcept {
+		return instance_data.end();
+	}
+	auto end() noexcept {
+		return instance_data.end();
+	}
+
+	entry const* find(psl::string_view name) const noexcept;
+	entry const* find(binding::header const& header) const noexcept;
+	bool contains(psl::string_view name) const noexcept;
+
+  private:
 	std::shared_ptr<storage_link> m_Link {std::make_shared<storage_link>()};
 	psl::sparse_indice_array<instancing_size_type,
 							 instancing_size_type,
@@ -119,19 +183,6 @@ struct geometry_instance_data {
 													// these.
 													// Note that these will never be compacted.
 	instancing_size_type m_Max {0};	   // Maximum number of instances allowed, set to numeric_limits::max to disable
-
-	instancing_size_type available() const noexcept;
-	instancing_size_type capacity() const noexcept;
-	void capacity(instancing_size_type max);
-	std::vector<instancing_size_type> add(instancing_size_type count);
-	instancing_size_type size() const noexcept;
-	void erase(instancing_size_type id);
-	void erase(auto&& first, auto&& last);
-
-	/// \brief returns the offset of the instance data's member. Note that this is not accounting for the instance's size
-	instancing_size_type index_of(instancing_size_type id) const noexcept;
-	void clear() noexcept;
-	psl::array<core::gfx::memory_copy> consume();
 };
 
 }	 // namespace core::gfx::details::instance

--- a/core/inc/core/gfx/details/instance.hpp
+++ b/core/inc/core/gfx/details/instance.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "core/gfx/types.hpp"
 #include "core/meta/shader.hpp"
 #include "core/resource/resource.hpp"
 #include "psl/array.hpp"
@@ -12,12 +13,6 @@
 // additionally they manage the instance data associated to the materials themselves (only 1 per material).
 // This data is shared between all drawcalls using this bundle.
 
-namespace std {
-#ifdef _MSC_VER
-template <typename T>
-struct hash;
-#endif
-}	 // namespace std
 
 namespace core::gfx {
 class buffer_t;
@@ -30,14 +25,14 @@ namespace core::gfx::details::instance {
 
 struct storage_link {
 	struct swap_command {
-		uint32_t src;
-		uint32_t dst;
-		uint32_t count;
+		instancing_size_type src;
+		instancing_size_type dst;
+		instancing_size_type count;
 	};
 	struct resize_command {
-		uint32_t new_size;
+		instancing_size_type new_size;
 	};
-	uint32_t m_MaxSize {std::numeric_limits<uint32_t>::max()};
+	instancing_size_type m_MaxSize {std::numeric_limits<instancing_size_type>::max()};
 	std::vector<std::variant<swap_command, resize_command>> m_Commands;
 };
 
@@ -89,7 +84,7 @@ struct binding {
 			return /*size_of_element == b.size_of_element && */ name == b.name;
 		}
 		psl::string name {};
-		uint32_t size_of_element {0};
+		instancing_size_type size_of_element {0};
 	};
 
 	bool operator==(const binding& b) const noexcept {
@@ -111,37 +106,38 @@ struct geometry_instance_data {
 	geometry_instance_data(uint32_t capacity) : manager(capacity, m_Link), instance_data(), m_Max(capacity) {}
 
 	std::shared_ptr<storage_link> m_Link {std::make_shared<storage_link>()};
-	psl::sparse_indice_array<std::uint32_t,
-							 std::uint32_t,
+	psl::sparse_indice_array<instancing_size_type,
+							 instancing_size_type,
 							 4096,
 							 psl::details::default_buffer_growth_strategy_t,
-							 gpu_storage_buffer<std::uint32_t>>
+							 gpu_storage_buffer<instancing_size_type>>
 	  manager;
 	std::vector<entry> instance_data;
 
-	uint32_t m_Head {0};				// Head is always the highest allocated id + 1
-	std::vector<uint32_t> m_Orphans;	// Orphans are ids that were allocated but later freed, we can reuse these.
-										// Note that these will never be compacted.
-	uint32_t m_Max {0};					// Maximum number of instances allowed, set to numeric_limits::max to disable
+	instancing_size_type m_Head {0};				// Head is always the highest allocated id + 1
+	std::vector<instancing_size_type> m_Orphans;	// Orphans are ids that were allocated but later freed, we can reuse
+													// these.
+													// Note that these will never be compacted.
+	instancing_size_type m_Max {0};	   // Maximum number of instances allowed, set to numeric_limits::max to disable
 
-	uint32_t available() const noexcept;
-	size_t capacity() const noexcept;
-	void capacity(uint32_t max);
-	std::vector<uint32_t> add(uint32_t count);
-	uint32_t size() const noexcept;
-	void erase(uint32_t id);
+	instancing_size_type available() const noexcept;
+	instancing_size_type capacity() const noexcept;
+	void capacity(instancing_size_type max);
+	std::vector<instancing_size_type> add(instancing_size_type count);
+	instancing_size_type size() const noexcept;
+	void erase(instancing_size_type id);
 	void erase(auto&& first, auto&& last);
-	uint32_t offset_of(uint32_t id) const noexcept;
+
+	/// \brief returns the offset of the instance data's member. Note that this is not accounting for the instance's size
+	instancing_size_type index_of(instancing_size_type id) const noexcept;
 	void clear() noexcept;
 	psl::array<core::gfx::memory_copy> consume();
 };
 
 }	 // namespace core::gfx::details::instance
 
-namespace std {
-
 template <>
-struct hash<core::gfx::details::instance::binding::header> {
+struct std::hash<core::gfx::details::instance::binding::header> {
 	std::size_t operator()(const core::gfx::details::instance::binding::header& s) const noexcept {
 		std::size_t seed = std::hash<psl::string> {}(s.name);
 		// seed ^= (uint64_t)s.size_of_element + 0x9e3779b9 + (seed << 6) + (seed >> 2);
@@ -150,12 +146,11 @@ struct hash<core::gfx::details::instance::binding::header> {
 };
 
 template <>
-struct hash<core::gfx::details::instance::binding> {
+struct std::hash<core::gfx::details::instance::binding> {
 	std::size_t operator()(const core::gfx::details::instance::binding& s) const noexcept {
 		return std::hash<core::gfx::details::instance::binding::header> {}(s.description);
 	}
 };
-}	 // namespace std
 
 
 namespace core::gfx::details::instance {
@@ -178,7 +173,8 @@ class data final {
 	data(core::resource::handle<core::gfx::buffer_t> vertexBuffer,
 		 core::resource::handle<core::gfx::shader_buffer_binding> materialBuffer) noexcept;
 	void add(core::resource::handle<core::gfx::material_t> material);
-	std::vector<uint32_t> add(core::resource::tag<core::gfx::geometry_t> uid, uint32_t count = 1);
+	std::vector<instancing_size_type> add(core::resource::tag<core::gfx::geometry_t> uid,
+										  instancing_size_type count = 1);
 
 	bool remove(core::resource::handle<core::gfx::material_t> material) noexcept;
 
@@ -186,7 +182,7 @@ class data final {
 	bool has_element(core::resource::tag<core::gfx::geometry_t> geometry, psl::string_view name) const noexcept;
 	std::optional<std::pair<memory::segment, uint32_t>> segment(core::resource::tag<core::gfx::geometry_t> geometry,
 																psl::string_view name) const noexcept;
-	uint32_t count(core::resource::tag<core::gfx::geometry_t> uid) const noexcept;
+	instancing_size_type count(core::resource::tag<core::gfx::geometry_t> uid) const noexcept;
 
 	psl::array<std::pair<size_t, std::uintptr_t>>
 	bindings(core::resource::tag<core::gfx::material_t> material,
@@ -197,8 +193,8 @@ class data final {
 	}
 	core::resource::handle<core::gfx::buffer_t> material_buffer() const noexcept;
 
-	bool erase(core::resource::tag<core::gfx::geometry_t> geometry, uint32_t id) noexcept;
-	bool erase(core::resource::tag<core::gfx::geometry_t> geometry, std::span<uint32_t const> ids) noexcept;
+	bool erase(core::resource::tag<core::gfx::geometry_t> geometry, instancing_size_type id) noexcept;
+	bool erase(core::resource::tag<core::gfx::geometry_t> geometry, std::span<instancing_size_type const> ids) noexcept;
 	bool clear(core::resource::tag<core::gfx::geometry_t> geometry) noexcept;
 	bool clear() noexcept;
 
@@ -211,7 +207,8 @@ class data final {
 	/// the bracket operator '[i]', otherwise it will default to '[0]' implicitly.
 	size_t offset_of(core::resource::tag<core::gfx::material_t> material, psl::string_view name) const noexcept;
 
-	size_t offset_of(core::resource::tag<core::gfx::geometry_t> geometry, std::uint32_t id) const noexcept;
+	instancing_size_type index_of(core::resource::tag<core::gfx::geometry_t> geometry,
+								  instancing_size_type id) const noexcept;
 
 	void apply();
 

--- a/core/inc/core/gfx/types.hpp
+++ b/core/inc/core/gfx/types.hpp
@@ -9,6 +9,9 @@
 #include <vector>
 
 namespace core::gfx {
+/// \brief Defines the maximum number of instances that can be rendered in a single draw call.
+using instancing_size_type = std::uint32_t;
+
 enum class graphics_backend { undefined = 0, vulkan = 1 << 0, gles = 1 << 1, webgpu = 1 << 2 };
 
 constexpr auto graphics_backend_str(graphics_backend backend) noexcept {

--- a/core/inc/core/gfx/types.hpp
+++ b/core/inc/core/gfx/types.hpp
@@ -10,7 +10,8 @@
 
 namespace core::gfx {
 /// \brief Defines the maximum number of instances that can be rendered in a single draw call.
-using instancing_size_type = std::uint32_t;
+using instancing_size_type										  = std::uint32_t;
+static constexpr instancing_size_type instancing_default_capacity = 32;
 
 enum class graphics_backend { undefined = 0, vulkan = 1 << 0, gles = 1 << 1, webgpu = 1 << 2 };
 

--- a/core/src/ecs/systems/geometry_instance.cpp
+++ b/core/src/ecs/systems/geometry_instance.cpp
@@ -16,17 +16,12 @@ using namespace core::resource;
 using namespace core::ecs::components;
 
 geometry_instancing::geometry_instancing(psl::ecs::state_t& state) {
-	state.declare<"geometry_instancing::static_add">(psl::ecs::threading::seq, &geometry_instancing::static_add, this);
-	state.declare<"geometry_instancing::static_remove">(
-	  psl::ecs::threading::seq, &geometry_instancing::static_remove, this);
 	state.declare<"geometry_instancing::static_geometry_add">(
 	  psl::ecs::threading::seq, &geometry_instancing::static_geometry_add, this);
 	state.declare<"geometry_instancing::static_geometry_remove">(
 	  psl::ecs::threading::seq, &geometry_instancing::static_geometry_remove, this);
-	state.declare<"geometry_instancing::dynamic_add">(
-	  psl::ecs::threading::seq, &geometry_instancing::dynamic_add, this);
-	state.declare<"geometry_instancing::dynamic_remove">(
-	  psl::ecs::threading::par, &geometry_instancing::dynamic_remove, this);
+	state.declare<"geometry_instancing::add">(psl::ecs::threading::seq, &geometry_instancing::add, this);
+	state.declare<"geometry_instancing::remove">(psl::ecs::threading::par, &geometry_instancing::remove, this);
 	state.declare<"geometry_instancing::dynamic_update">(
 	  psl::ecs::threading::par, &geometry_instancing::dynamic_update, this);
 }
@@ -66,16 +61,17 @@ geometry_instancing::make_instances(renderable const& renderable, psl::array<tra
 	return compInstanceIDs;
 }
 
-void geometry_instancing::dynamic_add(info_t& info,
-									  pack_indirect_partial_t<entity_t,
-															  const renderable,
-															  const transform,
-															  filter<dynamic_tag>,
-															  except<dont_render_tag>,
-															  on_combine<renderable, transform>> geometry_pack) {
+void geometry_instancing::add(info_t& info,
+							  pack_indirect_partial_t<entity_t,
+													  const renderable,
+													  const transform,
+													  except<dont_render_tag>,
+													  on_combine<renderable, transform>,
+													  order_by<renderer_sort, renderable>> geometry_pack) {
 	if(geometry_pack.size() == 0) {
 		return;
 	}
+	core::profiler.scope_begin("geometry_instancing::add");
 
 	auto* render_it = &geometry_pack.get<renderable const>()[0];
 	psl::array<transform const*> transforms {};
@@ -83,8 +79,7 @@ void geometry_instancing::dynamic_add(info_t& info,
 	transforms.reserve(geometry_pack.size());
 	entities.reserve(geometry_pack.size());
 	for(auto [ent, render, trns] : geometry_pack) {
-		auto bundleHandle = render.bundle;
-		if(bundleHandle.uid() != render_it->bundle.uid() || render_it->geometry.uid() != render.geometry.uid()) {
+		if(render.bundle.uid() != render_it->bundle.uid() || render_it->geometry.uid() != render.geometry.uid()) {
 			auto instanceComponents = make_instances(*render_it, transforms);
 			info.command_buffer.add_components<instance_id>(entities, instanceComponents);
 			render_it = &render;
@@ -97,20 +92,21 @@ void geometry_instancing::dynamic_add(info_t& info,
 
 	auto instanceComponents = make_instances(*render_it, transforms);
 	info.command_buffer.add_components<instance_id>(entities, instanceComponents);
+	core::profiler.scope_end();
 }
 
-void geometry_instancing::dynamic_remove(
+void geometry_instancing::remove(
   info_t& info,
   pack_indirect_full_t<entity_t,
 					   const renderable,
 					   const instance_id,
-					   filter<dynamic_tag>,
 					   except<dont_render_tag>,
 					   on_break<renderable, transform, instance_id>,
 					   psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> pack) {
 	if(pack.empty()) {
 		return;
 	}
+	core::profiler.scope_begin("geometry_instancing::remove");
 	auto* render_it = &pack.get<renderable const>()[0];
 
 	psl::array<std::uint32_t> instanceIDs {};
@@ -144,6 +140,7 @@ void geometry_instancing::dynamic_remove(
 	}
 
 	info.command_buffer.remove_components<instance_id>(pack.get<entity_t>().to_array());
+	core::profiler.scope_end();
 }
 
 void geometry_instancing::dynamic_update(info_t& info,
@@ -193,58 +190,6 @@ void geometry_instancing::dynamic_update(info_t& info,
 		bundle->set(
 		  lastRenderable->geometry, instanceIDs, core::gfx::constants::INSTANCE_MODELMATRIX, std::move(modelMats));
 	}
-}
-
-void geometry_instancing::static_add(info_t& info,
-									 pack_indirect_full_t<entity_t,
-														  const renderable,
-														  const transform,
-														  psl::ecs::except<dynamic_tag>,
-														  on_combine<const renderable, const transform>,
-														  order_by<renderer_sort, renderable>> geometry_pack) {
-	if(geometry_pack.size() == 0) {
-		return;
-	}
-	core::profiler.scope_begin("geometry_instancing::static_add");
-	psl::array<transform const*> transforms {};
-	psl::array<entity_t> entities {};
-	transforms.reserve(geometry_pack.size());
-	entities.reserve(geometry_pack.size());
-
-	auto* render_it = &geometry_pack.get<renderable const>()[0];
-	for(auto [ent, render, trns] : geometry_pack) {
-		auto bundleHandle = render.bundle;
-		if(bundleHandle.uid() != render_it->bundle.uid() || render_it->geometry.uid() != render.geometry.uid()) {
-			auto instanceComponents = make_instances(*render_it, transforms);
-			info.command_buffer.add_components<instance_id>(entities, instanceComponents);
-			render_it = &render;
-		}
-		transforms.push_back(&trns);
-		entities.push_back(ent);
-	}
-
-	auto instanceComponents = make_instances(*render_it, transforms);
-	info.command_buffer.add_components<instance_id>(entities, instanceComponents);
-	core::profiler.scope_end();
-}
-void geometry_instancing::static_remove(info_t& info,
-										pack_direct_full_t<entity_t,
-														   renderable,
-														   const instance_id,
-														   psl::ecs::except<dynamic_tag>,
-														   on_break<const renderable, const transform>> geometry_pack) {
-	if(geometry_pack.size() == 0)
-		return;
-	core::log->info("deallocating {} static instances", geometry_pack.size());
-	core::profiler.scope_begin("release static geometry");
-	for(auto [entity, renderable, instance_id] : geometry_pack) {
-		if(renderable.bundle) {
-			renderable.bundle->release(renderable.geometry, instance_id.id);
-		}
-	}
-
-	info.command_buffer.remove_components<instance_id>(geometry_pack.get<entity_t>());
-	core::profiler.scope_end();
 }
 
 void geometry_instancing::static_geometry_add(

--- a/core/src/ecs/systems/geometry_instance.cpp
+++ b/core/src/ecs/systems/geometry_instance.cpp
@@ -33,7 +33,7 @@ geometry_instancing::geometry_instancing(psl::ecs::state_t& state) {
 
 psl::array<geometry_instancing::instance_id>
 geometry_instancing::make_instances(renderable const& renderable, const transform* first, const transform* last) {
-	const auto count = std::distance(first, last);
+	const auto count = psl::narrow_cast<core::gfx::instancing_size_type>(std::distance(first, last));
 	if(!renderable.bundle || !renderable.geometry || count == 0) {
 		return {};
 	}
@@ -128,6 +128,7 @@ void geometry_instancing::dynamic_remove(
 		last			  = &instance_id;
 		instanceIDs.push_back(instance_id.id);
 		if(bundleHandle.uid() != render_it->bundle.uid() || render_it->geometry.uid() != render.geometry.uid()) {
+			auto scoped_lock = std::scoped_lock(m_Mutex);
 			bundleHandle->release(render.geometry, instanceIDs);
 			if(seenBundles.find(bundleHandle.uid()) == seenBundles.end()) {
 				seenBundles.insert({bundleHandle.uid(), bundleHandle});
@@ -140,7 +141,8 @@ void geometry_instancing::dynamic_remove(
 	}
 
 	{
-		auto bundle = render_it->bundle;
+		auto scoped_lock = std::scoped_lock(m_Mutex);
+		auto bundle		 = render_it->bundle;
 		bundle->release(render_it->geometry, instanceIDs);
 		if(seenBundles.find(bundle.uid()) == seenBundles.end()) {
 			seenBundles.insert({bundle.uid(), bundle});

--- a/core/src/ecs/systems/geometry_instance.cpp
+++ b/core/src/ecs/systems/geometry_instance.cpp
@@ -30,10 +30,9 @@ geometry_instancing::geometry_instancing(psl::ecs::state_t& state) {
 	state.declare<"geometry_instancing::dynamic_update">(
 	  psl::ecs::threading::par, &geometry_instancing::dynamic_update, this);
 }
-
 psl::array<geometry_instancing::instance_id>
-geometry_instancing::make_instances(renderable const& renderable, const transform* first, const transform* last) {
-	const auto count = psl::narrow_cast<core::gfx::instancing_size_type>(std::distance(first, last));
+geometry_instancing::make_instances(renderable const& renderable, psl::array<transform const*> transforms) {
+	const auto count = psl::narrow_cast<core::gfx::instancing_size_type>(transforms.size());
 	if(!renderable.bundle || !renderable.geometry || count == 0) {
 		return {};
 	}
@@ -44,13 +43,14 @@ geometry_instancing::make_instances(renderable const& renderable, const transfor
 	psl::array<instance_id> compInstanceIDs {};
 	compInstanceIDs.reserve(count);
 
-	for(auto instanceId : instancesIDs) {
-		const psl::mat4x4 translationMat = translate(first->position);
-		const psl::mat4x4 rotationMat	 = to_matrix(first->rotation);
-		const psl::mat4x4 scaleMat		 = scale(first->scale);
+	for(auto i = 0; i < instancesIDs.size(); ++i) {
+		auto const* trnsform			 = transforms[i];
+		auto instanceId					 = instancesIDs[i];
+		const psl::mat4x4 translationMat = translate(trnsform->position);
+		const psl::mat4x4 rotationMat	 = to_matrix(trnsform->rotation);
+		const psl::mat4x4 scaleMat		 = scale(trnsform->scale);
 		modelMats.emplace_back(translationMat * rotationMat * scaleMat);
 		compInstanceIDs.emplace_back(instance_id {instanceId});
-		++first;
 	}
 
 	{
@@ -67,38 +67,36 @@ geometry_instancing::make_instances(renderable const& renderable, const transfor
 }
 
 void geometry_instancing::dynamic_add(info_t& info,
-									  pack_direct_partial_t<entity_t,
-															const renderable,
-															const transform,
-															filter<dynamic_tag>,
-															except<dont_render_tag>,
-															on_combine<renderable, transform>> geometry_pack) {
+									  pack_indirect_partial_t<entity_t,
+															  const renderable,
+															  const transform,
+															  filter<dynamic_tag>,
+															  except<dont_render_tag>,
+															  on_combine<renderable, transform>> geometry_pack) {
 	if(geometry_pack.size() == 0) {
 		return;
 	}
 
-	transform const* first {&geometry_pack.get<const transform>()[0]};
-	transform const* last {nullptr};
-	auto* render_it		= &geometry_pack.get<renderable const>()[0];
-	entity_t* first_ent = &geometry_pack.get<entity_t>()[0];
-	entity_t* last_ent {nullptr};
+	auto* render_it = &geometry_pack.get<renderable const>()[0];
+	psl::array<transform const*> transforms {};
+	psl::array<entity_t> entities {};
+	transforms.reserve(geometry_pack.size());
+	entities.reserve(geometry_pack.size());
 	for(auto [ent, render, trns] : geometry_pack) {
 		auto bundleHandle = render.bundle;
-		last_ent		  = &ent;
-		last			  = &trns;
 		if(bundleHandle.uid() != render_it->bundle.uid() || render_it->geometry.uid() != render.geometry.uid()) {
-			auto instanceComponents = make_instances(*render_it, first, last + 1);
-			info.command_buffer.add_components<instance_id>(psl::array_view<entity_t>(first_ent, last_ent + 1),
-															instanceComponents);
-			first	  = &trns;
-			first_ent = &ent;
+			auto instanceComponents = make_instances(*render_it, transforms);
+			info.command_buffer.add_components<instance_id>(entities, instanceComponents);
 			render_it = &render;
+			transforms.clear();
+			entities.clear();
 		}
+		transforms.push_back(&trns);
+		entities.push_back(ent);
 	}
 
-	auto instanceComponents = make_instances(*render_it, first, last + 1);
-	info.command_buffer.add_components<instance_id>(psl::array_view<entity_t>(first_ent, last_ent + 1),
-													instanceComponents);
+	auto instanceComponents = make_instances(*render_it, transforms);
+	info.command_buffer.add_components<instance_id>(entities, instanceComponents);
 }
 
 void geometry_instancing::dynamic_remove(
@@ -198,38 +196,35 @@ void geometry_instancing::dynamic_update(info_t& info,
 }
 
 void geometry_instancing::static_add(info_t& info,
-									 pack_direct_full_t<entity_t,
-														const renderable,
-														const transform,
-														psl::ecs::except<dynamic_tag>,
-														on_combine<const renderable, const transform>,
-														order_by<renderer_sort, renderable>> geometry_pack) {
+									 pack_indirect_full_t<entity_t,
+														  const renderable,
+														  const transform,
+														  psl::ecs::except<dynamic_tag>,
+														  on_combine<const renderable, const transform>,
+														  order_by<renderer_sort, renderable>> geometry_pack) {
 	if(geometry_pack.size() == 0) {
 		return;
 	}
 	core::profiler.scope_begin("geometry_instancing::static_add");
-	transform const* first {&geometry_pack.get<const transform>()[0]};
-	transform const* last {nullptr};
-	auto* render_it		= &geometry_pack.get<renderable const>()[0];
-	entity_t* first_ent = &geometry_pack.get<entity_t>()[0];
-	entity_t* last_ent {nullptr};
+	psl::array<transform const*> transforms {};
+	psl::array<entity_t> entities {};
+	transforms.reserve(geometry_pack.size());
+	entities.reserve(geometry_pack.size());
+
+	auto* render_it = &geometry_pack.get<renderable const>()[0];
 	for(auto [ent, render, trns] : geometry_pack) {
 		auto bundleHandle = render.bundle;
-		last_ent		  = &ent;
-		last			  = &trns;
 		if(bundleHandle.uid() != render_it->bundle.uid() || render_it->geometry.uid() != render.geometry.uid()) {
-			auto instanceComponents = make_instances(*render_it, first, last + 1);
-			info.command_buffer.add_components<instance_id>(psl::array_view<entity_t>(first_ent, last_ent + 1),
-															instanceComponents);
-			first	  = &trns;
-			first_ent = &ent;
+			auto instanceComponents = make_instances(*render_it, transforms);
+			info.command_buffer.add_components<instance_id>(entities, instanceComponents);
 			render_it = &render;
 		}
+		transforms.push_back(&trns);
+		entities.push_back(ent);
 	}
 
-	auto instanceComponents = make_instances(*render_it, first, last + 1);
-	info.command_buffer.add_components<instance_id>(psl::array_view<entity_t>(first_ent, last_ent + 1),
-													instanceComponents);
+	auto instanceComponents = make_instances(*render_it, transforms);
+	info.command_buffer.add_components<instance_id>(entities, instanceComponents);
 	core::profiler.scope_end();
 }
 void geometry_instancing::static_remove(info_t& info,

--- a/core/src/ecs/systems/geometry_instance.cpp
+++ b/core/src/ecs/systems/geometry_instance.cpp
@@ -67,12 +67,12 @@ geometry_instancing::make_instances(renderable const& renderable, const transfor
 }
 
 void geometry_instancing::dynamic_add(info_t& info,
-									  pack_indirect_partial_t<entity_t,
-															  const renderable,
-															  const transform,
-															  filter<dynamic_tag>,
-															  except<dont_render_tag>,
-															  on_combine<renderable, transform>> geometry_pack) {
+									  pack_direct_partial_t<entity_t,
+															const renderable,
+															const transform,
+															filter<dynamic_tag>,
+															except<dont_render_tag>,
+															on_combine<renderable, transform>> geometry_pack) {
 	if(geometry_pack.size() == 0) {
 		return;
 	}
@@ -113,19 +113,13 @@ void geometry_instancing::dynamic_remove(
 	if(pack.empty()) {
 		return;
 	}
-	instance_id const* first {&pack.get<const instance_id>()[0]};
-	instance_id const* last {nullptr};
-	auto* render_it		= &pack.get<renderable const>()[0];
-	entity_t* first_ent = &pack.get<entity_t>()[0];
-	entity_t* last_ent {nullptr};
+	auto* render_it = &pack.get<renderable const>()[0];
 
 	psl::array<std::uint32_t> instanceIDs {};
 	std::unordered_map<psl::UID, core::resource::handle<core::gfx::bundle>> seenBundles;
 
 	for(auto [ent, render, instance_id] : pack) {
 		auto bundleHandle = render.bundle;
-		last_ent		  = &ent;
-		last			  = &instance_id;
 		instanceIDs.push_back(instance_id.id);
 		if(bundleHandle.uid() != render_it->bundle.uid() || render_it->geometry.uid() != render.geometry.uid()) {
 			auto scoped_lock = std::scoped_lock(m_Mutex);
@@ -133,8 +127,6 @@ void geometry_instancing::dynamic_remove(
 			if(seenBundles.find(bundleHandle.uid()) == seenBundles.end()) {
 				seenBundles.insert({bundleHandle.uid(), bundleHandle});
 			}
-			first	  = &instance_id;
-			first_ent = &ent;
 			render_it = &render;
 			instanceIDs.clear();
 		}
@@ -262,11 +254,11 @@ void geometry_instancing::static_remove(info_t& info,
 
 void geometry_instancing::static_geometry_add(
   psl::ecs::info_t& info,
-  psl::ecs::pack_indirect_full_t<psl::ecs::entity_t,
-								 const core::ecs::components::renderable,
-								 psl::ecs::except<core::ecs::components::transform>,
-								 psl::ecs::on_add<core::ecs::components::renderable>,
-								 psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> pack) {
+  psl::ecs::pack_direct_full_t<psl::ecs::entity_t,
+							   const core::ecs::components::renderable,
+							   psl::ecs::except<core::ecs::components::transform>,
+							   psl::ecs::on_add<core::ecs::components::renderable>,
+							   psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> pack) {
 	if(pack.size() == 0) {
 		return;
 	}
@@ -305,7 +297,7 @@ void geometry_instancing::static_geometry_add(
 			instanceIds.emplace_back(instance_id {instanceId});
 		}
 	}
-	info.command_buffer.add_components<instance_id>(pack.get<entity_t>().to_array(), instanceIds);
+	info.command_buffer.add_components<instance_id>(pack.get<entity_t>(), instanceIds);
 }
 
 

--- a/core/src/ecs/systems/geometry_instance.cpp
+++ b/core/src/ecs/systems/geometry_instance.cpp
@@ -19,8 +19,6 @@ geometry_instancing::geometry_instancing(psl::ecs::state_t& state) {
 	state.declare<"geometry_instancing::static_add">(psl::ecs::threading::seq, &geometry_instancing::static_add, this);
 	state.declare<"geometry_instancing::static_remove">(
 	  psl::ecs::threading::seq, &geometry_instancing::static_remove, this);
-	/*state.declare<"geometry_instancing::dynamic_system">(
-	  psl::ecs::threading::seq, &geometry_instancing::dynamic_system, this);*/
 	state.declare<"geometry_instancing::static_geometry_add">(
 	  psl::ecs::threading::seq, &geometry_instancing::static_geometry_add, this);
 	state.declare<"geometry_instancing::static_geometry_remove">(
@@ -33,248 +31,176 @@ geometry_instancing::geometry_instancing(psl::ecs::state_t& state) {
 	  psl::ecs::threading::par, &geometry_instancing::dynamic_update, this);
 }
 
+psl::array<geometry_instancing::instance_id>
+geometry_instancing::make_instances(renderable const& renderable, const transform* first, const transform* last) {
+	const auto count = std::distance(first, last);
+	if(!renderable.bundle || !renderable.geometry || count == 0) {
+		return {};
+	}
+	auto bundle		  = renderable.bundle;
+	auto instancesIDs = bundle->instantiate(renderable.geometry, count);
+	psl::array<psl::mat4x4> modelMats {};
+	modelMats.reserve(count);
+	psl::array<instance_id> compInstanceIDs {};
+	compInstanceIDs.reserve(count);
+
+	for(auto instanceId : instancesIDs) {
+		const psl::mat4x4 translationMat = translate(first->position);
+		const psl::mat4x4 rotationMat	 = to_matrix(first->rotation);
+		const psl::mat4x4 scaleMat		 = scale(first->scale);
+		modelMats.emplace_back(translationMat * rotationMat * scaleMat);
+		compInstanceIDs.emplace_back(instance_id {instanceId});
+		++first;
+	}
+
+	{
+		std::scoped_lock lock(m_Mutex);
+		if(!bundle->set(
+			 renderable.geometry, instancesIDs, core::gfx::constants::INSTANCE_MODELMATRIX, std::move(modelMats)))
+			core::log->error(
+			  "could not set the instance data for the dynamic elements in geometry: {} size: "
+			  "{}",
+			  renderable.geometry,
+			  instancesIDs.size());
+	}
+	return compInstanceIDs;
+}
 
 void geometry_instancing::dynamic_add(info_t& info,
-									  pack_indirect_full_t<entity_t,
-														   renderable,
-														   const transform,
-														   filter<dynamic_tag>,
-														   except<dont_render_tag>,
-														   on_combine<renderable, transform>> geometry_pack) {
+									  pack_indirect_partial_t<entity_t,
+															  const renderable,
+															  const transform,
+															  filter<dynamic_tag>,
+															  except<dont_render_tag>,
+															  on_combine<renderable, transform>> geometry_pack) {
 	if(geometry_pack.size() == 0) {
 		return;
 	}
 
-	auto instantiate = [&info](renderable& rend,
-							   const transform* first,
-							   const transform* last,
-							   entity_t* first_ent,
-							   entity_t* last_ent,
-							   uint32_t count) {
-		if(!rend.bundle || !rend.geometry || count == 0) {
-			return;
-		}
-		auto instancesID = rend.bundle->instantiate(rend.geometry, count);
-		psl::array<psl::mat4x4> modelMats {};
-		modelMats.reserve(count);
-		psl::array<instance_id> instanceIDs {};
-		instanceIDs.reserve(count);
-
-		for(auto [startIndex, endIndex] : instancesID) {
-			auto const range = endIndex - startIndex;
-			for(auto i = 0u; i < range; ++i, ++first) {
-				const psl::mat4x4 translationMat = translate(first->position);
-				const psl::mat4x4 rotationMat	 = to_matrix(first->rotation);
-				const psl::mat4x4 scaleMat		 = scale(first->scale);
-				modelMats.emplace_back(translationMat * rotationMat * scaleMat);
-				instanceIDs.emplace_back(instance_id {startIndex + i});
-			}
-
-			if(!rend.bundle->set(rend.geometry, startIndex, core::gfx::constants::INSTANCE_MODELMATRIX, modelMats))
-				core::log->error(
-				  "could not set the instance data for the dynamic elements in geometry: {} startIndex: {} size: "
-				  "{}",
-				  rend.geometry,
-				  startIndex,
-				  modelMats.size());
-			modelMats.clear();
-		}
-		info.command_buffer.add_components<instance_id>(psl::array_view<entity_t>(first_ent, last_ent), instanceIDs);
-	};
-
-	core::resource::handle<core::gfx::bundle> lastBundle {};
-	uint32_t count {0};
-	transform const* first {geometry_pack.get<const transform>().data()};
+	transform const* first {&geometry_pack.get<const transform>()[0]};
 	transform const* last {nullptr};
-	auto* render_it = geometry_pack.get<renderable>().data();
-	psl::array<psl::mat4x4> modelMats {};
-	psl::array<instance_id> instanceIDs {};
-	entity_t* first_ent = geometry_pack.get<entity_t>().data();
+	auto* render_it		= &geometry_pack.get<renderable const>()[0];
+	entity_t* first_ent = &geometry_pack.get<entity_t>()[0];
 	entity_t* last_ent {nullptr};
 	for(auto [ent, render, trns] : geometry_pack) {
 		auto bundleHandle = render.bundle;
 		last_ent		  = &ent;
 		last			  = &trns;
-		render_it		  = &render;
-		if(bundleHandle != lastBundle && lastBundle && bundleHandle && count > 0) {
-			instantiate(*render_it, first, last + 1, first_ent, last_ent + 1, count);
+		if(bundleHandle.uid() != render_it->bundle.uid() || render_it->geometry.uid() != render.geometry.uid()) {
+			auto instanceComponents = make_instances(*render_it, first, last + 1);
+			info.command_buffer.add_components<instance_id>(psl::array_view<entity_t>(first_ent, last_ent + 1),
+															instanceComponents);
 			first	  = &trns;
-			count	  = 0;
 			first_ent = &ent;
+			render_it = &render;
 		}
-
-		lastBundle = bundleHandle;
-		++count;
 	}
 
-	if(count > 0) {
-		instantiate(*render_it, first, last + 1, first_ent, last_ent + 1, count);
-	}
+	auto instanceComponents = make_instances(*render_it, first, last + 1);
+	info.command_buffer.add_components<instance_id>(psl::array_view<entity_t>(first_ent, last_ent + 1),
+													instanceComponents);
 }
 
-void geometry_instancing::dynamic_remove(info_t& info,
-										 pack_direct_partial_t<entity_t,
-															   renderable,
-															   const instance_id,
-															   filter<dynamic_tag>,
-															   except<dont_render_tag>,
-															   on_break<renderable, transform, instance_id>> pack) {
-	for(auto [e, r, id] : pack) {
-		if(r.bundle && r.geometry) {
-			r.bundle->release(r.geometry, id.id);
+void geometry_instancing::dynamic_remove(
+  info_t& info,
+  pack_indirect_full_t<entity_t,
+					   const renderable,
+					   const instance_id,
+					   filter<dynamic_tag>,
+					   except<dont_render_tag>,
+					   on_break<renderable, transform, instance_id>,
+					   psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> pack) {
+	if(pack.empty()) {
+		return;
+	}
+	instance_id const* first {&pack.get<const instance_id>()[0]};
+	instance_id const* last {nullptr};
+	auto* render_it		= &pack.get<renderable const>()[0];
+	entity_t* first_ent = &pack.get<entity_t>()[0];
+	entity_t* last_ent {nullptr};
+
+	psl::array<std::uint32_t> instanceIDs {};
+	std::unordered_map<psl::UID, core::resource::handle<core::gfx::bundle>> seenBundles;
+
+	for(auto [ent, render, instance_id] : pack) {
+		auto bundleHandle = render.bundle;
+		last_ent		  = &ent;
+		last			  = &instance_id;
+		instanceIDs.push_back(instance_id.id);
+		if(bundleHandle.uid() != render_it->bundle.uid() || render_it->geometry.uid() != render.geometry.uid()) {
+			bundleHandle->release(render.geometry, instanceIDs);
+			if(seenBundles.find(bundleHandle.uid()) == seenBundles.end()) {
+				seenBundles.insert({bundleHandle.uid(), bundleHandle});
+			}
+			first	  = &instance_id;
+			first_ent = &ent;
+			render_it = &render;
+			instanceIDs.clear();
 		}
 	}
 
-	info.command_buffer.remove_components<instance_id>(pack.get<entity_t>());
+	{
+		auto bundle = render_it->bundle;
+		bundle->release(render_it->geometry, instanceIDs);
+		if(seenBundles.find(bundle.uid()) == seenBundles.end()) {
+			seenBundles.insert({bundle.uid(), bundle});
+		}
+	}
+
+	for(auto& [uid, bundle] : seenBundles) {
+		bundle->apply();
+	}
+
+	info.command_buffer.remove_components<instance_id>(pack.get<entity_t>().to_array());
 }
 
 void geometry_instancing::dynamic_update(info_t& info,
-										 pack_indirect_partial_t<renderable,
+										 pack_indirect_partial_t<const renderable,
 																 const transform,
 																 const instance_id,
 																 filter<dynamic_tag>,
 																 except<dont_render_tag>,
-																 order_by<instance_id_sort, instance_id>> pack) {
+																 psl::ecs::order_by<renderer_sort, renderable>> pack) {
 	if(pack.empty()) {
 		return;
 	}
-	struct temp {
-		instance_id id;
-		psl::mat4x4 model;
-	};
-	std::unordered_map<psl::UID, std::unordered_map<psl::UID, std::pair<renderable*, psl::array<temp>>>> combos;
-	psl::UID lastBundleUID {};
 	psl::UID lastGeometryUID {};
-	std::pair<renderable*, psl::array<temp>>* currentArray = nullptr;
+	renderable const* lastRenderable = nullptr;
+
+	psl::array<psl::mat4x4> modelMats {};
+	psl::array<std::uint32_t> instanceIDs {};
 	for(auto [r, t, id] : pack) {
+		if(!r.bundle || !r.geometry) {
+			continue;
+		}
+		if((lastRenderable == nullptr || lastRenderable->bundle.uid() != r.bundle.uid()) ||
+		   lastGeometryUID != r.geometry.uid()) {
+			if(lastRenderable) {
+				auto scoped_lock = std::scoped_lock(m_Mutex);
+				auto bundle		 = lastRenderable->bundle;
+				bundle->set(lastRenderable->geometry,
+							instanceIDs,
+							core::gfx::constants::INSTANCE_MODELMATRIX,
+							std::move(modelMats));
+			}
+			lastRenderable	= &r;
+			lastGeometryUID = r.geometry.uid();
+			modelMats.clear();
+			instanceIDs.clear();
+		}
 		const psl::mat4x4 translationMat = translate(t.position);
 		const psl::mat4x4 rotationMat	 = to_matrix(t.rotation);
 		const psl::mat4x4 scaleMat		 = scale(t.scale);
 		const auto modelMat				 = translationMat * rotationMat * scaleMat;
-		if(r.bundle.uid() == lastBundleUID && r.geometry.uid() == lastGeometryUID && currentArray) {
-			currentArray->second.emplace_back(temp {id, modelMat});
-		} else {
-			lastBundleUID	= r.bundle.uid();
-			lastGeometryUID = r.geometry.uid();
-			currentArray	= &combos[r.bundle][r.geometry];
-			currentArray->second.emplace_back(temp {id, modelMat});
-			if(currentArray->first == nullptr) {
-				currentArray->first = &r;
-				currentArray->second.reserve(pack.size());
-			}
-		}
+		modelMats.emplace_back(modelMat);
+		instanceIDs.push_back(id.id);
 	}
-
-	psl::array<psl::mat4x4> modelMats {};
-	modelMats.reserve(pack.size());
-	for(auto& [bundleUID, geomMap] : combos) {
-		for(auto& [geometryUID, instanceData] : geomMap) {
-			std::sort(instanceData.second.begin(), instanceData.second.end(), [](const temp& lhs, const temp& rhs) {
-				return lhs.id.id < rhs.id.id;
-			});
-
-			size_t index	  = 0;
-			size_t totalCount = 0;
-			while(index < instanceData.second.size()) {
-				totalCount = index;
-				// figure out contiguous ranges
-				auto* firstModelMat = &instanceData.second[index].model;
-				auto firstId		= instanceData.second[index].id.id;
-				modelMats.emplace_back(instanceData.second[index].model);
-				while(index + 1 < instanceData.second.size() &&
-					  firstId + index + 1 == instanceData.second[index + 1].id.id) {
-					++index;
-					modelMats.emplace_back(instanceData.second[index].model);
-				}
-
-				totalCount = index - totalCount + 1;
-
-				auto scoped_lock   = std::scoped_lock(m_Mutex);
-				auto* lastModelMat = &instanceData.second[index].model;
-				instanceData.first->bundle->set(
-				  instanceData.first->geometry, firstId, core::gfx::constants::INSTANCE_MODELMATRIX, modelMats);
-				++index;
-				modelMats.clear();
-			}
-		}
+	if(lastRenderable) {
+		auto scoped_lock = std::scoped_lock(m_Mutex);
+		auto bundle		 = lastRenderable->bundle;
+		bundle->set(
+		  lastRenderable->geometry, instanceIDs, core::gfx::constants::INSTANCE_MODELMATRIX, std::move(modelMats));
 	}
-}
-
-
-void geometry_instancing::dynamic_system(info_t& info,
-										 pack_direct_full_t<renderable,
-															const transform,
-															const dynamic_tag,
-															except<dont_render_tag>,
-															order_by<renderer_sort, renderable>> geometry_pack) {
-	// todo clean up in case the last renderable from a dynamic object is despawned. The instance will not be released
-	// todo this will trash static instances as well
-	core::log->warn("todo: instance leak");
-	core::profiler.scope_begin("release_all");
-
-	{
-		auto renderers = geometry_pack.get<renderable>();
-		for(auto renderable : renderers) {
-			if(renderable.bundle) {
-				renderable.bundle->release_all();
-			}
-		}
-	}
-
-	core::profiler.scope_end();
-
-	core::profiler.scope_begin("mapping");
-	std::unordered_map<psl::UID, std::unordered_map<psl::UID, geometry_instance>> UniqueCombinations;
-
-	for(uint32_t i = 0; i < (uint32_t)geometry_pack.size(); ++i) {
-		const auto& renderer = std::get<renderable&>(geometry_pack[i]);
-		if(!renderer.bundle)
-			continue;
-		if(UniqueCombinations[renderer.bundle].find(renderer.geometry) ==
-		   std::end(UniqueCombinations[renderer.bundle])) {
-			UniqueCombinations[renderer.bundle].emplace(renderer.geometry, geometry_instance {i, 0});
-		}
-		UniqueCombinations[renderer.bundle][renderer.geometry].count += 1;
-	}
-	core::profiler.scope_end();
-
-	core::profiler.scope_begin("create_all");
-	std::vector<psl::mat4x4> modelMats;
-	for(const auto& unique_bundle : UniqueCombinations) {
-		modelMats.clear();
-
-		for(const auto& [geometryUID, geometryData] : unique_bundle.second) {
-			const auto& renderer = std::get<renderable&>(geometry_pack[geometryData.startIndex]);
-			auto bundleHandle	 = renderer.bundle;
-			auto geometryHandle	 = renderer.geometry;
-
-			auto instancesID = bundleHandle->instantiate(geometryHandle, (uint32_t)geometryData.count);
-
-			size_t indicesCompleted = 0;
-			for(auto [startIndex, endIndex] : instancesID) {
-				auto range = endIndex - startIndex;
-				for(auto i = 0u; i < range; ++i, ++indicesCompleted) {
-					const auto& transform = std::get<const core::ecs::components::transform&>(
-					  geometry_pack[indicesCompleted + geometryData.startIndex]);
-					const psl::mat4x4 translationMat = translate(transform.position);
-					const psl::mat4x4 rotationMat	 = to_matrix(transform.rotation);
-					const psl::mat4x4 scaleMat		 = scale(transform.scale);
-					modelMats.emplace_back(translationMat * rotationMat * scaleMat);
-				}
-
-				if(!bundleHandle->set(
-					 geometryHandle, startIndex, core::gfx::constants::INSTANCE_MODELMATRIX, modelMats))
-					core::log->error(
-					  "could not set the instance data for the dynamic elements in geometry: {} startIndex: {} size: "
-					  "{}",
-					  geometryHandle,
-					  startIndex,
-					  modelMats.size());
-				modelMats.clear();
-			}
-		}
-	}
-	core::profiler.scope_end();
 }
 
 void geometry_instancing::static_add(info_t& info,
@@ -284,61 +210,32 @@ void geometry_instancing::static_add(info_t& info,
 														psl::ecs::except<dynamic_tag>,
 														on_combine<const renderable, const transform>,
 														order_by<renderer_sort, renderable>> geometry_pack) {
-	if(geometry_pack.size() == 0)
+	if(geometry_pack.size() == 0) {
 		return;
-
-	core::profiler.scope_begin("mapping");
-	std::unordered_map<psl::UID, std::unordered_map<psl::UID, geometry_instance>> UniqueCombinations;
-
-	for(uint32_t i = 0; i < (uint32_t)geometry_pack.size(); ++i) {
-		const auto& renderer = std::get<const renderable&>(geometry_pack[i]);
-		if(!renderer.bundle)
-			continue;
-		if(UniqueCombinations[renderer.bundle].find(renderer.geometry) == std::end(UniqueCombinations[renderer.bundle]))
-			UniqueCombinations[renderer.bundle].emplace(renderer.geometry, geometry_instance {i, 0});
-		UniqueCombinations[renderer.bundle][renderer.geometry].count += 1;
 	}
-	core::profiler.scope_end();
-
-	core::profiler.scope_begin("create_all");
-	std::vector<psl::mat4x4> modelMats;
-	psl::array<entity_t> eIds;
-	psl::array<instance_id> instanceIds;
-	for(const auto& unique_bundle : UniqueCombinations) {
-		modelMats.clear();
-
-		for(const auto& [geometryUID, geometryData] : unique_bundle.second) {
-			const auto& renderer = std::get<const renderable&>(geometry_pack[geometryData.startIndex]);
-			auto bundleHandle	 = renderer.bundle;
-			auto geometryHandle	 = renderer.geometry;
-
-			auto instancesID = bundleHandle->instantiate(geometryHandle, (uint32_t)geometryData.count);
-
-			uint32_t indicesCompleted = 0;
-			for(auto [startIndex, endIndex] : instancesID) {
-				eIds.reserve(endIndex - startIndex);
-				instanceIds.reserve(endIndex - startIndex);
-				modelMats.reserve(endIndex - startIndex);
-				for(auto i = startIndex; i < endIndex; ++i, ++indicesCompleted) {
-					const auto& transform = std::get<const core::ecs::components::transform&>(
-					  geometry_pack[indicesCompleted + geometryData.startIndex]);
-					const psl::mat4x4 translationMat = translate(transform.position);
-					const psl::mat4x4 rotationMat	 = to_matrix(transform.rotation);
-					const psl::mat4x4 scaleMat		 = scale(transform.scale);
-					modelMats.emplace_back(translationMat * rotationMat * scaleMat);
-
-					eIds.emplace_back(std::get<entity_t&>(geometry_pack[indicesCompleted + geometryData.startIndex]));
-					instanceIds.emplace_back(instance_id {i});
-				}
-				info.command_buffer.add_components<instance_id>(eIds, instanceIds);
-				bundleHandle->set(geometryHandle, startIndex, core::gfx::constants::INSTANCE_MODELMATRIX, modelMats);
-
-				modelMats.clear();
-				eIds.clear();
-				instanceIds.clear();
-			}
+	core::profiler.scope_begin("geometry_instancing::static_add");
+	transform const* first {&geometry_pack.get<const transform>()[0]};
+	transform const* last {nullptr};
+	auto* render_it		= &geometry_pack.get<renderable const>()[0];
+	entity_t* first_ent = &geometry_pack.get<entity_t>()[0];
+	entity_t* last_ent {nullptr};
+	for(auto [ent, render, trns] : geometry_pack) {
+		auto bundleHandle = render.bundle;
+		last_ent		  = &ent;
+		last			  = &trns;
+		if(bundleHandle.uid() != render_it->bundle.uid() || render_it->geometry.uid() != render.geometry.uid()) {
+			auto instanceComponents = make_instances(*render_it, first, last + 1);
+			info.command_buffer.add_components<instance_id>(psl::array_view<entity_t>(first_ent, last_ent + 1),
+															instanceComponents);
+			first	  = &trns;
+			first_ent = &ent;
+			render_it = &render;
 		}
 	}
+
+	auto instanceComponents = make_instances(*render_it, first, last + 1);
+	info.command_buffer.add_components<instance_id>(psl::array_view<entity_t>(first_ent, last_ent + 1),
+													instanceComponents);
 	core::profiler.scope_end();
 }
 void geometry_instancing::static_remove(info_t& info,
@@ -352,8 +249,9 @@ void geometry_instancing::static_remove(info_t& info,
 	core::log->info("deallocating {} static instances", geometry_pack.size());
 	core::profiler.scope_begin("release static geometry");
 	for(auto [entity, renderable, instance_id] : geometry_pack) {
-		if(renderable.bundle)
+		if(renderable.bundle) {
 			renderable.bundle->release(renderable.geometry, instance_id.id);
+		}
 	}
 
 	info.command_buffer.remove_components<instance_id>(geometry_pack.get<entity_t>());
@@ -362,21 +260,50 @@ void geometry_instancing::static_remove(info_t& info,
 
 void geometry_instancing::static_geometry_add(
   psl::ecs::info_t& info,
-  psl::ecs::pack_direct_full_t<psl::ecs::entity_t,
-							   const core::ecs::components::renderable,
-							   psl::ecs::except<core::ecs::components::transform>,
-							   psl::ecs::on_add<core::ecs::components::renderable>> pack) {
-	if(pack.size() == 0)
+  psl::ecs::pack_indirect_full_t<psl::ecs::entity_t,
+								 const core::ecs::components::renderable,
+								 psl::ecs::except<core::ecs::components::transform>,
+								 psl::ecs::on_add<core::ecs::components::renderable>,
+								 psl::ecs::order_by<renderer_sort, core::ecs::components::renderable>> pack) {
+	if(pack.size() == 0) {
 		return;
+	}
+
+	auto instantiate = [](core::ecs::components::renderable const& rend, uint32_t count) {
+		if(!rend.bundle || !rend.geometry || count == 0) {
+			return psl::array<uint32_t> {};
+		}
+		auto bundle = rend.bundle;
+		return bundle->instantiate(rend.geometry, count);
+	};
+	auto firstRenderable = &pack.get<const core::ecs::components::renderable>()[0];
+	psl::UID geometry_uid {firstRenderable->geometry.uid()};
 	psl::array<instance_id> instanceIds;
+	uint32_t count {0};
 	for(auto [entity, render] : pack) {
 		auto bundleHandle	= render.bundle;
 		auto geometryHandle = render.geometry;
 
-		auto instancesID = bundleHandle->instantiate(geometryHandle, 1);
-		instanceIds.emplace_back(instancesID[0].first);
+		if(bundleHandle.uid() != firstRenderable->bundle.uid() || geometry_uid != geometryHandle.uid()) {
+			if(count > 0) {
+				auto instancesID = instantiate(*firstRenderable, count);
+				for(auto instanceId : instancesID) {
+					instanceIds.emplace_back(instance_id {instanceId});
+				}
+			}
+			firstRenderable = &render;
+			count			= 0;
+			geometry_uid	= geometryHandle.uid();
+		}
+		++count;
 	}
-	info.command_buffer.add_components<instance_id>(pack.get<entity_t>(), instanceIds);
+	if(count > 0 && firstRenderable) {
+		auto instancesID = instantiate(*firstRenderable, count);
+		for(auto instanceId : instancesID) {
+			instanceIds.emplace_back(instance_id {instanceId});
+		}
+	}
+	info.command_buffer.add_components<instance_id>(pack.get<entity_t>().to_array(), instanceIds);
 }
 
 

--- a/core/src/gfx/bundle.cpp
+++ b/core/src/gfx/bundle.cpp
@@ -86,7 +86,7 @@ uint32_t bundle::instances(core::resource::tag<core::gfx::geometry_t> geometry) 
 	return m_InstanceData.count(geometry);
 }
 
-std::vector<std::pair<uint32_t, uint32_t>>
+std::vector<uint32_t>
 bundle::instantiate(core::resource::tag<core::gfx::geometry_t> geometry, uint32_t count, geometry_type type) {
 	return m_InstanceData.add(geometry, count);
 }
@@ -102,22 +102,90 @@ bool bundle::release(tag<core::gfx::geometry_t> geometry, uint32_t id) noexcept 
 	return m_InstanceData.erase(geometry, id);
 }
 
+bool bundle::release(tag<core::gfx::geometry_t> geometry, std::span<uint32_t const> ids) noexcept {
+	return m_InstanceData.erase(geometry, ids);
+}
+
 bool bundle::release_all(std::optional<geometry_type> type) noexcept {
 	return m_InstanceData.clear();
 };
 
-bool bundle::set(tag<core::gfx::geometry_t> geometry,
-				 uint32_t id,
+bool bundle::set(core::resource::tag<core::gfx::geometry_t> geometry,
+				 std::span<uint32_t const> ids,
 				 memory::segment segment,
 				 uint32_t size_of_element,
-				 const void* data,
-				 size_t size,
-				 size_t count) {
-	return m_InstanceData.vertex_buffer()->commit({core::gfx::commit_instruction {
-	  (void*)data, size * count, segment, memory::range_t {size_of_element * id, size_of_element * (id + count)}}});
+				 std::byte* data,
+				 size_t size) {
+	if(ids.size() == 0) {
+		return true;
+	}
+	struct range {
+		size_t begin, end;
+		std::byte *data_begin, *data_end;
+	};
+	std::vector<range> ranges {};
+	ranges.reserve(ids.size());
+	auto data_offset = data;
+	{
+		auto offset_of = m_InstanceData.offset_of(geometry, ids[0]);
+		ranges.push_back(range {offset_of, offset_of + 1, data, data + size});
+		data_offset += size;
+	}
+
+	for(auto i = 1; i < ids.size(); ++i, data_offset += size) {
+		auto offset_of = m_InstanceData.offset_of(geometry, ids[i]);
+		if(ranges.back().end == offset_of) {
+			ranges.back().end = offset_of + 1;
+			ranges.back().data_end += size;
+		} else {
+			ranges.emplace_back(range {offset_of, offset_of + 1, data_offset, data_offset + size});
+		}
+	}
+
+	std::byte* temp = new std::byte[size * ids.size()];
+	// sort the ranges, and swap the memory of the data pointer accordingly.
+	std::sort(std::begin(ranges), std::end(ranges), [](const range& a, const range& b) { return a.begin < b.begin; });
+
+	// now copy the data over to a temp buffer in the right order.
+	size_t offset = 0;
+	for(auto& range : ranges) {
+		auto range_size = range.data_end - range.data_begin;
+		std::memcpy(temp + offset, range.data_begin, range_size);
+		range.data_begin = temp + offset;
+		range.data_end	 = range.data_begin + range_size;
+		offset += range_size;
+	}
+
+	// now that the ranges are sorted, we can merge them if the end == begin of the next range
+	for(size_t i = 1; i < ranges.size(); ++i) {
+		if(ranges[i - 1].end == ranges[i].begin) {
+			ranges[i - 1].end	   = ranges[i].end;
+			ranges[i - 1].data_end = ranges[i].data_end;
+			ranges.erase(std::begin(ranges) + i);
+			--i;
+		}
+	}
+
+	psl::array<core::gfx::commit_instruction> instructions {};
+	for(auto range : ranges) {
+		auto range_count = range.end - range.begin;
+		instructions.emplace_back(
+		  core::gfx::commit_instruction {range.data_begin,
+										 size * range_count,
+										 segment,
+										 memory::range_t {size_of_element * range.begin, size_of_element * range.end}});
+	}
+
+	auto res = m_InstanceData.vertex_buffer()->commit(instructions);
+	delete[] temp;
+	return res;
 }
 
 
 bool bundle::set(tag<core::gfx::material_t> material, const void* data, size_t size, size_t offset) {
 	return m_InstanceData.set(material, data, size, offset);
+}
+
+void bundle::apply() {
+	m_InstanceData.apply();
 }

--- a/core/src/gfx/bundle.cpp
+++ b/core/src/gfx/bundle.cpp
@@ -82,27 +82,28 @@ bool bundle::bind_material(uint32_t renderlayer) noexcept {
 // instance data API
 // ------------------------------------------------------------------------------------------------------------
 
-uint32_t bundle::instances(core::resource::tag<core::gfx::geometry_t> geometry) const noexcept {
+instancing_size_type bundle::instances(core::resource::tag<core::gfx::geometry_t> geometry) const noexcept {
 	return m_InstanceData.count(geometry);
 }
 
-std::vector<uint32_t>
-bundle::instantiate(core::resource::tag<core::gfx::geometry_t> geometry, uint32_t count, geometry_type type) {
+std::vector<instancing_size_type> bundle::instantiate(core::resource::tag<core::gfx::geometry_t> geometry,
+													  instancing_size_type count,
+													  geometry_type type) {
 	return m_InstanceData.add(geometry, count);
 }
 
-uint32_t bundle::size(tag<core::gfx::geometry_t> geometry) const noexcept {
+instancing_size_type bundle::size(tag<core::gfx::geometry_t> geometry) const noexcept {
 	return m_InstanceData.count(geometry);
 }
 bool bundle::has(tag<core::gfx::geometry_t> geometry) const noexcept {
 	return size(geometry) > 0;
 }
 
-bool bundle::release(tag<core::gfx::geometry_t> geometry, uint32_t id) noexcept {
+bool bundle::release(tag<core::gfx::geometry_t> geometry, instancing_size_type id) noexcept {
 	return m_InstanceData.erase(geometry, id);
 }
 
-bool bundle::release(tag<core::gfx::geometry_t> geometry, std::span<uint32_t const> ids) noexcept {
+bool bundle::release(tag<core::gfx::geometry_t> geometry, std::span<instancing_size_type const> ids) noexcept {
 	return m_InstanceData.erase(geometry, ids);
 }
 
@@ -111,7 +112,7 @@ bool bundle::release_all(std::optional<geometry_type> type) noexcept {
 };
 
 bool bundle::set(core::resource::tag<core::gfx::geometry_t> geometry,
-				 std::span<uint32_t const> ids,
+				 std::span<instancing_size_type const> ids,
 				 memory::segment segment,
 				 uint32_t size_of_element,
 				 std::byte* data,
@@ -120,25 +121,25 @@ bool bundle::set(core::resource::tag<core::gfx::geometry_t> geometry,
 		return true;
 	}
 	struct range {
-		size_t begin, end;
+		instancing_size_type begin, end;
 		std::byte *data_begin, *data_end;
 	};
 	std::vector<range> ranges {};
 	ranges.reserve(ids.size());
 	auto data_offset = data;
 	{
-		auto offset_of = m_InstanceData.offset_of(geometry, ids[0]);
-		ranges.push_back(range {offset_of, offset_of + 1, data, data + size});
+		auto index_of = m_InstanceData.index_of(geometry, ids[0]);
+		ranges.push_back(range {index_of, index_of + 1, data, data + size});
 		data_offset += size;
 	}
 
 	for(auto i = 1; i < ids.size(); ++i, data_offset += size) {
-		auto offset_of = m_InstanceData.offset_of(geometry, ids[i]);
-		if(ranges.back().end == offset_of) {
-			ranges.back().end = offset_of + 1;
+		auto index_of = m_InstanceData.index_of(geometry, ids[i]);
+		if(ranges.back().end == index_of) {
+			ranges.back().end = index_of + 1;
 			ranges.back().data_end += size;
 		} else {
-			ranges.emplace_back(range {offset_of, offset_of + 1, data_offset, data_offset + size});
+			ranges.emplace_back(range {index_of, index_of + 1, data_offset, data_offset + size});
 		}
 	}
 

--- a/core/src/gfx/details/instance.cpp
+++ b/core/src/gfx/details/instance.cpp
@@ -13,8 +13,6 @@ using namespace core::gfx;
 using namespace core::gfx::details::instance;
 using namespace core::resource;
 
-constexpr instancing_size_type default_capacity = 32;
-
 data::data(core::resource::handle<core::gfx::buffer_t> vertexBuffer,
 		   core::resource::handle<core::gfx::shader_buffer_binding> materialBuffer) noexcept
 	: m_VertexInstanceBuffer(vertexBuffer), m_MaterialInstanceBuffer(materialBuffer) {}
@@ -96,7 +94,7 @@ void data::add(core::resource::handle<material_t> material) {
 					core::gfx::log->error("could not allocate");
 					continue;
 				}
-				data.instance_data.emplace_back(geometry_instance_data::entry {res.value(), d.description, d.slot});
+				data.add_binding(d.description, res.value(), d.slot);
 			}
 		} else {
 			if(it->first.size_of_element != d.description.size_of_element)
@@ -111,7 +109,7 @@ std::vector<instancing_size_type> data::add(core::resource::tag<core::gfx::geome
 											instancing_size_type count) {
 	auto it = m_GeometryInstanceData.find(uid);
 	if(it == std::end(m_GeometryInstanceData)) {
-		auto const size = std::max(count, default_capacity);
+		auto const size = std::max(count, instancing_default_capacity);
 		it				= m_GeometryInstanceData.emplace(uid, geometry_instance_data {size}).first;
 		it->second.capacity(size);
 		for(const auto& b : m_UniqueBindings) {
@@ -120,7 +118,7 @@ std::vector<instancing_size_type> data::add(core::resource::tag<core::gfx::geome
 				core::gfx::log->error("could not allocate");
 				continue;
 			}
-			it->second.instance_data.emplace_back(geometry_instance_data::entry {res.value(), b.first, b.second});
+			it->second.add_binding(b.first, res.value(), b.second);
 		}
 	}
 
@@ -128,7 +126,7 @@ std::vector<instancing_size_type> data::add(core::resource::tag<core::gfx::geome
 		auto const size = it->second.capacity();
 		auto new_size	= std::max(size + count, size + (size >> 1));
 
-		for(auto& entry : it->second.instance_data) {
+		for(auto& entry : it->second) {
 			auto res = m_VertexInstanceBuffer->reserve(new_size * entry.description.size_of_element);
 			if(!res) {
 				core::gfx::log->error("could not allocate");
@@ -162,7 +160,7 @@ bool data::remove(core::resource::handle<material_t> material) noexcept {
 
 instancing_size_type data::count(core::resource::tag<core::gfx::geometry_t> uid) const noexcept {
 	if(auto it = m_GeometryInstanceData.find(uid.uid()); it != std::end(m_GeometryInstanceData)) {
-		return it->second.size();
+		return it->second.count();
 	}
 	return 0;
 }
@@ -175,12 +173,9 @@ psl::array<std::pair<size_t, std::uintptr_t>> data::bindings(tag<material_t> mat
 		if(auto geomIt = m_GeometryInstanceData.find(geometry); geomIt != std::end(m_GeometryInstanceData)) {
 			size_t count = {0};
 			for(const auto& binding : matIt->second) {
-				auto it = std::find_if(std::begin(geomIt->second.instance_data),
-									   std::end(geomIt->second.instance_data),
-									   [&bDescr = binding.description](const geometry_instance_data::entry& entry) {
-										   return entry.description == bDescr;
-									   });
-
+				auto it = geomIt->second.find(binding.description);
+				psl_assert(
+				  it != nullptr, "could not find binding {} in geometry instance data", binding.description.name);
 				result.emplace_back(binding.slot, it->memory.range().begin);
 			}
 		}
@@ -191,11 +186,7 @@ psl::array<std::pair<size_t, std::uintptr_t>> data::bindings(tag<material_t> mat
 
 bool data::has_element(tag<geometry_t> geometry, psl::string_view name) const noexcept {
 	if(auto it = m_GeometryInstanceData.find(geometry); it != std::end(m_GeometryInstanceData)) {
-		return std::find_if(std::begin(it->second.instance_data),
-							std::end(it->second.instance_data),
-							[&name](const geometry_instance_data::entry& entry) {
-								return entry.description.name == name;
-							}) != std::end(it->second.instance_data);
+		return it->second.contains(name);
 	}
 	return false;
 }
@@ -203,11 +194,8 @@ bool data::has_element(tag<geometry_t> geometry, psl::string_view name) const no
 std::optional<std::pair<memory::segment, uint32_t>> data::segment(tag<geometry_t> geometry,
 																  psl::string_view name) const noexcept {
 	if(auto it = m_GeometryInstanceData.find(geometry); it != std::end(m_GeometryInstanceData)) {
-		auto descrIt =
-		  std::find_if(std::begin(it->second.instance_data),
-					   std::end(it->second.instance_data),
-					   [&name](const geometry_instance_data::entry& entry) { return entry.description.name == name; });
-		if(descrIt != std::end(it->second.instance_data)) {
+		auto descrIt = it->second.find(name);
+		if(descrIt != nullptr) {
 			return std::pair {descrIt->memory, descrIt->description.size_of_element};
 		}
 	}
@@ -233,7 +221,7 @@ bool data::erase(core::resource::tag<core::gfx::geometry_t> geometry, instancing
 }
 bool data::clear(core::resource::tag<core::gfx::geometry_t> geometry) noexcept {
 	if(auto it = m_GeometryInstanceData.find(geometry); it != std::end(m_GeometryInstanceData)) {
-		for(auto& data : it->second.instance_data) {
+		for(auto& data : it->second) {
 			m_VertexInstanceBuffer->deallocate(data.memory);
 		}
 
@@ -244,7 +232,7 @@ bool data::clear(core::resource::tag<core::gfx::geometry_t> geometry) noexcept {
 }
 bool data::clear() noexcept {
 	for(auto& [uid, geom_data] : m_GeometryInstanceData) {
-		for(auto& data : geom_data.instance_data) {
+		for(auto& data : geom_data) {
 			m_VertexInstanceBuffer->deallocate(data.memory);
 		}
 	}
@@ -343,7 +331,8 @@ instancing_size_type geometry_instance_data::capacity() const noexcept {
 void geometry_instance_data::capacity(instancing_size_type max) {
 	psl_assert(max > manager.size(),
 			   "Setting a max capacity lower than the current allocated entries will end up in errors.");
-	m_Max = max;
+	m_Max			  = max;
+	m_Link->m_MaxSize = m_Max;
 }
 
 std::vector<instancing_size_type> geometry_instance_data::add(instancing_size_type count) {
@@ -386,7 +375,7 @@ std::vector<instancing_size_type> geometry_instance_data::add(instancing_size_ty
 	return ids;
 };
 
-instancing_size_type geometry_instance_data::size() const noexcept {
+instancing_size_type geometry_instance_data::count() const noexcept {
 	return manager.size();
 }
 
@@ -415,23 +404,61 @@ void geometry_instance_data::clear() noexcept {
 }
 
 psl::array<core::gfx::memory_copy> geometry_instance_data::consume() {
-	auto commands = std::move(m_Link->m_Commands);
-	m_Link->m_Commands.clear();
+	auto& commands = m_Link->consume();
 	if(commands.empty()) {
 		return {};
 	}
 
 	psl::array<core::gfx::memory_copy> instructions {};
+	instructions.reserve(commands.size() * instance_data.size());
 	for(auto const& data : instance_data) {
 		for(auto& command : commands) {
-			// we can safely ignore resize commands, as they are implicit in the copy commands.
-			if(std::holds_alternative<storage_link::swap_command>(command)) {
-				auto& swap = std::get<storage_link::swap_command>(command);
-				instructions.push_back({data.memory.range().begin + (swap.src * data.description.size_of_element),
-										data.memory.range().begin + (swap.dst * data.description.size_of_element),
-										swap.count * data.description.size_of_element});
-			}
+			instructions.push_back({data.memory.range().begin + (command.src * data.description.size_of_element),
+									data.memory.range().begin + (command.dst * data.description.size_of_element),
+									command.count * data.description.size_of_element});
 		}
 	}
+	commands.clear();
 	return instructions;
+}
+
+void geometry_instance_data::add_binding(binding::header description, memory::segment segment, uint32_t slot) {
+	auto it = std::find_if(
+	  std::begin(instance_data), std::end(instance_data), [&description](const geometry_instance_data::entry& entry) {
+		  return entry.description == description;
+	  });
+	if(it != std::end(instance_data)) {
+		core::gfx::log->error("binding {} already exists, cannot add it again", description.name);
+		return;
+	}
+	instance_data.emplace_back(geometry_instance_data::entry {segment, description, slot});
+}
+
+geometry_instance_data::entry const* geometry_instance_data::find(psl::string_view name) const noexcept {
+	auto it =
+	  std::find_if(std::begin(instance_data),
+				   std::end(instance_data),
+				   [&name](const geometry_instance_data::entry& entry) { return entry.description.name == name; });
+	if(it != std::end(instance_data)) {
+		return &*it;
+	}
+	return nullptr;
+}
+
+geometry_instance_data::entry const* geometry_instance_data::find(binding::header const& header) const noexcept {
+	auto it =
+	  std::find_if(std::begin(instance_data),
+				   std::end(instance_data),
+				   [&header](const geometry_instance_data::entry& entry) { return entry.description == header; });
+	if(it != std::end(instance_data)) {
+		return &*it;
+	}
+	return nullptr;
+}
+
+bool geometry_instance_data::contains(psl::string_view name) const noexcept {
+	return std::find_if(
+			 std::begin(instance_data), std::end(instance_data), [&name](const geometry_instance_data::entry& entry) {
+				 return entry.description.name == name;
+			 }) != std::end(instance_data);
 }

--- a/core/src/gfx/details/instance.cpp
+++ b/core/src/gfx/details/instance.cpp
@@ -13,7 +13,7 @@ using namespace core::gfx;
 using namespace core::gfx::details::instance;
 using namespace core::resource;
 
-constexpr uint32_t default_capacity = 32;
+constexpr instancing_size_type default_capacity = 32;
 
 data::data(core::resource::handle<core::gfx::buffer_t> vertexBuffer,
 		   core::resource::handle<core::gfx::shader_buffer_binding> materialBuffer) noexcept
@@ -107,7 +107,8 @@ void data::add(core::resource::handle<material_t> material) {
 	}
 }
 
-std::vector<uint32_t> data::add(core::resource::tag<core::gfx::geometry_t> uid, uint32_t count) {
+std::vector<instancing_size_type> data::add(core::resource::tag<core::gfx::geometry_t> uid,
+											instancing_size_type count) {
 	auto it = m_GeometryInstanceData.find(uid);
 	if(it == std::end(m_GeometryInstanceData)) {
 		auto const size = std::max(count, default_capacity);
@@ -159,7 +160,7 @@ bool data::remove(core::resource::handle<material_t> material) noexcept {
 }
 
 
-uint32_t data::count(core::resource::tag<core::gfx::geometry_t> uid) const noexcept {
+instancing_size_type data::count(core::resource::tag<core::gfx::geometry_t> uid) const noexcept {
 	if(auto it = m_GeometryInstanceData.find(uid.uid()); it != std::end(m_GeometryInstanceData)) {
 		return it->second.size();
 	}
@@ -214,7 +215,8 @@ std::optional<std::pair<memory::segment, uint32_t>> data::segment(tag<geometry_t
 }
 
 
-bool data::erase(core::resource::tag<core::gfx::geometry_t> geometry, std::span<uint32_t const> ids) noexcept {
+bool data::erase(core::resource::tag<core::gfx::geometry_t> geometry,
+				 std::span<instancing_size_type const> ids) noexcept {
 	if(auto it = m_GeometryInstanceData.find(geometry); it != std::end(m_GeometryInstanceData)) {
 		it->second.erase(ids.begin(), ids.end());
 		return true;
@@ -222,7 +224,7 @@ bool data::erase(core::resource::tag<core::gfx::geometry_t> geometry, std::span<
 	return false;
 }
 
-bool data::erase(core::resource::tag<core::gfx::geometry_t> geometry, uint32_t id) noexcept {
+bool data::erase(core::resource::tag<core::gfx::geometry_t> geometry, instancing_size_type id) noexcept {
 	if(auto it = m_GeometryInstanceData.find(geometry); it != std::end(m_GeometryInstanceData)) {
 		it->second.erase(id);
 		return true;
@@ -282,11 +284,12 @@ size_t data::offset_of(core::resource::tag<core::gfx::material_t> material, psl:
 	return res;
 }
 
-size_t data::offset_of(core::resource::tag<core::gfx::geometry_t> geometry, std::uint32_t id) const noexcept {
+instancing_size_type data::index_of(core::resource::tag<core::gfx::geometry_t> geometry,
+									instancing_size_type id) const noexcept {
 	if(auto it = m_GeometryInstanceData.find(geometry); it != std::end(m_GeometryInstanceData)) {
-		return it->second.offset_of(id);
+		return it->second.index_of(id);
 	}
-	return std::numeric_limits<size_t>::max();
+	return std::numeric_limits<instancing_size_type>::max();
 }
 
 bool data::set(core::resource::tag<core::gfx::material_t> material,
@@ -309,7 +312,7 @@ bool data::bind_material(core::resource::handle<core::gfx::material_t> material)
 	}
 
 	return material->bind_instance_data(it->second.descriptor.binding(),
-										static_cast<uint32_t>(it->second.segment.range().begin));
+										psl::narrow_cast<uint32_t>(it->second.segment.range().begin));
 }
 
 core::resource::handle<core::gfx::buffer_t> data::material_buffer() const noexcept {
@@ -329,21 +332,21 @@ void data::apply() {
 }
 
 
-uint32_t geometry_instance_data::available() const noexcept {
-	return m_Max - (m_Head - static_cast<uint32_t>(m_Orphans.size()));
+instancing_size_type geometry_instance_data::available() const noexcept {
+	return m_Max - (m_Head - psl::narrow_cast<uint32_t>(m_Orphans.size()));
 }
 
-size_t geometry_instance_data::capacity() const noexcept {
+instancing_size_type geometry_instance_data::capacity() const noexcept {
 	return m_Max;
 }
 
-void geometry_instance_data::capacity(uint32_t max) {
+void geometry_instance_data::capacity(instancing_size_type max) {
 	psl_assert(max > manager.size(),
 			   "Setting a max capacity lower than the current allocated entries will end up in errors.");
 	m_Max = max;
 }
 
-std::vector<uint32_t> geometry_instance_data::add(uint32_t count) {
+std::vector<instancing_size_type> geometry_instance_data::add(instancing_size_type count) {
 	if(count == 0) {
 		return {};
 	}
@@ -361,12 +364,12 @@ std::vector<uint32_t> geometry_instance_data::add(uint32_t count) {
 		return {};
 	}
 
-	std::vector<uint32_t> ids {};
+	std::vector<instancing_size_type> ids {};
 	ids.resize(count);
-	auto orphans_to_use = std::min(static_cast<uint32_t>(m_Orphans.size()), count);
+	auto orphans_to_use = std::min(static_cast<instancing_size_type>(m_Orphans.size()), count);
 	if(orphans_to_use > 0) {
 		auto it = std::end(m_Orphans);
-		for(uint32_t i = 0; i != orphans_to_use; ++i) {
+		for(instancing_size_type i = 0; i != orphans_to_use; ++i) {
 			it	   = std::prev(it);
 			ids[i] = *it;
 		}
@@ -383,11 +386,11 @@ std::vector<uint32_t> geometry_instance_data::add(uint32_t count) {
 	return ids;
 };
 
-uint32_t geometry_instance_data::size() const noexcept {
+instancing_size_type geometry_instance_data::size() const noexcept {
 	return manager.size();
 }
 
-void geometry_instance_data::erase(uint32_t id) {
+void geometry_instance_data::erase(instancing_size_type id) {
 	psl_assert(manager.contains(id), "Trying to erase an id that does not exist");
 	manager.erase(id);
 	m_Orphans.push_back(id);
@@ -398,9 +401,9 @@ void geometry_instance_data::erase(auto&& first, auto&& last) {
 	m_Orphans.insert(m_Orphans.end(), first, last);
 }
 
-uint32_t geometry_instance_data::offset_of(uint32_t id) const noexcept {
+instancing_size_type geometry_instance_data::index_of(instancing_size_type id) const noexcept {
 	if(!manager.contains(id)) {
-		return std::numeric_limits<uint32_t>::max();
+		return std::numeric_limits<instancing_size_type>::max();
 	}
 	return manager.index_of(id);
 }

--- a/core/src/gfx/details/instance.cpp
+++ b/core/src/gfx/details/instance.cpp
@@ -90,15 +90,13 @@ void data::add(core::resource::handle<material_t> material) {
 		if(it == std::end(m_UniqueBindings)) {
 			m_UniqueBindings.emplace_back(std::pair<binding::header, uint32_t> {d.description, 0});
 
-			for(auto& [uid, obj] : m_InstanceData) {
-				auto res = m_VertexInstanceBuffer->reserve(obj.id_generator.capacity() * d.description.size_of_element);
+			for(auto& [uid, data] : m_GeometryInstanceData) {
+				auto res = m_VertexInstanceBuffer->reserve(data.capacity() * d.description.size_of_element);
 				if(!res) {
 					core::gfx::log->error("could not allocate");
 					continue;
 				}
-
-				obj.data.emplace_back(res.value());
-				obj.description.emplace_back(d.description);
+				data.instance_data.emplace_back(geometry_instance_data::entry {res.value(), d.description, d.slot});
 			}
 		} else {
 			if(it->first.size_of_element != d.description.size_of_element)
@@ -109,52 +107,44 @@ void data::add(core::resource::handle<material_t> material) {
 	}
 }
 
-std::vector<std::pair<uint32_t, uint32_t>> data::add(core::resource::tag<core::gfx::geometry_t> uid, uint32_t count) {
-	auto it = m_InstanceData.find(uid);
-	if(it == std::end(m_InstanceData)) {
+std::vector<uint32_t> data::add(core::resource::tag<core::gfx::geometry_t> uid, uint32_t count) {
+	auto it = m_GeometryInstanceData.find(uid);
+	if(it == std::end(m_GeometryInstanceData)) {
 		auto const size = std::max(count, default_capacity);
-		it				= m_InstanceData.emplace(uid, object {uid, size}).first;
+		it				= m_GeometryInstanceData.emplace(uid, geometry_instance_data {size}).first;
+		it->second.capacity(size);
 		for(const auto& b : m_UniqueBindings) {
-			auto res = m_VertexInstanceBuffer->reserve(it->second.id_generator.capacity() * b.first.size_of_element);
+			auto res = m_VertexInstanceBuffer->reserve(it->second.capacity() * b.first.size_of_element);
 			if(!res) {
 				core::gfx::log->error("could not allocate");
 				continue;
 			}
-			it->second.data.emplace_back(res.value());
-			it->second.description.emplace_back(b.first);
+			it->second.instance_data.emplace_back(geometry_instance_data::entry {res.value(), b.first, b.second});
 		}
 	}
 
-	if(it->second.id_generator.available() < count) {
-		auto size	  = it->second.id_generator.size();
-		auto new_size = std::max(size + count, size + (size >> 1));
-		if(!it->second.id_generator.resize(new_size))
-			core::gfx::log->error("could not increase the id_generator size from {} to {}", size, new_size);
-		else {
-			psl_assert(it->second.data.size() == it->second.description.size(),
-					   "Assuming that descriptions and data are always 1-1 match");
-			auto dataIt	 = std::begin(it->second.data);
-			auto descrIt = std::begin(it->second.description);
-			for(; dataIt != std::end(it->second.data) && descrIt != std::end(it->second.description);
-				++dataIt, ++descrIt) {
-				auto& d					   = *dataIt;
-				const auto requested_bytes = it->second.id_generator.capacity() * descrIt->size_of_element;
-				auto res				   = m_VertexInstanceBuffer->reserve(requested_bytes);
-				if(!res) {
-					core::gfx::log->error("could not allocate");
-					continue;
-				}
-				auto& value = res.value();
-				m_VertexInstanceBuffer->copy_from(
-				  m_VertexInstanceBuffer.value(),
-				  {core::gfx::memory_copy {d.range().begin, value.range().begin, d.range().size()}});
-				std::swap(d, value);
-				m_VertexInstanceBuffer->deallocate(value);
+	if(it->second.available() < count) {
+		auto const size = it->second.capacity();
+		auto new_size	= std::max(size + count, size + (size >> 1));
+
+		for(auto& entry : it->second.instance_data) {
+			auto res = m_VertexInstanceBuffer->reserve(new_size * entry.description.size_of_element);
+			if(!res) {
+				core::gfx::log->error("could not allocate");
+				continue;
 			}
+			auto& value = res.value();
+			m_VertexInstanceBuffer->copy_from(
+			  m_VertexInstanceBuffer.value(),
+			  {core::gfx::memory_copy {entry.memory.range().begin, value.range().begin, entry.memory.range().size()}});
+			std::swap(entry.memory, value);
+			m_VertexInstanceBuffer->deallocate(value);
 		}
+
+		it->second.capacity(new_size);
 	}
 
-	return it->second.id_generator.create_multi(count);
+	return it->second.add(count);
 }
 
 
@@ -170,8 +160,8 @@ bool data::remove(core::resource::handle<material_t> material) noexcept {
 
 
 uint32_t data::count(core::resource::tag<core::gfx::geometry_t> uid) const noexcept {
-	if(auto it = m_InstanceData.find(uid.uid()); it != std::end(m_InstanceData)) {
-		return it->second.id_generator.size();
+	if(auto it = m_GeometryInstanceData.find(uid.uid()); it != std::end(m_GeometryInstanceData)) {
+		return it->second.size();
 	}
 	return 0;
 }
@@ -181,18 +171,16 @@ psl::array<std::pair<size_t, std::uintptr_t>> data::bindings(tag<material_t> mat
 															 tag<geometry_t> geometry) const noexcept {
 	psl::array<std::pair<size_t, std::uintptr_t>> result {};
 	if(auto matIt = m_Bindings.find(material); matIt != std::end(m_Bindings)) {
-		if(auto geomIt = m_InstanceData.find(geometry); geomIt != std::end(m_InstanceData)) {
+		if(auto geomIt = m_GeometryInstanceData.find(geometry); geomIt != std::end(m_GeometryInstanceData)) {
 			size_t count = {0};
 			for(const auto& binding : matIt->second) {
-				auto it = std::find_if(
-				  std::begin(geomIt->second.description),
-				  std::end(geomIt->second.description),
-				  [&bDescr = binding.description](const binding::header& descr) { return descr == bDescr; });
+				auto it = std::find_if(std::begin(geomIt->second.instance_data),
+									   std::end(geomIt->second.instance_data),
+									   [&bDescr = binding.description](const geometry_instance_data::entry& entry) {
+										   return entry.description == bDescr;
+									   });
 
-				auto index	  = std::distance(std::begin(geomIt->second.description), it);
-				auto& segment = *std::next(std::begin(geomIt->second.data), index);
-
-				result.emplace_back(binding.slot, segment.range().begin);
+				result.emplace_back(binding.slot, it->memory.range().begin);
 			}
 		}
 	}
@@ -201,67 +189,66 @@ psl::array<std::pair<size_t, std::uintptr_t>> data::bindings(tag<material_t> mat
 
 
 bool data::has_element(tag<geometry_t> geometry, psl::string_view name) const noexcept {
-	if(auto it = m_InstanceData.find(geometry); it != std::end(m_InstanceData)) {
-		return std::find_if(std::begin(it->second.description),
-							std::end(it->second.description),
-							[&name](const auto& descr) { return descr.name == name; }) !=
-			   std::end(it->second.description);
+	if(auto it = m_GeometryInstanceData.find(geometry); it != std::end(m_GeometryInstanceData)) {
+		return std::find_if(std::begin(it->second.instance_data),
+							std::end(it->second.instance_data),
+							[&name](const geometry_instance_data::entry& entry) {
+								return entry.description.name == name;
+							}) != std::end(it->second.instance_data);
 	}
 	return false;
 }
 
 std::optional<std::pair<memory::segment, uint32_t>> data::segment(tag<geometry_t> geometry,
 																  psl::string_view name) const noexcept {
-	if(auto it = m_InstanceData.find(geometry); it != std::end(m_InstanceData)) {
-		auto descrIt = std::find_if(std::begin(it->second.description),
-									std::end(it->second.description),
-									[&name](const auto& descr) { return descr.name == name; });
-		if(descrIt != std::end(it->second.description)) {
-			auto index = std::distance(std::begin(it->second.description), descrIt);
-
-			return std::pair {*std::next(std::begin(it->second.data), index), descrIt->size_of_element};
+	if(auto it = m_GeometryInstanceData.find(geometry); it != std::end(m_GeometryInstanceData)) {
+		auto descrIt =
+		  std::find_if(std::begin(it->second.instance_data),
+					   std::end(it->second.instance_data),
+					   [&name](const geometry_instance_data::entry& entry) { return entry.description.name == name; });
+		if(descrIt != std::end(it->second.instance_data)) {
+			return std::pair {descrIt->memory, descrIt->description.size_of_element};
 		}
 	}
 	return std::nullopt;
 }
 
 
+bool data::erase(core::resource::tag<core::gfx::geometry_t> geometry, std::span<uint32_t const> ids) noexcept {
+	if(auto it = m_GeometryInstanceData.find(geometry); it != std::end(m_GeometryInstanceData)) {
+		it->second.erase(ids.begin(), ids.end());
+		return true;
+	}
+	return false;
+}
+
 bool data::erase(core::resource::tag<core::gfx::geometry_t> geometry, uint32_t id) noexcept {
-	if(auto it = m_InstanceData.find(geometry); it != std::end(m_InstanceData)) {
-		it->second.id_generator.destroy(id);
-
-		if(it->second.id_generator.size() == 0) {
-			for(auto& segment : it->second.data) {
-				m_VertexInstanceBuffer->deallocate(segment);
-			}
-
-			m_InstanceData.erase(it);
-		}
+	if(auto it = m_GeometryInstanceData.find(geometry); it != std::end(m_GeometryInstanceData)) {
+		it->second.erase(id);
 		return true;
 	}
 	return false;
 }
 bool data::clear(core::resource::tag<core::gfx::geometry_t> geometry) noexcept {
-	if(auto it = m_InstanceData.find(geometry); it != std::end(m_InstanceData)) {
-		for(auto& segment : it->second.data) {
-			m_VertexInstanceBuffer->deallocate(segment);
+	if(auto it = m_GeometryInstanceData.find(geometry); it != std::end(m_GeometryInstanceData)) {
+		for(auto& data : it->second.instance_data) {
+			m_VertexInstanceBuffer->deallocate(data.memory);
 		}
 
-		m_InstanceData.erase(it);
+		m_GeometryInstanceData.erase(it);
 		return true;
 	}
 	return false;
 }
 bool data::clear() noexcept {
-	for(auto& [uid, obj] : m_InstanceData) {
-		for(auto& segment : obj.data) {
-			m_VertexInstanceBuffer->deallocate(segment);
+	for(auto& [uid, geom_data] : m_GeometryInstanceData) {
+		for(auto& data : geom_data.instance_data) {
+			m_VertexInstanceBuffer->deallocate(data.memory);
 		}
 	}
-	m_InstanceData.clear();
+	m_GeometryInstanceData.clear();
 	return true;
 }
-
 
 size_t data::offset_of(core::resource::tag<core::gfx::material_t> material, psl::string_view name) const noexcept {
 	auto it = m_MaterialInstanceData.find(material);
@@ -295,6 +282,13 @@ size_t data::offset_of(core::resource::tag<core::gfx::material_t> material, psl:
 	return res;
 }
 
+size_t data::offset_of(core::resource::tag<core::gfx::geometry_t> geometry, std::uint32_t id) const noexcept {
+	if(auto it = m_GeometryInstanceData.find(geometry); it != std::end(m_GeometryInstanceData)) {
+		return it->second.offset_of(id);
+	}
+	return std::numeric_limits<size_t>::max();
+}
+
 bool data::set(core::resource::tag<core::gfx::material_t> material,
 			   const void* data,
 			   size_t size,
@@ -323,4 +317,118 @@ core::resource::handle<core::gfx::buffer_t> data::material_buffer() const noexce
 }
 bool data::has_data(core::resource::handle<core::gfx::material_t> material) const noexcept {
 	return m_MaterialInstanceData.find(material) != std::end(m_MaterialInstanceData);
+}
+
+void data::apply() {
+	for(auto& [uid, geom_data] : m_GeometryInstanceData) {
+		auto commands = geom_data.consume();
+		if(!commands.empty()) {
+			m_VertexInstanceBuffer->copy_from(m_VertexInstanceBuffer.value(), commands);
+		}
+	}
+}
+
+
+uint32_t geometry_instance_data::available() const noexcept {
+	return m_Max - (m_Head - static_cast<uint32_t>(m_Orphans.size()));
+}
+
+size_t geometry_instance_data::capacity() const noexcept {
+	return m_Max;
+}
+
+void geometry_instance_data::capacity(uint32_t max) {
+	psl_assert(max > manager.size(),
+			   "Setting a max capacity lower than the current allocated entries will end up in errors.");
+	m_Max = max;
+}
+
+std::vector<uint32_t> geometry_instance_data::add(uint32_t count) {
+	if(count == 0) {
+		return {};
+	}
+
+	psl_assert(count <= m_Max,
+			   "cannot allocate more instances than the maximum allowed. Requested {}, but only have {} left out of {}",
+			   count,
+			   available(),
+			   m_Max);
+	if(count > available()) {
+		core::gfx::log->error("cannot allocate {} instances, maximum is {} and we have {} active right now",
+							  count,
+							  m_Max,
+							  m_Head - m_Orphans.size());
+		return {};
+	}
+
+	std::vector<uint32_t> ids {};
+	ids.resize(count);
+	auto orphans_to_use = std::min(static_cast<uint32_t>(m_Orphans.size()), count);
+	if(orphans_to_use > 0) {
+		auto it = std::end(m_Orphans);
+		for(uint32_t i = 0; i != orphans_to_use; ++i) {
+			it	   = std::prev(it);
+			ids[i] = *it;
+		}
+		m_Orphans.erase(it, std::end(m_Orphans));
+	}
+
+	auto remainder = count - orphans_to_use;
+	if(remainder > 0) {
+		std::iota(ids.begin() + orphans_to_use, ids.end(), m_Head);
+		m_Head += remainder;
+	}
+
+	manager.insert(std::begin(ids), std::end(ids));
+	return ids;
+};
+
+uint32_t geometry_instance_data::size() const noexcept {
+	return manager.size();
+}
+
+void geometry_instance_data::erase(uint32_t id) {
+	psl_assert(manager.contains(id), "Trying to erase an id that does not exist");
+	manager.erase(id);
+	m_Orphans.push_back(id);
+}
+
+void geometry_instance_data::erase(auto&& first, auto&& last) {
+	manager.erase(first, last);
+	m_Orphans.insert(m_Orphans.end(), first, last);
+}
+
+uint32_t geometry_instance_data::offset_of(uint32_t id) const noexcept {
+	if(!manager.contains(id)) {
+		return std::numeric_limits<uint32_t>::max();
+	}
+	return manager.index_of(id);
+}
+
+void geometry_instance_data::clear() noexcept {
+	manager.clear();
+	m_Orphans.clear();
+	m_Head = 0;
+}
+
+psl::array<core::gfx::memory_copy> geometry_instance_data::consume() {
+	auto commands = std::move(m_Link->m_Commands);
+	m_Link->m_Commands.clear();
+	if(commands.empty()) {
+		return {};
+	}
+
+	psl::array<core::gfx::memory_copy> instructions {};
+	for(auto const& data : instance_data) {
+		for(auto& command : commands) {
+			// we can safely ignore resize commands, as they are implicit in the copy commands.
+			if(std::holds_alternative<storage_link::swap_command>(command)) {
+				auto& swap = std::get<storage_link::swap_command>(command);
+				instructions.push_back({data.memory.range().begin + (swap.src * data.description.size_of_element),
+										data.memory.range().begin + (swap.dst * data.description.size_of_element),
+										swap.count * data.description.size_of_element});
+			}
+		}
+	}
+	return instructions;
 }

--- a/core/src/vk/buffer.cpp
+++ b/core/src/vk/buffer.cpp
@@ -250,10 +250,6 @@ bool buffer_t::commit(std::vector<core::gfx::commit_instruction> instructions) {
 				return false;
 			}
 
-			if(i == 4) {
-				core::log->info("first element: {}", *(float*)(instructions[i].source));
-			}
-
 			memcpy((void*)((std::uintptr_t)tuple.value + stagingSegments[i].second.begin),
 				   (void*)(instructions[i].source),
 				   instructions[i].size);
@@ -401,11 +397,6 @@ bool buffer_t::copy_from(const buffer_t& other, const std::vector<vk::BufferCopy
 						 psl::utility::to_string(m_UID),
 						 totalsize,
 						 copyRegions.size());
-
-	for(const auto& region : copyRegions) {
-		core::ivk::log->info(
-		  "srcOffset | dstOffset | size : {0} | {1} | {2}", region.srcOffset, region.dstOffset, region.size);
-	}
 
 	vk::CommandBufferBeginInfo cmdBufferBeginInfo;
 	cmdBufferBeginInfo.pNext = NULL;

--- a/psl/inc.txt
+++ b/psl/inc.txt
@@ -39,6 +39,7 @@ stream_utils
 string_utils
 template_utils
 terminal_utils
+thread_safety_guard
 timer
 unique_ptr
 unordered_map

--- a/psl/inc/psl/ecs/details/component_container.hpp
+++ b/psl/inc/psl/ecs/details/component_container.hpp
@@ -551,8 +551,7 @@ class component_container_untyped_t final : public component_container_t {
 		psl_assert((std::uintptr_t)source % m_Info.alignment == 0, "pointer has to be aligned");
 		std::byte* src = (std::byte*)source;
 		if(repeat) {
-			m_Entities.assign(
-			  entities.begin(), entities.end(), details::untyped_iterator_t {src, m_Info.size}, nullptr);
+			m_Entities.assign(entities.begin(), entities.end(), details::untyped_iterator_t {src, m_Info.size});
 
 		} else {
 			m_Entities.assign(entities.begin(),

--- a/psl/inc/psl/ecs/details/component_container.hpp
+++ b/psl/inc/psl/ecs/details/component_container.hpp
@@ -239,7 +239,7 @@ class component_container_typed_t final : public component_container_t {
 	size_t copy_from(psl::array_view<entity_t> entities, void* source, bool repeat) noexcept override {
 		psl_assert((std::uintptr_t)source % m_Info.alignment == 0, "pointer has to be aligned");
 		T* src = (T*)source;
-		m_Entities.set(entities.begin(), entities.end(), src, repeat ? nullptr : src + entities.size());
+		m_Entities.assign(entities.begin(), entities.end(), src, repeat ? nullptr : src + entities.size());
 		return sizeof(T) * entities.size();
 	};
 
@@ -551,14 +551,14 @@ class component_container_untyped_t final : public component_container_t {
 		psl_assert((std::uintptr_t)source % m_Info.alignment == 0, "pointer has to be aligned");
 		std::byte* src = (std::byte*)source;
 		if(repeat) {
-			for(auto e : entities) {
-				std::memcpy(m_Entities.addressof(e, stage_range_t::ALL), src, m_Info.size);
-			}
+			m_Entities.assign(
+			  entities.begin(), entities.end(), details::untyped_iterator_t {src, m_Info.size}, nullptr);
+
 		} else {
-			for(auto e : entities) {
-				std::memcpy(m_Entities.addressof(e, stage_range_t::ALL), src, m_Info.size);
-				src += m_Info.size;
-			}
+			m_Entities.assign(entities.begin(),
+							  entities.end(),
+							  details::untyped_iterator_t {src, m_Info.size},
+							  details::untyped_iterator_t {src + entities.size(), m_Info.size});
 		}
 		return m_Info.size * entities.size();
 	};

--- a/psl/inc/psl/ecs/details/staged_sparse_array.hpp
+++ b/psl/inc/psl/ecs/details/staged_sparse_array.hpp
@@ -2227,7 +2227,7 @@ class staged_sparse_array final : private impl::dense_storage_base_t<T, IndexTyp
 	psl::static_array<index_type, 4> m_StageStart {0, 0, 0, 0};
 	psl::static_array<index_type, 3> m_StageSize {0, 0, 0};
 
-	psl::thread_safety_guard_t m_Guard {};
+	psl::dbg_thread_safety_guard_t m_Guard {};
 };
 
 }	 // namespace psl::ecs::details

--- a/psl/inc/psl/ecs/details/staged_sparse_array.hpp
+++ b/psl/inc/psl/ecs/details/staged_sparse_array.hpp
@@ -8,6 +8,7 @@
 #include "psl/memory/raw_region.hpp"
 #include "psl/platform_def.hpp"
 #include "psl/sparse_array.hpp"
+#include "psl/thread_safety_guard.hpp"
 #include "psl/utility/cast.hpp"
 #include <cstring>	  // std::memmove
 #include <memory>	  // std::uninitialized_move
@@ -204,12 +205,16 @@ namespace impl {
 		}
 
 		void reserve(Key new_size) {
-			if(new_size > capacity()) {
-				auto const old_size = m_End - m_Begin;
+			const auto cap = capacity();
+			if(new_size > cap) {
+				auto const old_count = m_End - m_Begin;
+				auto const old_size	 = old_count * sizeof(T);
 
 				::memory::raw_region new_dense(new_size * sizeof(T));
+				psl_assert(new_dense.size() >= old_size,
+						   "new dense size must be greater than or equal to current size");
 				if constexpr(std::is_trivially_copyable_v<T>) {
-					std::memcpy(new_dense.data(), m_Dense.data(), old_size * sizeof(T));
+					std::memcpy(new_dense.data(), m_Dense.data(), old_size);
 					// when available use std::start_lifetime_as<T>(...);
 				} else {
 					auto currentPtr		= m_Begin;
@@ -262,8 +267,7 @@ namespace impl {
 			auto const old_size = size();
 			if constexpr(!std::is_trivially_destructible_v<T>) {
 				for(size_t i = new_size; i < old_size; ++i) {
-					m_End->~T();
-					--m_End;
+					(--m_End)->~T();
 				}
 			} else {
 				m_End -= (old_size - new_size);
@@ -1249,6 +1253,7 @@ class staged_sparse_array final : private impl::dense_storage_base_t<T, IndexTyp
 		if(it_index_first == it_index_last) {
 			return 0;
 		}
+		auto lock		  = m_Guard.scoped_guard();
 		index_type* begin = &convert_from_user_type(it_index_first);
 		index_type* end	  = begin + std::distance(it_index_first, it_index_last);
 		return insert_impl<insertion_mode::insert>(begin, end, it_data_first, it_data_last);
@@ -1264,6 +1269,7 @@ class staged_sparse_array final : private impl::dense_storage_base_t<T, IndexTyp
 		if(it_index_first == it_index_last) {
 			return 0;
 		}
+		auto lock		  = m_Guard.scoped_guard();
 		index_type* begin = &convert_from_user_type(it_index_first);
 		index_type* end	  = begin + std::distance(it_index_first, it_index_last);
 		return insert_impl<insertion_mode::try_insert>(begin, end, it_data_first, it_data_last);
@@ -1278,6 +1284,7 @@ class staged_sparse_array final : private impl::dense_storage_base_t<T, IndexTyp
 		if(it_index_first == it_index_last) {
 			return 0;
 		}
+		auto lock		  = m_Guard.scoped_guard();
 		index_type* begin = &convert_from_user_type(it_index_first);
 		index_type* end	  = begin + std::distance(it_index_first, it_index_last);
 		return insert_impl<insertion_mode::set>(begin, end, it_data_first, it_data_last);
@@ -1303,6 +1310,7 @@ class staged_sparse_array final : private impl::dense_storage_base_t<T, IndexTyp
 		if(it_index_first == it_index_last) {
 			return 0;
 		}
+		auto lock		  = m_Guard.scoped_guard();
 		index_type* begin = &convert_from_user_type(it_index_first);
 		index_type* end	  = begin + std::distance(it_index_first, it_index_last);
 		return erase_impl<false>(begin, end);
@@ -1314,6 +1322,7 @@ class staged_sparse_array final : private impl::dense_storage_base_t<T, IndexTyp
 		if(it_index_first == it_index_last) {
 			return 0;
 		}
+		auto lock		  = m_Guard.scoped_guard();
 		index_type* begin = &convert_from_user_type(it_index_first);
 		index_type* end	  = begin + std::distance(it_index_first, it_index_last);
 		return erase_impl<true>(begin, end);
@@ -2021,7 +2030,9 @@ class staged_sparse_array final : private impl::dense_storage_base_t<T, IndexTyp
 					   "Data iterator range must match the index iterator range in size");
 		}
 
-		m_Reverse.reserve(m_StageStart[3] + size);
+		if constexpr(InsertMode != insertion_mode::assign) {
+			m_Reverse.reserve(m_StageStart[3] + size);
+		}
 
 		// as we'll insert as we go along, we need to reserve space upfront
 		// try_insert can have holes and set can add new elements.
@@ -2074,6 +2085,10 @@ class staged_sparse_array final : private impl::dense_storage_base_t<T, IndexTyp
 		  },
 		  it_data_first,
 		  it_data_last);
+
+		if constexpr(InsertMode == insertion_mode::assign) {
+			return count;
+		}
 
 		if(count > 0) {
 			if constexpr(IS_ASSIGNABLE && InsertMode == insertion_mode::try_insert &&
@@ -2211,6 +2226,8 @@ class staged_sparse_array final : private impl::dense_storage_base_t<T, IndexTyp
 
 	psl::static_array<index_type, 4> m_StageStart {0, 0, 0, 0};
 	psl::static_array<index_type, 3> m_StageSize {0, 0, 0};
+
+	psl::thread_safety_guard_t m_Guard {};
 };
 
 }	 // namespace psl::ecs::details

--- a/psl/inc/psl/ecs/pack.hpp
+++ b/psl/inc/psl/ecs/pack.hpp
@@ -235,6 +235,11 @@ namespace details {
 			return m_Data;
 		}
 
+		constexpr inline auto to_array() const noexcept -> psl::array<value_type> {
+			psl::array<value_type> arr(begin(), end());
+			return arr;
+		}
+
 	  private:
 		psl::array_view<size_type> m_Indices {};
 		pointer_type m_Data {};

--- a/psl/inc/psl/sparse_array.hpp
+++ b/psl/inc/psl/sparse_array.hpp
@@ -1236,7 +1236,7 @@ class sparse_array {
 	psl::array<index_type> m_Reverse {};
 	chunk_storage_type m_Sparse {};
 
-	std::shared_ptr<psl::thread_safety_guard_t> m_Guard {std::make_shared<psl::thread_safety_guard_t>()};
+	std::shared_ptr<psl::dbg_thread_safety_guard_t> m_Guard {std::make_shared<psl::dbg_thread_safety_guard_t>()};
 };
 
 

--- a/psl/inc/psl/sparse_array.hpp
+++ b/psl/inc/psl/sparse_array.hpp
@@ -26,6 +26,11 @@ namespace impl {
 		{ a.data() };
 	};
 
+	struct no_data_t {};
+
+	template <typename T>
+	concept IsNoDataSpecialization = std::is_same_v<T, no_data_t>;
+
 	/// \brief A storage type that uses a memory::raw_region as its backing storage. Typically this is a virtual page allocator
 	template <typename T, typename Key>
 	struct dense_storage_base_t {
@@ -396,7 +401,8 @@ class sparse_array {
 	};
 
   public:
-	sparse_array(index_type initial_size = 16) : m_Data(initial_size) {
+	template <typename... Args>
+	sparse_array(index_type initial_size = 16, Args&&... args) : m_Data(initial_size, std::forward<Args>(args)...) {
 		m_Reverse.reserve(initial_size);
 	}
 
@@ -843,6 +849,23 @@ class sparse_array {
 		return try_erase(&index, &index + 1) != 0;
 	}
 
+	/// \brief Returns the internal dense storage index of the provided user index.
+	/// \param index The user provided index to look up.
+	/// \details This function is only available really for sparse arrays that do not store any data,
+	/// this allows for a mapping between user indices and dense indices. Useful for tracking indices
+	/// in other data structures.
+	/// \see psl::sparse_indices_array
+	constexpr FORCEINLINE auto index_of(user_index_type index) const -> index_type
+		requires(impl::IsNoDataSpecialization<value_type> && !impl::StorageDataAccessible<dense_storage_type>)
+	{
+		auto element_index = static_cast<index_type>(index);
+		auto chunk		   = std::as_const(*this).userspace_to_internal(element_index);
+		psl_assert(chunk != TOMBSTONE && m_Sparse[chunk] != nullptr, "index not found in sparse array");
+		auto dense_index = (*m_Sparse[chunk])[element_index];
+		psl_assert(dense_index != TOMBSTONE, "index not found in sparse array");
+		return dense_index;
+	}
+
   private:
 	/// \brief Entrypoint for all operations that modify the sparse array's underlying data, or add new indices.
 	/// \tparam InsertMode The mode of insertion to perform. Can be insert, try_insert, set, or assign.
@@ -1218,11 +1241,8 @@ class sparse_array {
 template <typename UserKey				= size_t,
 		  typename IndexType			= UserKey,
 		  IndexType CHUNKS_SIZE			= 4096,
-		  typename BufferGrowthStrategy = details::default_buffer_growth_strategy_t>
-using sparse_indice_array = psl::sparse_array<std::byte,
-											  UserKey,
-											  IndexType,
-											  CHUNKS_SIZE,
-											  BufferGrowthStrategy,
-											  impl::no_storage_base_t<std::byte, IndexType>>;
+		  typename BufferGrowthStrategy = details::default_buffer_growth_strategy_t,
+		  typename StorageType			= impl::no_storage_base_t<impl::no_data_t, IndexType>>
+using sparse_indice_array =
+  psl::sparse_array<impl::no_data_t, UserKey, IndexType, CHUNKS_SIZE, BufferGrowthStrategy, StorageType>;
 }	 // namespace psl

--- a/psl/inc/psl/sparse_array.hpp
+++ b/psl/inc/psl/sparse_array.hpp
@@ -5,6 +5,7 @@
 #include "psl/details/buffer_growth_strategy.hpp"
 #include "psl/memory/raw_region.hpp"
 #include "psl/platform_def.hpp"
+#include "psl/thread_safety_guard.hpp"
 #include "psl/utility/cast.hpp"
 
 #include <cstring>	  // std::memmove
@@ -634,6 +635,7 @@ class sparse_array {
 
 		auto index_span = impl::to_span_wrapper(it_index_first, it_index_last);
 		auto data_span	= impl::to_span_wrapper(it_data_first, it_data_last);
+		auto lock		= m_Guard->scoped_guard();
 		return insert_impl<insertion_mode::insert>(index_span, data_span);
 	}
 
@@ -681,6 +683,7 @@ class sparse_array {
 
 		auto index_span = impl::to_span_wrapper(it_index_first, it_index_last);
 		auto data_span	= impl::to_span_wrapper(it_data_first, it_data_last);
+		auto lock		= m_Guard->scoped_guard();
 		return insert_impl<insertion_mode::try_insert>(index_span, data_span);
 	}
 
@@ -747,6 +750,7 @@ class sparse_array {
 
 		auto index_span = impl::to_span_wrapper(it_index_first, it_index_last);
 		auto data_span	= impl::to_span_wrapper(it_data_first, it_data_last);
+		auto lock		= m_Guard->scoped_guard();
 		return insert_impl<insertion_mode::set>(index_span, data_span);
 	}
 
@@ -814,6 +818,7 @@ class sparse_array {
 			return index_type {0};
 		}
 		auto index_span = impl::to_span_wrapper(std::make_reverse_iterator(end), std::make_reverse_iterator(begin));
+		auto lock		= m_Guard->scoped_guard();
 		return erase_impl<false>(index_span);
 	}
 
@@ -839,6 +844,7 @@ class sparse_array {
 			return index_type {0};
 		}
 		auto index_span = impl::to_span_wrapper(std::make_reverse_iterator(end), std::make_reverse_iterator(begin));
+		auto lock		= m_Guard->scoped_guard();
 		return erase_impl<true>(index_span);
 	}
 
@@ -874,13 +880,18 @@ class sparse_array {
 	template <insertion_mode InsertMode>
 	constexpr FORCEINLINE auto insert_impl(auto&& index_span, auto&& data_span) -> index_type {
 		const auto size = psl::narrow_cast<index_type>(index_span.size());
-		m_Reverse.reserve(m_Reverse.size() + size);
-		m_Data.reserve(psl::narrow_cast<index_type>(m_Reverse.size()) + size);
+
+		// assign is thread safe as it only modifies existing elements
+		if constexpr(InsertMode != insertion_mode::assign) {
+			m_Reverse.reserve(m_Reverse.size() + size);
+			m_Data.reserve(psl::narrow_cast<index_type>(m_Reverse.size()) + size);
+		}
 		index_type count = 0;
 
 		invoke_for_l0<true>(
 		  index_span,
-		  [&, this](index_type index, chunk_type& chunk, index_type chunk_offset, auto&&... dataIt) {
+		  [&, this](
+			index_type index, chunk_type& chunk, index_type chunk_index, index_type chunk_offset, auto&&... dataIt) {
 			  static_assert(sizeof...(dataIt) <= 1, "dataIt can only be empty, or contain a single element");
 			  index_type rev_index {chunk[chunk_offset]};
 			  // try_insert requires the element to be empty
@@ -969,29 +980,28 @@ class sparse_array {
 		index_type start_size = psl::narrow_cast<index_type>(m_Reverse.size());
 
 		invoke_for_l0<false, std::greater<index_type>>(
-		  range, [this](index_type user_index, chunk_type& chunk, index_type chunk_offset) {
+		  range, [this](index_type user_index, chunk_type& chunk, index_type chunk_index, index_type chunk_offset) {
+			  auto const reverse_index = chunk[chunk_offset];
 			  if constexpr(TryErase) {
-				  if(chunk[chunk_offset] == TOMBSTONE) {
+				  if(reverse_index == TOMBSTONE) {
 					  return;
 				  }
 			  } else {
-				  psl_assert(chunk[chunk_offset] != TOMBSTONE);
+				  psl_assert(reverse_index != TOMBSTONE);
 			  }
-			  auto reverse_index = chunk[chunk_offset];
-			  auto last_index	 = m_Reverse.back();
+			  auto const last_index = m_Reverse.back();
 			  // if we're not removing the last element, we need to swap the last element into the removed element's
 			  // place otherwise we can just pop the last element
 			  if(last_index != user_index) {
-				  auto const chunk_index = &chunk - m_Sparse.front().get();
 				  if(last_index >= chunk_index * CHUNKS_SIZE && last_index < (chunk_index + 1) * CHUNKS_SIZE) {
 					  chunk[last_index - (chunk_index * CHUNKS_SIZE)] = reverse_index;
 				  } else {
 					  auto original_sparse_offset = last_index;
-					  auto original_sparse		  = userspace_to_internal(original_sparse_offset);
+					  auto original_sparse		  = std::as_const(*this).userspace_to_internal(original_sparse_offset);
 					  (*m_Sparse[original_sparse])[original_sparse_offset] = reverse_index;
 				  }
 
-				  std::iter_swap(std::next(std::begin(m_Reverse), reverse_index), std::prev(std::end(m_Reverse)));
+				  m_Reverse[reverse_index] = last_index;
 				  m_Data.swap(reverse_index, psl::narrow_cast<index_type>(m_Reverse.size()) - 1);
 			  }
 
@@ -1126,10 +1136,10 @@ class sparse_array {
 				}
 
 				if constexpr(!HasDataSpan) {
-					CallbackFound(next_index, chunk, next_element_index);
+					CallbackFound(next_index, chunk, chunk_index, next_element_index);
 				} else {
 					auto data_it = data_span.current();
-					CallbackFound(next_index, chunk, next_element_index, data_it);
+					CallbackFound(next_index, chunk, chunk_index, next_element_index, data_it);
 					data_span.next();
 				}
 				index_span.next();
@@ -1225,6 +1235,8 @@ class sparse_array {
 	dense_storage_type m_Data {};
 	psl::array<index_type> m_Reverse {};
 	chunk_storage_type m_Sparse {};
+
+	std::shared_ptr<psl::thread_safety_guard_t> m_Guard {std::make_shared<psl::thread_safety_guard_t>()};
 };
 
 

--- a/psl/inc/psl/sparse_array.hpp
+++ b/psl/inc/psl/sparse_array.hpp
@@ -171,8 +171,7 @@ namespace impl {
 			auto const old_size = size();
 			if constexpr(!std::is_trivially_destructible_v<T>) {
 				for(size_t i = new_size; i < old_size; ++i) {
-					m_End->~T();
-					--m_End;
+					(--m_End)->~T();
 				}
 			} else {
 				m_End -= (old_size - new_size);

--- a/psl/inc/psl/thread_safety_guard.hpp
+++ b/psl/inc/psl/thread_safety_guard.hpp
@@ -1,39 +1,20 @@
 #pragma once
 #include <atomic>
-#include <cassert>
 #include <thread>
 
 namespace psl {
 
 /// \brief A thread safety guard that can be used to ensure that a certain scope is only accessed by a single thread at a time.
-class thread_safety_guard_t {
+class thread_safety_guard_t final {
   public:
-	class scoped_guard_t {
+	/// \brief A scoped guard that ensures that the current thread is the only one accessing the guarded scope.
+	class scoped_guard_t final {
 		const thread_safety_guard_t& m_Guard;
 		bool m_isPrimaryOwner {false};
 
 	  public:
-		explicit scoped_guard_t(const thread_safety_guard_t& guard) : m_Guard(guard) {
-			auto current_id = std::this_thread::get_id();
-			auto expected	= std::thread::id {};
-
-			if(m_Guard.m_Owner.compare_exchange_strong(expected, current_id)) {
-				m_isPrimaryOwner	= true;
-				m_Guard.m_Recursion = 1;
-			} else if(expected == current_id) {
-				m_Guard.m_Recursion++;
-			} else {
-				assert(false && "Thread safety violation: scope owned by another thread!");
-			}
-		}
-
-		~scoped_guard_t() {
-			if(--m_Guard.m_Recursion == 0) {
-				assert(m_isPrimaryOwner &&
-					   "Thread safety violation: recursion count reached zero, but not primary owner!");
-				m_Guard.m_Owner.store(std::thread::id {});
-			}
-		}
+		explicit scoped_guard_t(const thread_safety_guard_t& guard);
+		~scoped_guard_t();
 
 		scoped_guard_t(scoped_guard_t const&)			 = delete;
 		scoped_guard_t& operator=(scoped_guard_t const&) = delete;
@@ -41,6 +22,7 @@ class thread_safety_guard_t {
 		scoped_guard_t& operator=(scoped_guard_t&&)		 = delete;
 	};
 
+	/// \brief Creates a new scoped guard that will lock the current thread to the guarded scope.
 	scoped_guard_t scoped_guard() const {
 		return scoped_guard_t(*this);
 	}
@@ -51,9 +33,10 @@ class thread_safety_guard_t {
 };
 
 namespace {
-	class thread_safety_noop_guard_t {
+	/// \brief A thread safety guard that does nothing. Mirrors the interface of thread_safety_guard_t.
+	class thread_safety_noop_guard_t final {
 	  public:
-		class scoped_guard_t {
+		class scoped_guard_t final {
 		  public:
 			explicit scoped_guard_t(const thread_safety_noop_guard_t&) {}
 			~scoped_guard_t() {}
@@ -68,9 +51,12 @@ namespace {
 	};
 }	 // namespace
 
+
+/// \brief Depending on the build configuration, this type alias will either be a real thread safety guard or a noop guard.
+using dbg_thread_safety_guard_t =
 #if defined(PE_DEBUG)
-using dbg_thread_safety_guard_t = thread_safety_guard_t;
+  thread_safety_guard_t;
 #else
-using dbg_thread_safety_guard_t = thread_safety_noop_guard_t;
+  thread_safety_noop_guard_t;
 #endif
 }	 // namespace psl

--- a/psl/inc/psl/thread_safety_guard.hpp
+++ b/psl/inc/psl/thread_safety_guard.hpp
@@ -1,0 +1,52 @@
+#pragma once
+#include <atomic>
+#include <cassert>
+#include <thread>
+
+namespace psl {
+
+/// \brief A thread safety guard that can be used to ensure that a certain scope is only accessed by a single thread at a time.
+class thread_safety_guard_t {
+  public:
+	class scoped_guard_t {
+		const thread_safety_guard_t& m_Guard;
+		bool m_isPrimaryOwner {false};
+
+	  public:
+		explicit scoped_guard_t(const thread_safety_guard_t& guard) : m_Guard(guard) {
+			auto current_id = std::this_thread::get_id();
+			auto expected	= std::thread::id {};
+
+			if(m_Guard.m_Owner.compare_exchange_strong(expected, current_id)) {
+				m_isPrimaryOwner	= true;
+				m_Guard.m_Recursion = 1;
+			} else if(expected == current_id) {
+				m_Guard.m_Recursion++;
+			} else {
+				assert(false && "Thread safety violation: scope owned by another thread!");
+			}
+		}
+
+		~scoped_guard_t() {
+			if(--m_Guard.m_Recursion == 0) {
+				assert(m_isPrimaryOwner &&
+					   "Thread safety violation: recursion count reached zero, but not primary owner!");
+				m_Guard.m_Owner.store(std::thread::id {});
+			}
+		}
+
+		scoped_guard_t(scoped_guard_t const&)			 = delete;
+		scoped_guard_t& operator=(scoped_guard_t const&) = delete;
+		scoped_guard_t(scoped_guard_t&&)				 = delete;
+		scoped_guard_t& operator=(scoped_guard_t&&)		 = delete;
+	};
+
+	scoped_guard_t scoped_guard() const {
+		return scoped_guard_t(*this);
+	}
+
+  private:
+	mutable std::atomic<std::thread::id> m_Owner {};
+	mutable std::atomic<size_t> m_Recursion {0};
+};
+}	 // namespace psl

--- a/psl/inc/psl/thread_safety_guard.hpp
+++ b/psl/inc/psl/thread_safety_guard.hpp
@@ -49,4 +49,28 @@ class thread_safety_guard_t {
 	mutable std::atomic<std::thread::id> m_Owner {};
 	mutable std::atomic<size_t> m_Recursion {0};
 };
+
+namespace {
+	class thread_safety_noop_guard_t {
+	  public:
+		class scoped_guard_t {
+		  public:
+			explicit scoped_guard_t(const thread_safety_noop_guard_t&) {}
+			~scoped_guard_t() {}
+			scoped_guard_t(scoped_guard_t const&)			 = delete;
+			scoped_guard_t& operator=(scoped_guard_t const&) = delete;
+			scoped_guard_t(scoped_guard_t&&)				 = delete;
+			scoped_guard_t& operator=(scoped_guard_t&&)		 = delete;
+		};
+		scoped_guard_t scoped_guard() const {
+			return scoped_guard_t(*this);
+		}
+	};
+}	 // namespace
+
+#if defined(PE_DEBUG)
+using dbg_thread_safety_guard_t = thread_safety_guard_t;
+#else
+using dbg_thread_safety_guard_t = thread_safety_noop_guard_t;
+#endif
 }	 // namespace psl

--- a/psl/src.txt
+++ b/psl/src.txt
@@ -3,6 +3,7 @@ assertions
 platform_utils
 debug_utils
 terminal_utils
+thread_safety_guard
 application_utils
 formatted_string_buffer
 stdafx_psl

--- a/psl/src/thread_safety_guard.cpp
+++ b/psl/src/thread_safety_guard.cpp
@@ -1,0 +1,41 @@
+#include "psl/thread_safety_guard.hpp"
+#include <cassert>
+#include <cstdio>
+
+namespace psl {
+thread_safety_guard_t::scoped_guard_t::scoped_guard_t(const thread_safety_guard_t& guard) : m_Guard(guard) {
+	auto current_id = std::this_thread::get_id();
+	auto expected	= std::thread::id {};
+
+	if(m_Guard.m_Owner.compare_exchange_strong(expected, current_id)) {
+		m_isPrimaryOwner	= true;
+		m_Guard.m_Recursion = 1;
+	} else if(expected == current_id) {
+		m_Guard.m_Recursion++;
+	} else {
+#ifndef NDEBUG
+		assert(false && "Thread safety violation: scope already owned by another thread");
+#else
+		std::fprintf(stderr,
+					 "Thread safety violation: scope owned by thread %zu, current thread is %zu\n",
+					 std::hash<std::thread::id> {}(expected),
+					 std::hash<std::thread::id> {}(current_id));
+#endif
+		std::abort();
+	}
+}
+
+thread_safety_guard_t::scoped_guard_t::~scoped_guard_t() {
+	if(--m_Guard.m_Recursion == 0) {
+		if(!m_isPrimaryOwner) {
+#ifndef NDEBUG
+			assert(false && "Thread safety violation: recursion count reached zero, but not primary owner");
+#else
+			std::fprintf(stderr, "Thread safety violation: recursion count reached zero, but not primary owner!\n");
+#endif
+			std::abort();
+		}
+		m_Guard.m_Owner.store(std::thread::id {});
+	}
+}
+}	 // namespace psl


### PR DESCRIPTION
Resolves #173 

Changes the backing of instanced data to be a `psl::sparse_array` (specifically an indices array). This allows us to hand out instance ID's which are disconnected from the memory locations allowing compaction etc..

Additionally this simplified several of the API's, and came with a performance boost (though lower peak as it's hard to beat 1:1 access to memory indices).

There were a few issues resolved in `psl::sparse_array` and `psl::ecs::details::staged_sparse_array` as well